### PR TITLE
Added option to track 404 (Not Found) errors 

### DIFF
--- a/includes/class-wc-google-analytics-js.php
+++ b/includes/class-wc-google-analytics-js.php
@@ -93,7 +93,7 @@ class WC_Google_Analytics_JS {
 		}
 
 		$track_404_enabled = '';
-		if ( 'yes' === self::get( 'ga_404_tracking_enabled' ) ) {
+		if ( 'yes' === self::get( 'ga_404_tracking_enabled' ) && is_404() ) {
 			// See https://developers.google.com/analytics/devguides/collection/gajs/methods/gaJSApiEventTracking#_trackevent
 			$track_404_enabled = "['_trackEvent', 'Error', '404 Not Found', 'page: ' + document.location.pathname + document.location.search + ' referrer: ' + document.referrer ],";
 		}
@@ -235,8 +235,7 @@ class WC_Google_Analytics_JS {
 		}
 
 		$track_404_enabled = '';
-		if ( 'yes' === self::get( 'ga_404_tracking_enabled' && is_404() ) ) {
-			// FIXME:   ga('send', 'event', 'error', '404', 'page: ' + document.location.pathname + document.location.search + ' ref: ' + document.referrer, {'nonInteraction': 1});
+		if ( 'yes' === self::get( 'ga_404_tracking_enabled' ) && is_404() ) {
 			// See https://developers.google.com/analytics/devguides/collection/analyticsjs/events for reference
 			$track_404_enabled = "" . self::tracker_var() . "( 'send', 'event', 'Error', '404 Not Found', 'page: ' + document.location.pathname + document.location.search + ' referrer: ' + document.referrer );";
 		}

--- a/includes/class-wc-google-analytics-js.php
+++ b/includes/class-wc-google-analytics-js.php
@@ -211,6 +211,8 @@ class WC_Google_Analytics_JS {
 	 */
 	public static function load_analytics_universal( $logged_in ) {
 
+		$ga_id = self::get( 'ga_id' );
+
 		$domainname = self::get( 'ga_set_domain_name' );
 
 		if ( ! empty( $domainname ) ) {

--- a/includes/class-wc-google-analytics-js.php
+++ b/includes/class-wc-google-analytics-js.php
@@ -92,6 +92,13 @@ class WC_Google_Analytics_JS {
 			$anonymize_enabled = "['_gat._anonymizeIp'],";
 		}
 
+		$track_404_enabled = '';
+		if ( 'yes' === self::get( 'ga_404_tracking_enabled' ) ) {
+			// See https://developers.google.com/analytics/devguides/collection/gajs/methods/gaJSApiEventTracking#_trackevent
+			$track_404_enabled = "['_trackEvent', 'Error', '404 Not Found', 'page: ' + document.location.pathname + document.location.search + ' referrer: ' + document.referrer ],";
+		}
+
+
 		$domainname = self::get( 'ga_set_domain_name' );
 
 		if ( ! empty( $domainname ) ) {
@@ -103,7 +110,8 @@ class WC_Google_Analytics_JS {
 		$code = "var _gaq = _gaq || [];
 		_gaq.push(
 			['_setAccount', '" . esc_js( self::get( 'ga_id' ) ) . "'], " . $set_domain_name .
-			$anonymize_enabled . "
+			$anonymize_enabled . 
+			$track_404_enabled . "
 			['_setCustomVar', 1, 'logged-in', '" . esc_js( $logged_in ) . "', 1],
 			['_trackPageview']";
 
@@ -226,6 +234,13 @@ class WC_Google_Analytics_JS {
 			$anonymize_enabled = "" . self::tracker_var() . "( 'set', 'anonymizeIp', true );";
 		}
 
+		$track_404_enabled = '';
+		if ( 'yes' === self::get( 'ga_404_tracking_enabled' && is_404() ) ) {
+			// FIXME:   ga('send', 'event', 'error', '404', 'page: ' + document.location.pathname + document.location.search + ' ref: ' + document.referrer, {'nonInteraction': 1});
+			// See https://developers.google.com/analytics/devguides/collection/analyticsjs/events for reference
+			$track_404_enabled = "" . self::tracker_var() . "( 'send', 'event', 'Error', '404 Not Found', 'page: ' + document.location.pathname + document.location.search + ' referrer: ' + document.referrer );";
+		}
+
 		$ga_snippet_head = "(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
 		(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
 		m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
@@ -236,7 +251,8 @@ class WC_Google_Analytics_JS {
 		$ga_snippet_require =
 		$support_display_advertising .
 		$support_enhanced_link_attribution .
-		$anonymize_enabled . "
+		$anonymize_enabled . 
+		$track_404_enabled . "
 		" . self::tracker_var() . "( 'set', 'dimension1', '" . $logged_in . "' );\n";
 
 		if ( 'yes' === self::get( 'ga_enhanced_ecommerce_tracking_enabled' ) ) {

--- a/includes/class-wc-google-analytics.php
+++ b/includes/class-wc-google-analytics.php
@@ -76,6 +76,7 @@ class WC_Google_Analytics extends WC_Integration {
 			'ga_support_enhanced_link_attribution',
 			'ga_use_universal_analytics',
 			'ga_anonymize_enabled',
+			'ga_404_tracking_enabled',
 			'ga_ecommerce_tracking_enabled',
 			'ga_enhanced_ecommerce_tracking_enabled',
 			'ga_enhanced_remove_from_cart_enabled',
@@ -148,6 +149,13 @@ class WC_Google_Analytics extends WC_Integration {
 				'checkboxgroup' => '',
 				'default'       => 'yes'
 			),
+			'ga_404_tracking_enabled' => array(
+				'label'         => __( 'Track 404 (Not found) Errors.', 'woocommerce-google-analytics-integration' ),
+				'description'   => sprintf( __( 'Enable this to find broken or dead links. An "Event" with category "Error" and action "404 Not Found" will be created in Google Analytics for each incoming pageview to a non-existing page. By setting up a "Custom Goal" for these events within Google Analytics you can find out where broken links originated from (the referrer). %sRead how to set up a goal%s.', 'woocommerce-google-analytics-integration' ), '<a href="https://support.google.com/analytics/answer/1032415" target="_blank">', '</a>' ),
+				'type'          => 'checkbox',
+				'checkboxgroup' => '',
+				'default'       => 'yes'
+			),			
 			'ga_ecommerce_tracking_enabled' => array(
 				'label' 			=> __( 'Purchase Transactions', 'woocommerce-google-analytics-integration' ),
 				'description' 			=> __( 'This requires a payment gateway that redirects to the thank you/order received page after payment. Orders paid with gateways which do not do this will not be tracked.', 'woocommerce-google-analytics-integration' ),
@@ -238,6 +246,7 @@ class WC_Google_Analytics extends WC_Integration {
 			'support_enhanced_link_attribution' => $this->ga_support_enhanced_link_attribution,
 			'use_universal_analytics'     		=> $this->ga_use_universal_analytics,
 			'anonymize_enabled'           		=> $this->ga_anonymize_enabled,
+			'ga_404_tracking_enabled'           => $this->ga_404_tracking_enabled,
 			'ecommerce_tracking_enabled'  		=> $this->ga_ecommerce_tracking_enabled,
 			'event_tracking_enabled'      		=> $this->ga_event_tracking_enabled
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
- Added option to track 404 (Not Found) errors 
- Also Fixes #84.

---
- [ x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] Did you make changes, or create a **new .js file**? Make sure you ran `grunt` before creating this Pull Request.
