### PR TITLE
Revert last release that is causing ecommerce tracking to fail when s…

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** Changelog ***
 
+= 1.4.11 - 2019-08-01 =
+* Fix - Revert last release due to it causing ecommerce tracking to be disabled when standard tracking is disabled.
+
 = 1.4.10 - 2019-07-10 =
 * Fix - Ensure universal analytics pageview doesn’t occur if standard tracking is disabled.
  

--- a/includes/class-wc-google-analytics-js.php
+++ b/includes/class-wc-google-analytics-js.php
@@ -197,9 +197,7 @@ class WC_Google_Analytics_JS {
 	 * Sends the pageview last thing (needed for things like addImpression)
 	 */
 	public static function universal_analytics_footer() {
-		if ( 'yes' === self::get( 'ga_standard_tracking_enabled' ) ) {
-			wc_enqueue_js( "" . self::tracker_var() . "( 'send', 'pageview' ); " );
-		}
+		wc_enqueue_js( "" . self::tracker_var() . "( 'send', 'pageview' ); " );
 	}
 
 	/**

--- a/languages/woocommerce-google-analytics-integration.pot
+++ b/languages/woocommerce-google-analytics-integration.pot
@@ -2,11 +2,11 @@
 # This file is distributed under the GPLv2 or later.
 msgid ""
 msgstr ""
-"Project-Id-Version: WooCommerce Google Analytics Integration 1.4.10\n"
+"Project-Id-Version: WooCommerce Google Analytics Integration 1.4.11\n"
 "Report-Msgid-Bugs-To: "
 "https://github.com/woocommerce/woocommerce-google-analytics-integration/"
 "issues\n"
-"POT-Creation-Date: 2019-07-10 20:15:32+00:00\n"
+"POT-Creation-Date: 2019-08-01 16:09:33+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"

--- a/package-lock.json
+++ b/package-lock.json
@@ -85,12 +85,6 @@
         "concat-map": "0.0.1"
       }
     },
-    "builtin-modules": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
-      "dev": true
-    },
     "bytes": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz",
@@ -286,9 +280,9 @@
       }
     },
     "error-ex": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
-      "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "dev": true,
       "requires": {
         "is-arrayish": "^0.2.1"
@@ -301,9 +295,9 @@
       "dev": true
     },
     "esprima": {
-      "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-      "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true
     },
     "eventemitter2": {
@@ -473,23 +467,23 @@
           }
         },
         "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
           "dev": true
         }
       }
     },
     "graceful-fs": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.0.tgz",
+      "integrity": "sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg==",
       "dev": true
     },
     "grunt": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/grunt/-/grunt-1.0.3.tgz",
-      "integrity": "sha512-/JzmZNPfKorlCrrmxWqQO4JVodO+DVd5XX4DkocL/1WlLlKVLE9+SdEIempOAxDhWPysLle6afvn/hg7Ck2k9g==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/grunt/-/grunt-1.0.4.tgz",
+      "integrity": "sha512-PYsMOrOC+MsdGEkFVwMaMyc6Ob7pKmq+deg1Sjr+vvMWp35sztfwKE7qoN51V+UEtHsyNuMcGdgMLFkBHvMxHQ==",
       "dev": true,
       "requires": {
         "coffeescript": "~1.10.0",
@@ -503,7 +497,7 @@
         "grunt-legacy-log": "~2.0.0",
         "grunt-legacy-util": "~1.1.1",
         "iconv-lite": "~0.4.13",
-        "js-yaml": "~3.5.2",
+        "js-yaml": "~3.13.0",
         "minimatch": "~3.0.2",
         "mkdirp": "~0.5.1",
         "nopt": "~3.0.6",
@@ -522,6 +516,12 @@
             "nopt": "~3.0.6",
             "resolve": "~1.1.0"
           }
+        },
+        "resolve": {
+          "version": "1.1.7",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+          "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+          "dev": true
         }
       }
     },
@@ -573,9 +573,9 @@
           }
         },
         "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
           "dev": true
         }
       }
@@ -697,9 +697,9 @@
           }
         },
         "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
           "dev": true
         }
       }
@@ -742,21 +742,15 @@
           }
         },
         "chalk": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
             "ansi-styles": "^3.2.1",
             "escape-string-regexp": "^1.0.5",
             "supports-color": "^5.3.0"
           }
-        },
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
         },
         "supports-color": {
           "version": "5.5.0",
@@ -782,14 +776,6 @@
         "lodash": "~4.17.10",
         "underscore.string": "~3.3.4",
         "which": "~1.3.0"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
-        }
       }
     },
     "grunt-phpcs": {
@@ -954,9 +940,9 @@
       "dev": true
     },
     "hosted-git-info": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
-      "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
+      "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
       "dev": true
     },
     "http-parser-js": {
@@ -1002,15 +988,6 @@
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
     },
-    "is-builtin-module": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-      "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-      "dev": true,
-      "requires": {
-        "builtin-modules": "^1.0.0"
-      }
-    },
     "is-finite": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
@@ -1039,13 +1016,13 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.5.5",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.5.5.tgz",
-      "integrity": "sha1-A3fDgBfKvHMisNH7zSWkkWQfL74=",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
       "dev": true,
       "requires": {
-        "argparse": "^1.0.2",
-        "esprima": "^2.6.0"
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
       }
     },
     "json5": {
@@ -1077,9 +1054,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.5",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-      "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
       "dev": true
     },
     "loud-rejection": {
@@ -1203,21 +1180,21 @@
       }
     },
     "normalize-package-data": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
       "dev": true,
       "requires": {
         "hosted-git-info": "^2.1.4",
-        "is-builtin-module": "^1.0.0",
+        "resolve": "^1.10.0",
         "semver": "2 || 3 || 4 || 5",
         "validate-npm-package-license": "^3.0.1"
       }
     },
     "npm": {
-      "version": "6.7.0",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-6.7.0.tgz",
-      "integrity": "sha512-OtxCLzx+pcsjMGrjZpBp214ZjxzHcAe3zLYIlaVpRYqFHff6bgggyTLf2OZPO8lfxN0RHLJnFFUU016JCzM/Ww==",
+      "version": "6.10.2",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-6.10.2.tgz",
+      "integrity": "sha512-B6n5dgmsl1fpBYhor2OTEn9Md0r63/FpQocDn4WNT4gIQRQZLql9g+mk8s3j9qZD370kUTzwDaOBSmDdNGK3NA==",
       "requires": {
         "JSONStream": "^1.3.5",
         "abbrev": "~1.1.1",
@@ -1226,11 +1203,11 @@
         "aproba": "^2.0.0",
         "archy": "~1.0.0",
         "bin-links": "^1.1.2",
-        "bluebird": "^3.5.3",
+        "bluebird": "^3.5.5",
         "byte-size": "^5.0.1",
-        "cacache": "^11.3.2",
-        "call-limit": "~1.1.0",
-        "chownr": "^1.1.1",
+        "cacache": "^12.0.2",
+        "call-limit": "^1.1.1",
+        "chownr": "^1.1.2",
         "ci-info": "^2.0.0",
         "cli-columns": "^3.1.2",
         "cli-table3": "^0.5.1",
@@ -1247,28 +1224,29 @@
         "fs-vacuum": "~1.2.10",
         "fs-write-stream-atomic": "~1.0.10",
         "gentle-fs": "^2.0.1",
-        "glob": "^7.1.3",
-        "graceful-fs": "^4.1.15",
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.2.0",
         "has-unicode": "~2.0.1",
         "hosted-git-info": "^2.7.1",
         "iferr": "^1.0.2",
         "imurmurhash": "*",
+        "infer-owner": "^1.0.4",
         "inflight": "~1.0.6",
-        "inherits": "~2.0.3",
+        "inherits": "^2.0.4",
         "ini": "^1.3.5",
         "init-package-json": "^1.10.3",
         "is-cidr": "^3.0.0",
         "json-parse-better-errors": "^1.0.2",
         "lazy-property": "~1.0.0",
-        "libcipm": "^3.0.3",
-        "libnpm": "^2.0.1",
-        "libnpmaccess": "*",
-        "libnpmhook": "^5.0.2",
-        "libnpmorg": "*",
-        "libnpmsearch": "*",
-        "libnpmteam": "*",
+        "libcipm": "^4.0.0",
+        "libnpm": "^3.0.1",
+        "libnpmaccess": "^3.0.2",
+        "libnpmhook": "^5.0.3",
+        "libnpmorg": "^1.0.1",
+        "libnpmsearch": "^2.0.2",
+        "libnpmteam": "^1.0.2",
         "libnpx": "^10.2.0",
-        "lock-verify": "^2.0.2",
+        "lock-verify": "^2.1.0",
         "lockfile": "^1.0.4",
         "lodash._baseindexof": "*",
         "lodash._baseuniq": "~4.6.0",
@@ -1281,53 +1259,53 @@
         "lodash.union": "~4.6.0",
         "lodash.uniq": "~4.5.0",
         "lodash.without": "~4.4.0",
-        "lru-cache": "^4.1.5",
+        "lru-cache": "^5.1.1",
         "meant": "~1.0.1",
         "mississippi": "^3.0.0",
         "mkdirp": "~0.5.1",
         "move-concurrently": "^1.0.1",
-        "node-gyp": "^3.8.0",
+        "node-gyp": "^5.0.3",
         "nopt": "~4.0.1",
-        "normalize-package-data": "~2.4.0",
+        "normalize-package-data": "^2.5.0",
         "npm-audit-report": "^1.3.2",
         "npm-cache-filename": "~1.0.2",
         "npm-install-checks": "~3.0.0",
-        "npm-lifecycle": "^2.1.0",
+        "npm-lifecycle": "^3.1.2",
         "npm-package-arg": "^6.1.0",
-        "npm-packlist": "^1.2.0",
+        "npm-packlist": "^1.4.4",
         "npm-pick-manifest": "^2.2.3",
-        "npm-profile": "*",
-        "npm-registry-fetch": "^3.8.0",
+        "npm-profile": "^4.0.2",
+        "npm-registry-fetch": "^4.0.0",
         "npm-user-validate": "~1.0.0",
         "npmlog": "~4.1.2",
         "once": "~1.4.0",
         "opener": "^1.5.1",
         "osenv": "^0.1.5",
-        "pacote": "^9.4.0",
+        "pacote": "^9.5.4",
         "path-is-inside": "~1.0.2",
         "promise-inflight": "~1.0.1",
         "qrcode-terminal": "^0.12.0",
-        "query-string": "^6.2.0",
+        "query-string": "^6.8.1",
         "qw": "~1.0.1",
         "read": "~1.0.7",
         "read-cmd-shim": "~1.0.1",
         "read-installed": "~4.0.3",
         "read-package-json": "^2.0.13",
-        "read-package-tree": "^5.2.1",
-        "readable-stream": "^3.1.1",
-        "readdir-scoped-modules": "*",
+        "read-package-tree": "^5.3.1",
+        "readable-stream": "^3.4.0",
+        "readdir-scoped-modules": "^1.1.0",
         "request": "^2.88.0",
         "retry": "^0.12.0",
         "rimraf": "^2.6.3",
         "safe-buffer": "^5.1.2",
-        "semver": "^5.6.0",
-        "sha": "~2.0.1",
+        "semver": "^5.7.0",
+        "sha": "^3.0.0",
         "slide": "~1.1.6",
         "sorted-object": "~2.0.1",
         "sorted-union-stream": "~2.1.3",
         "ssri": "^6.0.1",
         "stringify-package": "^1.0.0",
-        "tar": "^4.4.8",
+        "tar": "^4.4.10",
         "text-table": "~0.2.0",
         "tiny-relative-date": "^1.3.0",
         "uid-number": "0.0.6",
@@ -1339,8 +1317,8 @@
         "validate-npm-package-license": "^3.0.4",
         "validate-npm-package-name": "~3.0.0",
         "which": "^1.3.1",
-        "worker-farm": "^1.6.0",
-        "write-file-atomic": "^2.4.2"
+        "worker-farm": "^1.7.0",
+        "write-file-atomic": "^2.4.3"
       },
       "dependencies": {
         "JSONStream": {
@@ -1356,14 +1334,14 @@
           "bundled": true
         },
         "agent-base": {
-          "version": "4.2.0",
+          "version": "4.3.0",
           "bundled": true,
           "requires": {
             "es6-promisify": "^5.0.0"
           }
         },
         "agentkeepalive": {
-          "version": "3.4.1",
+          "version": "3.5.2",
           "bundled": true,
           "requires": {
             "humanize-ms": "^1.2.1"
@@ -1493,15 +1471,8 @@
             "write-file-atomic": "^2.3.0"
           }
         },
-        "block-stream": {
-          "version": "0.0.9",
-          "bundled": true,
-          "requires": {
-            "inherits": "~2.0.0"
-          }
-        },
         "bluebird": {
-          "version": "3.5.3",
+          "version": "3.5.5",
           "bundled": true
         },
         "boxen": {
@@ -1529,10 +1500,6 @@
           "version": "1.0.0",
           "bundled": true
         },
-        "builtin-modules": {
-          "version": "1.1.1",
-          "bundled": true
-        },
         "builtins": {
           "version": "1.0.3",
           "bundled": true
@@ -1546,51 +1513,28 @@
           "bundled": true
         },
         "cacache": {
-          "version": "11.3.2",
+          "version": "12.0.2",
           "bundled": true,
           "requires": {
-            "bluebird": "^3.5.3",
+            "bluebird": "^3.5.5",
             "chownr": "^1.1.1",
             "figgy-pudding": "^3.5.1",
-            "glob": "^7.1.3",
+            "glob": "^7.1.4",
             "graceful-fs": "^4.1.15",
+            "infer-owner": "^1.0.3",
             "lru-cache": "^5.1.1",
             "mississippi": "^3.0.0",
             "mkdirp": "^0.5.1",
             "move-concurrently": "^1.0.1",
             "promise-inflight": "^1.0.1",
-            "rimraf": "^2.6.2",
+            "rimraf": "^2.6.3",
             "ssri": "^6.0.1",
             "unique-filename": "^1.1.1",
             "y18n": "^4.0.0"
-          },
-          "dependencies": {
-            "chownr": {
-              "version": "1.1.1",
-              "bundled": true
-            },
-            "lru-cache": {
-              "version": "5.1.1",
-              "bundled": true,
-              "requires": {
-                "yallist": "^3.0.2"
-              }
-            },
-            "unique-filename": {
-              "version": "1.1.1",
-              "bundled": true,
-              "requires": {
-                "unique-slug": "^2.0.0"
-              }
-            },
-            "yallist": {
-              "version": "3.0.3",
-              "bundled": true
-            }
           }
         },
         "call-limit": {
-          "version": "1.1.0",
+          "version": "1.1.1",
           "bundled": true
         },
         "camelcase": {
@@ -1615,7 +1559,7 @@
           }
         },
         "chownr": {
-          "version": "1.1.1",
+          "version": "1.1.2",
           "bundled": true
         },
         "ci-info": {
@@ -1823,6 +1767,20 @@
             "lru-cache": "^4.0.1",
             "shebang-command": "^1.2.0",
             "which": "^1.2.9"
+          },
+          "dependencies": {
+            "lru-cache": {
+              "version": "4.1.5",
+              "bundled": true,
+              "requires": {
+                "pseudomap": "^1.0.2",
+                "yallist": "^2.1.2"
+              }
+            },
+            "yallist": {
+              "version": "2.1.2",
+              "bundled": true
+            }
           }
         },
         "crypto-random-string": {
@@ -1874,6 +1832,13 @@
           "bundled": true,
           "requires": {
             "clone": "^1.0.2"
+          }
+        },
+        "define-properties": {
+          "version": "1.1.3",
+          "bundled": true,
+          "requires": {
+            "object-keys": "^1.0.12"
           }
         },
         "delayed-stream": {
@@ -1974,6 +1939,10 @@
             "once": "^1.4.0"
           }
         },
+        "env-paths": {
+          "version": "1.0.0",
+          "bundled": true
+        },
         "err-code": {
           "version": "1.1.2",
           "bundled": true
@@ -1985,8 +1954,28 @@
             "prr": "~1.0.1"
           }
         },
+        "es-abstract": {
+          "version": "1.12.0",
+          "bundled": true,
+          "requires": {
+            "es-to-primitive": "^1.1.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.1",
+            "is-callable": "^1.1.3",
+            "is-regex": "^1.0.4"
+          }
+        },
+        "es-to-primitive": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "is-callable": "^1.1.4",
+            "is-date-object": "^1.0.1",
+            "is-symbol": "^1.0.2"
+          }
+        },
         "es6-promise": {
-          "version": "4.2.4",
+          "version": "4.2.8",
           "bundled": true
         },
         "es6-promisify": {
@@ -2124,7 +2113,7 @@
           }
         },
         "fs-minipass": {
-          "version": "1.2.5",
+          "version": "1.2.6",
           "bundled": true,
           "requires": {
             "minipass": "^2.2.1"
@@ -2179,15 +2168,9 @@
           "version": "1.0.0",
           "bundled": true
         },
-        "fstream": {
-          "version": "1.0.11",
-          "bundled": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "inherits": "~2.0.0",
-            "mkdirp": ">=0.5 0",
-            "rimraf": "2"
-          }
+        "function-bind": {
+          "version": "1.1.1",
+          "bundled": true
         },
         "gauge": {
           "version": "2.7.4",
@@ -2265,7 +2248,7 @@
           }
         },
         "glob": {
-          "version": "7.1.3",
+          "version": "7.1.4",
           "bundled": true,
           "requires": {
             "fs.realpath": "^1.0.0",
@@ -2307,7 +2290,7 @@
           }
         },
         "graceful-fs": {
-          "version": "4.1.15",
+          "version": "4.2.0",
           "bundled": true
         },
         "har-schema": {
@@ -2322,8 +2305,19 @@
             "har-schema": "^2.0.0"
           }
         },
+        "has": {
+          "version": "1.0.3",
+          "bundled": true,
+          "requires": {
+            "function-bind": "^1.1.1"
+          }
+        },
         "has-flag": {
           "version": "3.0.0",
+          "bundled": true
+        },
+        "has-symbols": {
+          "version": "1.0.0",
           "bundled": true
         },
         "has-unicode": {
@@ -2356,10 +2350,10 @@
           }
         },
         "https-proxy-agent": {
-          "version": "2.2.1",
+          "version": "2.2.2",
           "bundled": true,
           "requires": {
-            "agent-base": "^4.1.0",
+            "agent-base": "^4.3.0",
             "debug": "^3.1.0"
           }
         },
@@ -2396,6 +2390,10 @@
           "version": "0.1.4",
           "bundled": true
         },
+        "infer-owner": {
+          "version": "1.0.4",
+          "bundled": true
+        },
         "inflight": {
           "version": "1.0.6",
           "bundled": true,
@@ -2405,7 +2403,7 @@
           }
         },
         "inherits": {
-          "version": "2.0.3",
+          "version": "2.0.4",
           "bundled": true
         },
         "ini": {
@@ -2438,12 +2436,9 @@
           "version": "2.1.0",
           "bundled": true
         },
-        "is-builtin-module": {
-          "version": "1.0.0",
-          "bundled": true,
-          "requires": {
-            "builtin-modules": "^1.0.0"
-          }
+        "is-callable": {
+          "version": "1.1.4",
+          "bundled": true
         },
         "is-ci": {
           "version": "1.1.0",
@@ -2464,6 +2459,10 @@
           "requires": {
             "cidr-regex": "^2.0.10"
           }
+        },
+        "is-date-object": {
+          "version": "1.0.1",
+          "bundled": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
@@ -2499,6 +2498,13 @@
           "version": "1.0.0",
           "bundled": true
         },
+        "is-regex": {
+          "version": "1.0.4",
+          "bundled": true,
+          "requires": {
+            "has": "^1.0.1"
+          }
+        },
         "is-retry-allowed": {
           "version": "1.1.0",
           "bundled": true
@@ -2506,6 +2512,13 @@
         "is-stream": {
           "version": "1.1.0",
           "bundled": true
+        },
+        "is-symbol": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "has-symbols": "^1.0.0"
+          }
         },
         "is-typedarray": {
           "version": "1.0.0",
@@ -2577,7 +2590,7 @@
           }
         },
         "libcipm": {
-          "version": "3.0.3",
+          "version": "4.0.0",
           "bundled": true,
           "requires": {
             "bin-links": "^1.1.2",
@@ -2588,7 +2601,7 @@
             "ini": "^1.3.5",
             "lock-verify": "^2.0.2",
             "mkdirp": "^0.5.1",
-            "npm-lifecycle": "^2.0.3",
+            "npm-lifecycle": "^3.0.0",
             "npm-logical-tree": "^1.2.1",
             "npm-package-arg": "^6.1.0",
             "pacote": "^9.1.0",
@@ -2598,45 +2611,39 @@
           }
         },
         "libnpm": {
-          "version": "2.0.1",
+          "version": "3.0.1",
           "bundled": true,
           "requires": {
             "bin-links": "^1.1.2",
             "bluebird": "^3.5.3",
             "find-npm-prefix": "^1.0.2",
-            "libnpmaccess": "^3.0.1",
+            "libnpmaccess": "^3.0.2",
             "libnpmconfig": "^1.2.1",
-            "libnpmhook": "^5.0.2",
-            "libnpmorg": "^1.0.0",
-            "libnpmpublish": "^1.1.0",
-            "libnpmsearch": "^2.0.0",
-            "libnpmteam": "^1.0.1",
+            "libnpmhook": "^5.0.3",
+            "libnpmorg": "^1.0.1",
+            "libnpmpublish": "^1.1.2",
+            "libnpmsearch": "^2.0.2",
+            "libnpmteam": "^1.0.2",
             "lock-verify": "^2.0.2",
-            "npm-lifecycle": "^2.1.0",
+            "npm-lifecycle": "^3.0.0",
             "npm-logical-tree": "^1.2.1",
             "npm-package-arg": "^6.1.0",
-            "npm-profile": "^4.0.1",
-            "npm-registry-fetch": "^3.8.0",
+            "npm-profile": "^4.0.2",
+            "npm-registry-fetch": "^4.0.0",
             "npmlog": "^4.1.2",
-            "pacote": "^9.2.3",
+            "pacote": "^9.5.3",
             "read-package-json": "^2.0.13",
             "stringify-package": "^1.0.0"
           }
         },
         "libnpmaccess": {
-          "version": "3.0.1",
+          "version": "3.0.2",
           "bundled": true,
           "requires": {
             "aproba": "^2.0.0",
             "get-stream": "^4.0.0",
             "npm-package-arg": "^6.1.0",
-            "npm-registry-fetch": "^3.8.0"
-          },
-          "dependencies": {
-            "aproba": {
-              "version": "2.0.0",
-              "bundled": true
-            }
+            "npm-registry-fetch": "^4.0.0"
           }
         },
         "libnpmconfig": {
@@ -2664,7 +2671,7 @@
               }
             },
             "p-limit": {
-              "version": "2.1.0",
+              "version": "2.2.0",
               "bundled": true,
               "requires": {
                 "p-try": "^2.0.0"
@@ -2678,39 +2685,33 @@
               }
             },
             "p-try": {
-              "version": "2.0.0",
+              "version": "2.2.0",
               "bundled": true
             }
           }
         },
         "libnpmhook": {
-          "version": "5.0.2",
+          "version": "5.0.3",
           "bundled": true,
           "requires": {
             "aproba": "^2.0.0",
             "figgy-pudding": "^3.4.1",
             "get-stream": "^4.0.0",
-            "npm-registry-fetch": "^3.8.0"
+            "npm-registry-fetch": "^4.0.0"
           }
         },
         "libnpmorg": {
-          "version": "1.0.0",
+          "version": "1.0.1",
           "bundled": true,
           "requires": {
             "aproba": "^2.0.0",
             "figgy-pudding": "^3.4.1",
             "get-stream": "^4.0.0",
-            "npm-registry-fetch": "^3.8.0"
-          },
-          "dependencies": {
-            "aproba": {
-              "version": "2.0.0",
-              "bundled": true
-            }
+            "npm-registry-fetch": "^4.0.0"
           }
         },
         "libnpmpublish": {
-          "version": "1.1.1",
+          "version": "1.1.2",
           "bundled": true,
           "requires": {
             "aproba": "^2.0.0",
@@ -2719,34 +2720,28 @@
             "lodash.clonedeep": "^4.5.0",
             "normalize-package-data": "^2.4.0",
             "npm-package-arg": "^6.1.0",
-            "npm-registry-fetch": "^3.8.0",
+            "npm-registry-fetch": "^4.0.0",
             "semver": "^5.5.1",
             "ssri": "^6.0.1"
           }
         },
         "libnpmsearch": {
-          "version": "2.0.0",
+          "version": "2.0.2",
           "bundled": true,
           "requires": {
             "figgy-pudding": "^3.5.1",
             "get-stream": "^4.0.0",
-            "npm-registry-fetch": "^3.8.0"
+            "npm-registry-fetch": "^4.0.0"
           }
         },
         "libnpmteam": {
-          "version": "1.0.1",
+          "version": "1.0.2",
           "bundled": true,
           "requires": {
             "aproba": "^2.0.0",
             "figgy-pudding": "^3.4.1",
             "get-stream": "^4.0.0",
-            "npm-registry-fetch": "^3.8.0"
-          },
-          "dependencies": {
-            "aproba": {
-              "version": "2.0.0",
-              "bundled": true
-            }
+            "npm-registry-fetch": "^4.0.0"
           }
         },
         "libnpx": {
@@ -2772,10 +2767,10 @@
           }
         },
         "lock-verify": {
-          "version": "2.0.2",
+          "version": "2.1.0",
           "bundled": true,
           "requires": {
-            "npm-package-arg": "^5.1.2 || 6",
+            "npm-package-arg": "^6.1.0",
             "semver": "^5.4.1"
           }
         },
@@ -2850,11 +2845,10 @@
           "bundled": true
         },
         "lru-cache": {
-          "version": "4.1.5",
+          "version": "5.1.1",
           "bundled": true,
           "requires": {
-            "pseudomap": "^1.0.2",
-            "yallist": "^2.1.2"
+            "yallist": "^3.0.2"
           }
         },
         "make-dir": {
@@ -2865,15 +2859,15 @@
           }
         },
         "make-fetch-happen": {
-          "version": "4.0.1",
+          "version": "5.0.0",
           "bundled": true,
           "requires": {
             "agentkeepalive": "^3.4.1",
-            "cacache": "^11.0.1",
+            "cacache": "^12.0.0",
             "http-cache-semantics": "^3.8.1",
             "http-proxy-agent": "^2.1.0",
             "https-proxy-agent": "^2.2.1",
-            "lru-cache": "^4.1.2",
+            "lru-cache": "^5.1.1",
             "mississippi": "^3.0.0",
             "node-fetch-npm": "^2.0.2",
             "promise-retry": "^1.1.1",
@@ -2933,7 +2927,7 @@
           }
         },
         "minizlib": {
-          "version": "1.1.1",
+          "version": "1.2.1",
           "bundled": true,
           "requires": {
             "minipass": "^2.2.1"
@@ -2998,20 +2992,19 @@
           }
         },
         "node-gyp": {
-          "version": "3.8.0",
+          "version": "5.0.3",
           "bundled": true,
           "requires": {
-            "fstream": "^1.0.0",
+            "env-paths": "^1.0.0",
             "glob": "^7.0.3",
             "graceful-fs": "^4.1.2",
             "mkdirp": "^0.5.0",
             "nopt": "2 || 3",
             "npmlog": "0 || 1 || 2 || 3 || 4",
-            "osenv": "0",
             "request": "^2.87.0",
             "rimraf": "2",
             "semver": "~5.3.0",
-            "tar": "^2.0.0",
+            "tar": "^4.4.8",
             "which": "1"
           },
           "dependencies": {
@@ -3025,15 +3018,6 @@
             "semver": {
               "version": "5.3.0",
               "bundled": true
-            },
-            "tar": {
-              "version": "2.2.1",
-              "bundled": true,
-              "requires": {
-                "block-stream": "*",
-                "fstream": "^1.0.2",
-                "inherits": "2"
-              }
             }
           }
         },
@@ -3046,13 +3030,22 @@
           }
         },
         "normalize-package-data": {
-          "version": "2.4.0",
+          "version": "2.5.0",
           "bundled": true,
           "requires": {
             "hosted-git-info": "^2.1.4",
-            "is-builtin-module": "^1.0.0",
+            "resolve": "^1.10.0",
             "semver": "2 || 3 || 4 || 5",
             "validate-npm-package-license": "^3.0.1"
+          },
+          "dependencies": {
+            "resolve": {
+              "version": "1.10.0",
+              "bundled": true,
+              "requires": {
+                "path-parse": "^1.0.6"
+              }
+            }
           }
         },
         "npm-audit-report": {
@@ -3064,7 +3057,7 @@
           }
         },
         "npm-bundled": {
-          "version": "1.0.5",
+          "version": "1.0.6",
           "bundled": true
         },
         "npm-cache-filename": {
@@ -3079,12 +3072,12 @@
           }
         },
         "npm-lifecycle": {
-          "version": "2.1.0",
+          "version": "3.1.2",
           "bundled": true,
           "requires": {
             "byline": "^5.0.0",
-            "graceful-fs": "^4.1.11",
-            "node-gyp": "^3.8.0",
+            "graceful-fs": "^4.1.15",
+            "node-gyp": "^5.0.2",
             "resolve-from": "^4.0.0",
             "slide": "^1.1.6",
             "uid-number": "0.0.6",
@@ -3107,7 +3100,7 @@
           }
         },
         "npm-packlist": {
-          "version": "1.2.0",
+          "version": "1.4.4",
           "bundled": true,
           "requires": {
             "ignore-walk": "^3.0.1",
@@ -3124,23 +3117,23 @@
           }
         },
         "npm-profile": {
-          "version": "4.0.1",
+          "version": "4.0.2",
           "bundled": true,
           "requires": {
             "aproba": "^1.1.2 || 2",
             "figgy-pudding": "^3.4.1",
-            "npm-registry-fetch": "^3.8.0"
+            "npm-registry-fetch": "^4.0.0"
           }
         },
         "npm-registry-fetch": {
-          "version": "3.8.0",
+          "version": "4.0.0",
           "bundled": true,
           "requires": {
             "JSONStream": "^1.3.4",
             "bluebird": "^3.5.1",
             "figgy-pudding": "^3.4.1",
-            "lru-cache": "^4.1.3",
-            "make-fetch-happen": "^4.0.1",
+            "lru-cache": "^5.1.1",
+            "make-fetch-happen": "^5.0.0",
             "npm-package-arg": "^6.1.0"
           }
         },
@@ -3176,6 +3169,18 @@
         "object-assign": {
           "version": "4.1.1",
           "bundled": true
+        },
+        "object-keys": {
+          "version": "1.0.12",
+          "bundled": true
+        },
+        "object.getownpropertydescriptors": {
+          "version": "2.0.3",
+          "bundled": true,
+          "requires": {
+            "define-properties": "^1.1.2",
+            "es-abstract": "^1.5.1"
+          }
         },
         "once": {
           "version": "1.4.0",
@@ -3246,16 +3251,16 @@
           }
         },
         "pacote": {
-          "version": "9.4.0",
+          "version": "9.5.4",
           "bundled": true,
           "requires": {
             "bluebird": "^3.5.3",
-            "cacache": "^11.3.2",
+            "cacache": "^12.0.0",
             "figgy-pudding": "^3.5.1",
             "get-stream": "^4.1.0",
             "glob": "^7.1.3",
             "lru-cache": "^5.1.1",
-            "make-fetch-happen": "^4.0.1",
+            "make-fetch-happen": "^5.0.0",
             "minimatch": "^3.0.4",
             "minipass": "^2.3.5",
             "mississippi": "^3.0.0",
@@ -3264,7 +3269,7 @@
             "npm-package-arg": "^6.1.0",
             "npm-packlist": "^1.1.12",
             "npm-pick-manifest": "^2.2.3",
-            "npm-registry-fetch": "^3.8.0",
+            "npm-registry-fetch": "^4.0.0",
             "osenv": "^0.1.5",
             "promise-inflight": "^1.0.1",
             "promise-retry": "^1.1.1",
@@ -3278,13 +3283,6 @@
             "which": "^1.3.1"
           },
           "dependencies": {
-            "lru-cache": {
-              "version": "5.1.1",
-              "bundled": true,
-              "requires": {
-                "yallist": "^3.0.2"
-              }
-            },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
@@ -3292,10 +3290,6 @@
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
               }
-            },
-            "yallist": {
-              "version": "3.0.3",
-              "bundled": true
             }
           }
         },
@@ -3344,6 +3338,10 @@
         },
         "path-key": {
           "version": "2.0.1",
+          "bundled": true
+        },
+        "path-parse": {
+          "version": "1.0.6",
           "bundled": true
         },
         "performance-now": {
@@ -3450,10 +3448,11 @@
           "bundled": true
         },
         "query-string": {
-          "version": "6.2.0",
+          "version": "6.8.1",
           "bundled": true,
           "requires": {
             "decode-uri-component": "^0.2.0",
+            "split-on-first": "^1.0.0",
             "strict-uri-encode": "^2.0.0"
           }
         },
@@ -3516,18 +3515,16 @@
           }
         },
         "read-package-tree": {
-          "version": "5.2.1",
+          "version": "5.3.1",
           "bundled": true,
           "requires": {
-            "debuglog": "^1.0.1",
-            "dezalgo": "^1.0.0",
-            "once": "^1.3.0",
             "read-package-json": "^2.0.0",
-            "readdir-scoped-modules": "^1.0.0"
+            "readdir-scoped-modules": "^1.0.0",
+            "util-promisify": "^2.1.0"
           }
         },
         "readable-stream": {
-          "version": "3.1.1",
+          "version": "3.4.0",
           "bundled": true,
           "requires": {
             "inherits": "^2.0.3",
@@ -3536,7 +3533,7 @@
           }
         },
         "readdir-scoped-modules": {
-          "version": "1.0.2",
+          "version": "1.1.0",
           "bundled": true,
           "requires": {
             "debuglog": "^1.0.1",
@@ -3631,7 +3628,7 @@
           "bundled": true
         },
         "semver": {
-          "version": "5.6.0",
+          "version": "5.7.0",
           "bundled": true
         },
         "semver-diff": {
@@ -3646,33 +3643,10 @@
           "bundled": true
         },
         "sha": {
-          "version": "2.0.1",
+          "version": "3.0.0",
           "bundled": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "readable-stream": "^2.0.2"
-          },
-          "dependencies": {
-            "readable-stream": {
-              "version": "2.3.6",
-              "bundled": true,
-              "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
-              }
-            },
-            "string_decoder": {
-              "version": "1.1.1",
-              "bundled": true,
-              "requires": {
-                "safe-buffer": "~5.1.0"
-              }
-            }
+            "graceful-fs": "^4.1.2"
           }
         },
         "shebang-command": {
@@ -3699,23 +3673,32 @@
           "bundled": true
         },
         "smart-buffer": {
-          "version": "4.0.1",
+          "version": "4.0.2",
           "bundled": true
         },
         "socks": {
-          "version": "2.2.0",
+          "version": "2.3.2",
           "bundled": true,
           "requires": {
             "ip": "^1.1.5",
-            "smart-buffer": "^4.0.1"
+            "smart-buffer": "4.0.2"
           }
         },
         "socks-proxy-agent": {
-          "version": "4.0.1",
+          "version": "4.0.2",
           "bundled": true,
           "requires": {
-            "agent-base": "~4.2.0",
-            "socks": "~2.2.0"
+            "agent-base": "~4.2.1",
+            "socks": "~2.3.2"
+          },
+          "dependencies": {
+            "agent-base": {
+              "version": "4.2.1",
+              "bundled": true,
+              "requires": {
+                "es6-promisify": "^5.0.0"
+              }
+            }
           }
         },
         "sorted-object": {
@@ -3780,6 +3763,10 @@
         },
         "spdx-license-ids": {
           "version": "3.0.3",
+          "bundled": true
+        },
+        "split-on-first": {
+          "version": "1.1.0",
           "bundled": true
         },
         "sshpk": {
@@ -3909,22 +3896,18 @@
           }
         },
         "tar": {
-          "version": "4.4.8",
+          "version": "4.4.10",
           "bundled": true,
           "requires": {
             "chownr": "^1.1.1",
             "fs-minipass": "^1.2.5",
-            "minipass": "^2.3.4",
-            "minizlib": "^1.1.1",
+            "minipass": "^2.3.5",
+            "minizlib": "^1.2.1",
             "mkdirp": "^0.5.0",
             "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.2"
+            "yallist": "^3.0.3"
           },
           "dependencies": {
-            "chownr": {
-              "version": "1.1.1",
-              "bundled": true
-            },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
@@ -4084,6 +4067,13 @@
           "version": "1.0.3",
           "bundled": true
         },
+        "util-promisify": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "object.getownpropertydescriptors": "^2.0.3"
+          }
+        },
         "uuid": {
           "version": "3.3.2",
           "bundled": true
@@ -4156,7 +4146,7 @@
           }
         },
         "worker-farm": {
-          "version": "1.6.0",
+          "version": "1.7.0",
           "bundled": true,
           "requires": {
             "errno": "~0.1.7"
@@ -4186,7 +4176,7 @@
           "bundled": true
         },
         "write-file-atomic": {
-          "version": "2.4.2",
+          "version": "2.4.3",
           "bundled": true,
           "requires": {
             "graceful-fs": "^4.1.11",
@@ -4207,7 +4197,7 @@
           "bundled": true
         },
         "yallist": {
-          "version": "2.1.2",
+          "version": "3.0.3",
           "bundled": true
         },
         "yargs": {
@@ -4307,6 +4297,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
       "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
     },
     "path-type": {
@@ -4477,10 +4473,13 @@
       }
     },
     "resolve": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-      "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
-      "dev": true
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
+      "integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
+      "dev": true,
+      "requires": {
+        "path-parse": "^1.0.6"
+      }
     },
     "rimraf": {
       "version": "2.6.2",
@@ -4596,9 +4595,9 @@
       "dev": true
     },
     "spdx-correct": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
-      "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
+      "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
       "dev": true,
       "requires": {
         "spdx-expression-parse": "^3.0.0",
@@ -4606,9 +4605,9 @@
       }
     },
     "spdx-exceptions": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
-      "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
+      "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
       "dev": true
     },
     "spdx-expression-parse": {
@@ -4622,9 +4621,9 @@
       }
     },
     "spdx-license-ids": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
-      "integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
+      "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
       "dev": true
     },
     "sprintf-js": {
@@ -4754,9 +4753,9 @@
       "dev": true
     },
     "validate-npm-package-license": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
-      "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
       "dev": true,
       "requires": {
         "spdx-correct": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "devDependencies": {
     "config": "^3.0.1",
     "cross-env": "^5.2.0",
-    "grunt": "^1.0.3",
+    "grunt": "^1.0.4",
     "grunt-checktextdomain": "~1.0.1",
     "grunt-contrib-clean": "~2.0.0",
     "grunt-contrib-concat": "~1.0.1",
@@ -35,6 +35,6 @@
     "npm": ">=5.5.1"
   },
   "dependencies": {
-    "npm": "^6.7.0"
+    "npm": "^6.10.2"
   }
 }

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: woocommerce, claudiosanches, bor0, royho, laurendavissmith001, c-shultz
 Tags: woocommerce, google analytics
 Requires at least: 3.8
-Tested up to: 5.1
-Stable tag: 1.4.10
+Tested up to: 5.2
+Stable tag: 1.4.11
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -67,6 +67,9 @@ Exact wording depends on the national data privacy laws and should be adjusted.
 1. Google Analytics Integration Settings.
 
 == Changelog ==
+
+= 1.4.11 - 2019-08-01 =
+* Fix - Revert last release due to it causing ecommerce tracking to be disabled when standard tracking is disabled.
 
 = 1.4.10 - 2019-07-10 =
 * Fix - Ensure universal analytics pageview doesn’t occur if standard tracking is disabled.

--- a/woocommerce-google-analytics-integration.php
+++ b/woocommerce-google-analytics-integration.php
@@ -5,7 +5,7 @@
  * Description: Allows Google Analytics tracking code to be inserted into WooCommerce store pages.
  * Author: WooCommerce
  * Author URI: https://woocommerce.com
- * Version: 1.4.10
+ * Version: 1.4.11
  * WC requires at least: 2.1
  * WC tested up to: 3.6
  * License: GPLv2 or later
@@ -29,7 +29,7 @@ if ( ! class_exists( 'WC_Google_Analytics_Integration' ) ) {
 		 *
 		 * @var string
 		 */
-		const VERSION = '1.4.10';
+		const VERSION = '1.4.11';
 
 		/**
 		 * Instance of this class.


### PR DESCRIPTION
…tandard tracking is disabled closes #145

Fixes #145

#### Changes proposed in this Pull Request:
- * Fix - Revert last release due to it causing ecommerce tracking to be disabled when standard tracking is disabled.


-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? Make sure you ran `grunt` before creating this Pull Request.

