### PR TITLE
Make analytics.js src filterable

### DIFF
--- a/includes/class-wc-google-analytics-js.php
+++ b/includes/class-wc-google-analytics-js.php
@@ -235,11 +235,13 @@ class WC_Google_Analytics_JS {
 			// See https://developers.google.com/analytics/devguides/collection/analyticsjs/events for reference
 			$track_404_enabled = "" . self::tracker_var() . "( 'send', 'event', 'Error', '404 Not Found', 'page: ' + document.location.pathname + document.location.search + ' referrer: ' + document.referrer );";
 		}
+		
+		$src = apply_filters('woocommerce_google_analytics_script_src', '//www.google-analytics.com/analytics.js');
 
 		$ga_snippet_head = "(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
 		(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
 		m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-		})(window,document,'script','//www.google-analytics.com/analytics.js','" . self::tracker_var() . "');";
+		})(window,document,'script', $src" . self::tracker_var() . "');";
 
 		$ga_id = self::get( 'ga_id' );
 		$ga_snippet_create = self::tracker_var() . "( 'create', '" . esc_js( $ga_id ) . "', '" . $set_domain_name . "' );";


### PR DESCRIPTION
This way other plugins can override the source, for example by a local copy (e.g. provided by CAOS for Analytics).

#### Changes proposed in this Pull Request:
- I've been getting many requests for this on the WP Support Forums and by e-mail. So I decided to make a pull request. Adding a filter the the analytics.js source URL will make it easy for plugins to alter the source of the analytics.js file. Some people want to host it locally, to up their Pagespeed score. My plugin does that, and keeps it updated using wp-cron. If you'd implement this, I could create an option to make my plugin compatible with yours! :)

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] Did you make changes, or create a **new .js file**? Make sure you ran `grunt` before creating this Pull Request.

