### PR TITLE
Check localStorage to avoid duplicate transactions

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** Changelog ***
 
+= 1.4.23 - 2020-xx-xx =
+* Fix - Prevent transaction from being tracked a second time when page is reloaded locally or from cache.
+
 = 1.4.22 - 2020-06-05 =
 * Tweak - WC 4.2 compatibility.
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

When the order-received page is loaded the first time the metadata `_ga_tracked` is saved on the order to prevent it from being tracked twice. However as we can see in the original issue there are scenarios where the page is not reloaded a second time from the server. For example if there is caching in place, or cases where the page is later reopened on a mobile device where the page is reloaded without requesting it from the server.

Thanks to @tc33 for the original PR: https://github.com/woocommerce/woocommerce-google-analytics-integration/pull/165
In this PR it was suggested to use localStorage to save the order ID's, which can be checked before sending the request. The solution from the original PR was copied and modified slightly to fallback in scenarios where localStorage is not available or has been disabled.

Closes #120 

### How to test the changes in this Pull Request:

1. Complete an order to confirm the transaction event still fires on the thank-you page
2. Manually remove the `_ga_tracked` post meta value to remove the server side protection
3. Reload the thank-you page to confirm transaction event does not fire a second time
4. The `ga_orders` localStorage item can be checked manually in developer tools


### Changelog entry
* Fix - Prevent transaction from being tracked a second time when page is reloaded locally or from cache.
