### PR TITLE
Add Plugin URI to WordPress Plugin Header

### DIFF
--- a/woocommerce-google-analytics-integration.php
+++ b/woocommerce-google-analytics-integration.php
@@ -2,6 +2,7 @@
 
 /*
 Plugin Name: WooCommerce Google Analytics Integration
+Plugin URI: http://github.com/woothemes/woocommerce-google-analytics-integration
 Description: Allows Google Analytics tracking code to be inserted into WooCommerce store pages.
 Author: WooThemes 
 Author URI: http://www.woothemes.com


### PR DESCRIPTION
It's nice to have a plugin uri so users to find the plugin.

It also looks silly on the WooCommerce System Status page without one. :) 

![woocommerce_status__wc_2_1_x__wordpress](https://f.cloud.github.com/assets/1065372/2208506/9f6f722a-9980-11e3-8089-a42511fd136b.png)
