### PR TITLE
Update class-wc-google-analytics.php

### DIFF
--- a/includes/class-wc-google-analytics.php
+++ b/includes/class-wc-google-analytics.php
@@ -382,6 +382,7 @@ class WC_Google_Analytics extends WC_Integration {
 			$code .= "'name': '" . esc_js( $product->get_title() ) . "',";
 			$code .= "'quantity': $( 'input.qty' ).val() ? $( 'input.qty' ).val() : '1'";
 			$code .= "} );";
+			$code = apply_filter("ga_add_to_card_item_object_js,$code,$product);
 			$parameters['enhanced'] = $code;
 		}
 

--- a/includes/class-wc-google-analytics.php
+++ b/includes/class-wc-google-analytics.php
@@ -382,7 +382,7 @@ class WC_Google_Analytics extends WC_Integration {
 			$code .= "'name': '" . esc_js( $product->get_title() ) . "',";
 			$code .= "'quantity': $( 'input.qty' ).val() ? $( 'input.qty' ).val() : '1'";
 			$code .= "} );";
-			$code = apply_filter("ga_add_to_card_item_object_js,$code,$product);
+			$code = apply_filters("ga_add_to_card_item_object_js,$code,$product);
 			$parameters['enhanced'] = $code;
 		}
 


### PR DESCRIPTION
add filter to add more fields in product object like brand and category

my recomments is instead of using string concatenation to create a object, we should use php array, then apply the filter in order to add more entries in the array and then, concatenate with json_encode inside the JS method. 
With this, is very easy to add new items to the object like brand and category.

Fixes # .

#### Changes proposed in this Pull Request:
-

-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? Make sure you ran `grunt` before creating this Pull Request.

