### PR TITLE
Change `utm_source` and `utm_medium` in upsell notice link

### DIFF
--- a/woocommerce-google-analytics-integration.php
+++ b/woocommerce-google-analytics-integration.php
@@ -141,7 +141,7 @@ if ( ! class_exists( 'WC_Google_Analytics_Integration' ) ) {
 			$notice_html  = '<strong>' . esc_html__( 'Get detailed insights into your sales with Google Analytics Pro', 'woocommerce-google-analytics-integration' ) . '</strong><br><br>';
 
 			/* translators: 1: href link to GA pro */
-			$notice_html .= sprintf( __( 'Add advanced tracking for your sales funnel, coupons and more. [<a href="%s" target="_blank">Learn more</a> &gt;]', 'woocommerce-google-analytics-integration' ), 'https://woocommerce.com/products/woocommerce-google-analytics-pro/?utm_source=product&utm_medium=upsell&utm_campaign=google%20analytics%20free%20to%20pro%20extension%20upsell' );
+			$notice_html .= sprintf( __( 'Add advanced tracking for your sales funnel, coupons and more. [<a href="%s" target="_blank">Learn more</a> &gt;]', 'woocommerce-google-analytics-integration' ), 'https://woocommerce.com/products/woocommerce-google-analytics-pro/?utm_source=woocommerce-google-analytics-integration&utm_medium=product&utm_campaign=google%20analytics%20free%20to%20pro%20extension%20upsell' );
 
 			WC_Admin_Notices::add_custom_notice( 'woocommerce_google_analytics_pro_notice', $notice_html );
 			update_option( 'woocommerce_google_analytics_pro_notice_shown', true );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #194 .

This PR changes the `utm_source` and `utm_medium` values in the link in the upsell notice to the following values:

- `utm_source=woocommerce-google-analytics-integration`
- `utm_medium=product`

The upsell notice is displayed in a page like this: 

![image](https://user-images.githubusercontent.com/417342/127363938-a2fab295-1974-418e-b634-c7228c5d73bd.png)

Prior to this PR, the link goes to: `https://woocommerce.com/products/woocommerce-google-analytics-pro/?utm_source=product&utm_medium=upsell&utm_campaign=google%20analytics%20free%20to%20pro%20extension%20upsell`

With this PR, the link goes to: `https://woocommerce.com/products/woocommerce-google-analytics-pro/?utm_source=woocommerce-google-analytics-integration&utm_medium=product&utm_campaign=google%20analytics%20free%20to%20pro%20extension%20upsell`

### How to test the changes in this Pull Request:

1. Checkout this branch. Run `npm ci` and `composer install`.
2. To easily test and verify the changes, you can comment out the following code: 

https://github.com/woocommerce/woocommerce-google-analytics-integration/blob/86e6e6d982b90132565715d669cd725d5361a193/woocommerce-google-analytics-integration.php#L129-L139

![image](https://user-images.githubusercontent.com/417342/127364269-a1e39024-bab7-4f1c-bd5e-ce2154ce2bd8.png)

3. Build the code by running `npm run build:dev`.
4. Go to the Plugins page in your site and activate the plugin. 
5. You should see the notice at the top of Plugins page.

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changelog entry

Fix - Change utm_source and utm_medium in upsell notice link.
