### PR TITLE
Set transaction currency

### DIFF
--- a/includes/class-wc-google-analytics-integration.php
+++ b/includes/class-wc-google-analytics-integration.php
@@ -319,7 +319,7 @@ class WC_Google_Analytics extends WC_Integration {
 					['_setAccount', '" . esc_js( $tracking_id ) . "'], " . $set_domain_name . "
 					['_setCustomVar', 1, 'logged-in', '" . esc_js( $loggedin ) . "', 1],
 					['_trackPageview'],
-					['_set', 'currencyCode', '" . esc_js( $order->get_order_currency() ) . "'],
+					['_set', 'currencyCode', '" . esc_js( $order->get_order_currency() ) . "']
 				);
 
 				_gaq.push(['_addTrans',


### PR DESCRIPTION
For stores that either sell in multiple currencies or where the transaction currency does not match the currency specified in Google Analytics view settings, providing the currency will convert the transaction amount to the view currency.

https://developers.google.com/analytics/devguides/collection/analyticsjs/ecommerce#multicurrency
