### PR TITLE
Fix fatal error on Thank You page

### DIFF
--- a/includes/class-wc-google-analytics.php
+++ b/includes/class-wc-google-analytics.php
@@ -321,7 +321,10 @@ class WC_Google_Analytics extends WC_Integration {
 	 */
 	protected function get_ecommerce_tracking_code( $order_id ) {
 		// Get the order and output tracking code
-		$order = new WC_Order( $order_id );
+		$order = wc_get_order( $order_id );
+
+		// Make sure we have a valid order object
+		if ( ! $order || is_wp_error( $order ) ) return "";
 
 		$code = WC_Google_Analytics_JS::get_instance()->load_analytics( $order );
 		$code .= WC_Google_Analytics_JS::get_instance()->add_transaction( $order );

--- a/includes/class-wc-google-analytics.php
+++ b/includes/class-wc-google-analytics.php
@@ -320,24 +320,26 @@ class WC_Google_Analytics extends WC_Integration {
 	 * @param int $order_id
 	 */
 	protected function get_ecommerce_tracking_code( $order_id ) {
-		// Get the order and output tracking code
+		// Get the order and output tracking code.
 		$order = wc_get_order( $order_id );
 
-		// Make sure we have a valid order object
-		if ( ! $order || is_wp_error( $order ) ) return "";
+		// Make sure we have a valid order object.
+		if ( ! $order ) {
+			return '';
+		}
 
 		$code = WC_Google_Analytics_JS::get_instance()->load_analytics( $order );
 		$code .= WC_Google_Analytics_JS::get_instance()->add_transaction( $order );
 
-		// Mark the order as tracked
+		// Mark the order as tracked.
 		update_post_meta( $order_id, '_ga_tracked', 1 );
 
-		return "
+		return '
 		<!-- WooCommerce Google Analytics Integration -->
-		" . WC_Google_Analytics_JS::get_instance()->header() . "
+		' . WC_Google_Analytics_JS::get_instance()->header() . '
 		<script type='text/javascript'>$code</script>
 		<!-- /WooCommerce Google Analytics Integration -->
-		";
+		';
 	}
 
 	/**


### PR DESCRIPTION
Fixes #124.

If we have an invalid order ID, we wind up throwing a fatal PHP error. This seems to solve the problem.

#### Changes proposed in this Pull Request:
- Use `wc_get_order()` instead of `new WC_Order()`
- Validate the order object before we try to use it.

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? Make sure you ran `grunt` before creating this Pull Request.

