### PR TITLE
Ensure universal analytics pageview doesn’t occur if standard tracking is disabled

### DIFF
--- a/includes/class-wc-google-analytics-js.php
+++ b/includes/class-wc-google-analytics-js.php
@@ -197,7 +197,9 @@ class WC_Google_Analytics_JS {
 	 * Sends the pageview last thing (needed for things like addImpression)
 	 */
 	public static function universal_analytics_footer() {
-		wc_enqueue_js( "" . self::tracker_var() . "( 'send', 'pageview' ); ");
+		if ( 'yes' === self::get( 'ga_standard_tracking_enabled' ) ) {
+			wc_enqueue_js( "" . self::tracker_var() . "( 'send', 'pageview' ); " );
+		}
 	}
 
 	/**


### PR DESCRIPTION
Fixes #143