### PR TITLE
Display GA Pro notice on plugin activation and on order complete

### DIFF
--- a/woocommerce-google-analytics-integration.php
+++ b/woocommerce-google-analytics-integration.php
@@ -22,6 +22,14 @@ if ( ! class_exists( 'WC_Google_Analytics_Integration' ) ) {
 
 	define( 'WC_GOOGLE_ANALYTICS_INTEGRATION_VERSION', '1.5.3' ); // WRCS: DEFINED_VERSION.
 
+	// Maybe show the GA Pro notice on plugin activation.
+	register_activation_hook(
+		__FILE__,
+		function () {
+			WC_Google_Analytics_Integration::get_instance()->maybe_show_ga_pro_notices();
+		}
+	);
+
 	/**
 	 * WooCommerce Google Analytics Integration main class.
 	 */
@@ -40,7 +48,9 @@ if ( ! class_exists( 'WC_Google_Analytics_Integration' ) ) {
 
 			// Load plugin text domain
 			add_action( 'init', array( $this, 'load_plugin_textdomain' ) );
-			add_action( 'admin_init', array( $this, 'show_ga_pro_notices' ) );
+
+			// Track completed orders and determine whether the GA Pro notice should be displayed.
+			add_action( 'woocommerce_order_status_completed', array( $this, 'maybe_show_ga_pro_notices' ) );
 
 			// Checks which WooCommerce is installed.
 			if ( class_exists( 'WC_Integration' ) && defined( 'WOOCOMMERCE_VERSION' ) && version_compare( WOOCOMMERCE_VERSION, '3.2', '>=' ) ) {
@@ -125,7 +135,7 @@ if ( ! class_exists( 'WC_Google_Analytics_Integration' ) ) {
 		/**
 		 * Logic for Google Analytics Pro notices.
 		 */
-		public function show_ga_pro_notices() {
+		public function maybe_show_ga_pro_notices() {
 			// Notice was already shown
 			if ( get_option( 'woocommerce_google_analytics_pro_notice_shown', false ) ) {
 				return;
@@ -134,13 +144,8 @@ if ( ! class_exists( 'WC_Google_Analytics_Integration' ) ) {
 			$completed_orders = wc_orders_count( 'completed' );
 
 			// Only show the notice if there are 10 <= completed orders <= 100.
-			$too_few_orders_to_show_the_notice  = $completed_orders < 10;
-			$too_many_orders_to_show_the_notice = $completed_orders > 100;
-			if ( $too_many_orders_to_show_the_notice ) {
+			if ( $completed_orders < 10 || $completed_orders > 100 ) {
 				update_option( 'woocommerce_google_analytics_pro_notice_shown', true );
-			}
-			if ( $too_few_orders_to_show_the_notice || $too_many_orders_to_show_the_notice ) {
-				return;
 			}
 
 			$notice_html  = '<strong>' . esc_html__( 'Get detailed insights into your sales with Google Analytics Pro', 'woocommerce-google-analytics-integration' ) . '</strong><br><br>';

--- a/woocommerce-google-analytics-integration.php
+++ b/woocommerce-google-analytics-integration.php
@@ -146,6 +146,8 @@ if ( ! class_exists( 'WC_Google_Analytics_Integration' ) ) {
 			// Only show the notice if there are 10 <= completed orders <= 100.
 			if ( $completed_orders < 10 || $completed_orders > 100 ) {
 				update_option( 'woocommerce_google_analytics_pro_notice_shown', true );
+
+				return;
 			}
 
 			$notice_html  = '<strong>' . esc_html__( 'Get detailed insights into your sales with Google Analytics Pro', 'woocommerce-google-analytics-integration' ) . '</strong><br><br>';


### PR DESCRIPTION

### All Submissions:

* [x] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* ~[ ] Have you written new tests for your changes, as applicable?~
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Previously, to display the Google Analytics Pro notice the shop's orders were counted on all page loads because the function was hooked into `admin_init`. This was causing performance issues for some users even though WooCommerce caches the results. Given that the notice isn't critical (it's a promo), we should only check if it should be displayed whenever a new order gets completed (since we're counting the completed orders) or on plugin activation.

Closes #188.

### How to test the changes in this Pull Request:

1. Remove the `woocommerce_google_analytics_pro_notice_shown` key from your options table
2. Make sure you have between 10 and 100 completed orders on your store (this is the criteria checked for the notice to be displayed)
3. Activate the plugin and confirm the notice is visible
4. Remove the `woocommerce_google_analytics_pro_notice_shown` key from your options table
5. Create a new order or edit an existing order
6. Change the order status to `Completed` and update the order
7. Confirm that the notice is displayed
8. Dismiss the notice and reactivate the plugin
9. Confirm that the notice is NOT displayed this time
10. Repeat steps 5 and 6 and confirm that the notice is NOT displayed

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Screenshot

![image](https://user-images.githubusercontent.com/73110514/140310703-bcbf80fe-1fd5-4c58-a3b1-1f2ef48d3622.png)

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Remove the slow order counting query from admin init.
