### PR TITLE
Add dev build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,14 +19,14 @@
     }
   },
   "scripts": {
-    "build": "npm run uglify && npm run makepot",
-    "postbuild": "npm run -s && npm run archive",
+    "prebuild": "rm -rf ./vendor",
+    "build": "npm run uglify && npm run makepot && npm run archive",
+    "build:dev": "npm run uglify && npm run makepot",
     "archive": "composer archive --file=$npm_package_name --format=zip",
     "postarchive": "rm -rf $npm_package_name && unzip $npm_package_name.zip -d $npm_package_name && rm $npm_package_name.zip && zip -r $npm_package_name.zip $npm_package_name && rm -rf $npm_package_name",
     "preuglify": "rm -f $npm_package_assets_js_min",
     "uglify": "for f in $npm_package_assets_js_js; do file=${f%.js}; node_modules/.bin/uglifyjs $f -c -m > $file.min.js; done",
-    "makepot": "wpi18n makepot --domain-path languages --pot-file $npm_package_name.pot --type plugin --main-file $npm_package_name.php --exclude node_modules,tests,docs",
-    "woorelease": "npm run build"
+    "makepot": "wpi18n makepot --domain-path languages --pot-file $npm_package_name.pot --type plugin --main-file $npm_package_name.php --exclude node_modules,tests,docs"
   },
   "engines": {
     "node": ">=8.9.3",


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Splits out the build into two separate steps:

1. Build for release
 - Includes only non dev dependencies in composer
 - Creates a zip archive
2. Build for development
 - Includes all dependencies in composer (including dev)
 - Generates all resources, but does not create a zip archive
 
 Note: For extensions that don't have any composer dependencies we don't run composer install at all so the autoloader isn't included.

Closes https://github.com/woocommerce/woocommerce-extension-library/issues/130

### How to test the changes in this Pull Request:

1. Run `npm install && npm run build`
2. Confirm that the zip archive is created and doesn't contain any dev dependencies (most our extensions won't have any)
