### PR TITLE
Release/1.4.4

### DIFF
--- a/includes/class-wc-google-analytics-js.php
+++ b/includes/class-wc-google-analytics-js.php
@@ -372,7 +372,7 @@ class WC_Google_Analytics_JS {
 	 * @param array $item  The item to add to a transaction/order
 	 */
 	function add_item_classic( $order, $item ) {
-		$_product = $order->get_product_from_item( $item );
+		$_product = version_compare( WC_VERSION, '3.0', '<' ) ? $order->get_product_from_item( $item ) : $item->get_product();
 
 		$code = "_gaq.push(['_addItem',";
 		$code .= "'" . esc_js( $order->get_order_number() ) . "',";
@@ -392,7 +392,7 @@ class WC_Google_Analytics_JS {
 	 * @param array $item  The item to add to a transaction/order
 	 */
 	function add_item_universal( $order, $item ) {
-		$_product = $order->get_product_from_item( $item );
+		$_product = version_compare( WC_VERSION, '3.0', '<' ) ? $order->get_product_from_item( $item ) : $item->get_product();
 
 		$code = "" . self::tracker_var() . "('ecommerce:addItem', {";
 		$code .= "'id': '" . esc_js( $order->get_order_number() ) . "',";
@@ -412,7 +412,7 @@ class WC_Google_Analytics_JS {
 	 * @param array $item The item to add to a transaction/order
 	 */
 	function add_item_enhanced( $order, $item ) {
-		$_product = $order->get_product_from_item( $item );
+		$_product = version_compare( WC_VERSION, '3.0', '<' ) ? $order->get_product_from_item( $item ) : $item->get_product();
 
 		$code = "" . self::tracker_var() . "( 'ec:addProduct', {";
 		$code .= "'id': '" . esc_js( $_product->get_sku() ? $_product->get_sku() : $_product->get_id() ) . "',";

--- a/includes/class-wc-google-analytics.php
+++ b/includes/class-wc-google-analytics.php
@@ -410,8 +410,17 @@ class WC_Google_Analytics extends WC_Integration {
 			return $url;
 		}
 
+		if ( ! is_object( WC()->cart ) ) {
+			return $url;
+		}
+
 		$item = WC()->cart->get_cart_item( $key );
 		$product = $item['data'];
+
+		if ( ! is_object( $product ) ) {
+			return $url;
+		}
+
 		$url = str_replace( 'href=', 'data-product_id="' . esc_attr( $product->get_id() ) . '" data-product_sku="' . esc_attr( $product->get_sku() )  . '" href=', $url );
 		return $url;
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -64,6 +64,9 @@ Exact wording depends on the national data privacy laws and should be adjusted.
 
 == Changelog ==
 
+= 1.4.4 - 2018-xx-xx =
+* Fix - WC30 compatibility error when using deprecated get_product_from_item method.
+
 = 1.4.3 - 15/06/2017 =
 * Fix - WC 3.x notice by using proper variation data.
 * Add - Option to track 404 (Not found) errors.

--- a/readme.txt
+++ b/readme.txt
@@ -66,6 +66,7 @@ Exact wording depends on the national data privacy laws and should be adjusted.
 
 = 1.4.4 - 2018-xx-xx =
 * Fix - WC30 compatibility error when using deprecated get_product_from_item method.
+* Fix - Check object before using methods to prevent errors.
 
 = 1.4.3 - 15/06/2017 =
 * Fix - WC 3.x notice by using proper variation data.


### PR DESCRIPTION
Fixes #104 #105 #100 #80

#### Changes proposed in this Pull Request:
* Fix - WC30 compatibility error when using deprecated get_product_from_item method.
* Fix - Check object before using methods to prevent errors.

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] Did you make changes, or create a **new .js file**? Make sure you ran `grunt` before creating this Pull Request.

