### PR TITLE
Fix delete item event not sent after a cart update fixes #119

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** Changelog ***
 
+= 1.4.8 - xx/xx/2019 =
+* Fix - Event for deleting from cart not sent after a cart update.
+
 = 1.4.7 - 11/19/2018 =
 * Tweak - WP 5.0 compatibility.
 

--- a/includes/class-wc-google-analytics-js.php
+++ b/includes/class-wc-google-analytics-js.php
@@ -476,7 +476,7 @@ class WC_Google_Analytics_JS {
 		echo( "
 			<script>
 			(function($) {
-				$( '.remove' ).click( function() {
+				$( document.body ).on( 'click', '.remove', function() {
 					" . self::tracker_var() . "( 'ec:addProduct', {
 						'id': ($(this).data('product_sku')) ? ($(this).data('product_sku')) : ('#' + $(this).data('product_id')),
 						'quantity': $(this).parent().parent().find( '.qty' ).val() ? $(this).parent().parent().find( '.qty' ).val() : '1',

--- a/readme.txt
+++ b/readme.txt
@@ -68,6 +68,9 @@ Exact wording depends on the national data privacy laws and should be adjusted.
 
 == Changelog ==
 
+= 1.4.8 - xx/xx/2019 =
+* Fix - Event for deleting from cart not sent after a cart update.
+
 = 1.4.7 - 11/19/2018 =
 * Tweak - WP 5.0 compatibility.
 


### PR DESCRIPTION
Fixes #119

#### Changes proposed in this Pull Request:
* Fix - Event for deleting from cart not sent after a cart update.

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? Make sure you ran `grunt` before creating this Pull Request.

