### PR TITLE
Add support for cross domain tracking features

### DIFF
--- a/includes/class-wc-google-analytics-js.php
+++ b/includes/class-wc-google-analytics-js.php
@@ -245,9 +245,9 @@ class WC_Google_Analytics_JS extends WC_Abstract_Google_Analytics_JS {
 		$ga_id = self::get( 'ga_id' );
 
 		if( 'yes' === self::get( 'ga_linker_allow_incoming_enabled' ) ) {
-			$ga_snippet_create       = self::tracker_var() . "( 'create', '" . esc_js( $ga_id ) . "', '" . $set_domain_name . "', { allowLinker: true });";
+			$ga_snippet_create = self::tracker_var() . "( 'create', '" . esc_js( $ga_id ) . "', '" . $set_domain_name . "', { allowLinker: true });";
 		} else {
-			$ga_snippet_create       = self::tracker_var() . "( 'create', '" . esc_js( $ga_id ) . "', '" . $set_domain_name . "' );";
+			$ga_snippet_create = self::tracker_var() . "( 'create', '" . esc_js( $ga_id ) . "', '" . $set_domain_name . "' );";
 		}
 
 		if ( ! empty( self::DEVELOPER_ID ) ) {
@@ -268,7 +268,7 @@ class WC_Google_Analytics_JS extends WC_Abstract_Google_Analytics_JS {
 			$ga_snippet_require .= "" . self::tracker_var() . "( 'require', 'ecommerce', 'ecommerce.js');";
 		}
 
-		$ga_cross_domains = !empty(self::get( 'ga_linker_cross_domains' )) ? array_map( 'esc_js', explode( ',', self::get( 'ga_linker_cross_domains' ) )) : false;
+		$ga_cross_domains = ! empty( self::get( 'ga_linker_cross_domains' ) ) ? array_map( 'esc_js', explode( ',', self::get( 'ga_linker_cross_domains' ) ) ) : false;
 
 		if( $ga_cross_domains ) {
 			$ga_snippet_require .= "" . self::tracker_var() . "( 'require', 'linker' );";

--- a/includes/class-wc-google-analytics-js.php
+++ b/includes/class-wc-google-analytics-js.php
@@ -243,7 +243,12 @@ class WC_Google_Analytics_JS extends WC_Abstract_Google_Analytics_JS {
 		})(window,document,'script', '{$src}','" . self::tracker_var() . "');";
 
 		$ga_id = self::get( 'ga_id' );
-		$ga_snippet_create       = self::tracker_var() . "( 'create', '" . esc_js( $ga_id ) . "', '" . $set_domain_name . "' );";
+
+		if( 'yes' === self::get( 'ga_linker_allow_incoming_enabled' ) ) {
+			$ga_snippet_create       = self::tracker_var() . "( 'create', '" . esc_js( $ga_id ) . "', '" . $set_domain_name . "', { allowLinker: true });";
+		} else {
+			$ga_snippet_create       = self::tracker_var() . "( 'create', '" . esc_js( $ga_id ) . "', '" . $set_domain_name . "' );";
+		}
 
 		if ( ! empty( self::DEVELOPER_ID ) ) {
 			$ga_snippet_developer_id = "(window.gaDevIds=window.gaDevIds||[]).push('" . self::DEVELOPER_ID . "');";
@@ -261,6 +266,13 @@ class WC_Google_Analytics_JS extends WC_Abstract_Google_Analytics_JS {
 			$ga_snippet_require .= "" . self::tracker_var() . "( 'require', 'ec' );";
 		} else {
 			$ga_snippet_require .= "" . self::tracker_var() . "( 'require', 'ecommerce', 'ecommerce.js');";
+		}
+
+		$ga_cross_domains = !empty(self::get( 'ga_linker_cross_domains' )) ? array_map( 'esc_js', explode( ',', self::get( 'ga_linker_cross_domains' ) )) : false;
+
+		if( $ga_cross_domains ) {
+			$ga_snippet_require .= "" . self::tracker_var() . "( 'require', 'linker' );";
+			$ga_snippet_require .= "" . self::tracker_var() . "( 'linker:autoLink', " . wp_json_encode( $ga_cross_domains ) . ");";
 		}
 
 		$ga_snippet_head         = apply_filters( 'woocommerce_ga_snippet_head', $ga_snippet_head );

--- a/includes/class-wc-google-analytics.php
+++ b/includes/class-wc-google-analytics.php
@@ -236,11 +236,11 @@ class WC_Google_Analytics extends WC_Integration {
 				'default'     => '',
 			),
 			'ga_linker_allow_incoming_enabled' => array(
-				'label' 			=> __( 'Accept Incoming Linker Parameters', 'woocommerce-google-analytics-integration' ),
-				'description' 			=> __( 'Enabling this option will allow incoming linker parameters from other websites.', 'woocommerce-google-analytics-integration' ),
-				'type' 				=> 'checkbox',
-				'checkboxgroup'		=> '',
-				'default' 			=> 'no',
+				'label'         => __( 'Accept Incoming Linker Parameters', 'woocommerce-google-analytics-integration' ),
+				'description'   => __( 'Enabling this option will allow incoming linker parameters from other websites.', 'woocommerce-google-analytics-integration' ),
+				'type'          => 'checkbox',
+				'checkboxgroup' => '',
+				'default'       => 'no',
 			),
 			'ga_enhanced_ecommerce_tracking_enabled' => array(
 				'title'         => __( 'Enhanced eCommerce', 'woocommerce-google-analytics-integration' ),
@@ -330,8 +330,8 @@ class WC_Google_Analytics extends WC_Integration {
 			'set_domain_name'                     => empty( $this->ga_set_domain_name ) ? 'no' : 'yes',
 			'plugin_version'                      => WC_GOOGLE_ANALYTICS_INTEGRATION_VERSION,
 			'enhanced_ecommerce_tracking_enabled' => $this->ga_enhanced_ecommerce_tracking_enabled,
-			'linker_allow_incoming_enabled'               => $this->ga_linker_allow_incoming_enabled,
-			'linker_cross_domains'					  => empty( $this->ga_linker_cross_domains ) ? 'no' : 'yes',
+			'linker_allow_incoming_enabled'       => $this->ga_linker_allow_incoming_enabled,
+			'linker_cross_domains'                => empty( $this->ga_linker_cross_domains ) ? 'no' : 'yes',
 		);
 
 		// ID prefix, blank, or X for unknown

--- a/includes/class-wc-google-analytics.php
+++ b/includes/class-wc-google-analytics.php
@@ -28,6 +28,8 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @property $ga_enhanced_checkout_process_enabled
  * @property $ga_enhanced_product_detail_view_enabled
  * @property $ga_event_tracking_enabled
+ * @property $ga_linker_cross_domains
+ * @property $ga_linker_allow_incoming_enabled
  */
 class WC_Google_Analytics extends WC_Integration {
 
@@ -120,6 +122,8 @@ class WC_Google_Analytics extends WC_Integration {
 			'ga_enhanced_checkout_process_enabled',
 			'ga_enhanced_product_detail_view_enabled',
 			'ga_event_tracking_enabled',
+			'ga_linker_cross_domains',
+			'ga_linker_allow_incoming_enabled',
 		);
 
 		$constructor = array();
@@ -224,7 +228,20 @@ class WC_Google_Analytics extends WC_Integration {
 				'checkboxgroup'		=> '',
 				'default' 			=> 'yes',
 			),
-
+			'ga_linker_cross_domains' => array(
+				'title'       => __( 'Cross Domain Tracking', 'woocommerce-google-analytics-integration' ),
+				'description' => sprintf(__( 'Add a comma separated list of domains for automatic linking. %sRead more about Cross Domain Measurement%s', 'woocommerce-google-analytics-integration' ), '<a href="https://support.google.com/analytics/answer/7476333" target="_blank">', '</a>'),
+				'type'        => 'text',
+				'placeholder' => 'example.com, example.net',
+				'default'     => '',
+			),
+			'ga_linker_allow_incoming_enabled' => array(
+				'label' 			=> __( 'Accept Incoming Linker Parameters', 'woocommerce-google-analytics-integration' ),
+				'description' 			=> __( 'Enabling this option will allow incoming linker parameters from other websites.', 'woocommerce-google-analytics-integration' ),
+				'type' 				=> 'checkbox',
+				'checkboxgroup'		=> '',
+				'default' 			=> 'no',
+			),
 			'ga_enhanced_ecommerce_tracking_enabled' => array(
 				'title'         => __( 'Enhanced eCommerce', 'woocommerce-google-analytics-integration' ),
 				'label'         => __( 'Enable Enhanced eCommerce ', 'woocommerce-google-analytics-integration' ),
@@ -235,6 +252,7 @@ class WC_Google_Analytics extends WC_Integration {
 				'class'         => 'legacy-setting'
 			),
 
+		
 			// Enhanced eCommerce Sub-Settings
 
 			'ga_enhanced_remove_from_cart_enabled' => array(
@@ -312,6 +330,8 @@ class WC_Google_Analytics extends WC_Integration {
 			'set_domain_name'                     => empty( $this->ga_set_domain_name ) ? 'no' : 'yes',
 			'plugin_version'                      => WC_GOOGLE_ANALYTICS_INTEGRATION_VERSION,
 			'enhanced_ecommerce_tracking_enabled' => $this->ga_enhanced_ecommerce_tracking_enabled,
+			'linker_allow_incoming_enabled'               => $this->ga_linker_allow_incoming_enabled,
+			'linker_cross_domains'					  => empty( $this->ga_linker_cross_domains ) ? 'no' : 'yes',
 		);
 
 		// ID prefix, blank, or X for unknown

--- a/includes/class-wc-google-gtag-js.php
+++ b/includes/class-wc-google-gtag-js.php
@@ -115,6 +115,8 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 		}
 
 		$gtag_id      = self::get( 'ga_id' );
+		$gtag_cross_domains = !empty(self::get( 'ga_linker_cross_domains' )) ? array_map( 'esc_js', explode( ',', self::get( 'ga_linker_cross_domains' ) )) : [];
+		
 		$gtag_snippet = '<script async src="https://www.googletagmanager.com/gtag/js?id=' . esc_js( $gtag_id ) . '"></script>';
 		$gtag_snippet .= "
 		<script>
@@ -127,6 +129,10 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 			'allow_google_signals': " . ( 'yes' === self::get( 'ga_support_display_advertising' ) ? 'true' : 'false' ) . ",
 			'link_attribution': " . ( 'yes' === self::get( 'ga_support_enhanced_link_attribution' ) ? 'true' : 'false' ) . ",
 			'anonymize_ip': " . ( 'yes' === self::get( 'ga_anonymize_enabled' ) ? 'true' : 'false' ) . ",
+			'linker':{
+				'domains': " . wp_json_encode( $gtag_cross_domains ) . ",
+				'allow_incoming': " . ( 'yes' === self::get( 'ga_linker_allow_incoming_enabled' ) ? 'true' : 'false' ) . ",
+			},
 			'custom_map': {
 				'dimension1': 'logged_in'
 			},

--- a/includes/class-wc-google-gtag-js.php
+++ b/includes/class-wc-google-gtag-js.php
@@ -115,7 +115,7 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 		}
 
 		$gtag_id      = self::get( 'ga_id' );
-		$gtag_cross_domains = !empty(self::get( 'ga_linker_cross_domains' )) ? array_map( 'esc_js', explode( ',', self::get( 'ga_linker_cross_domains' ) )) : [];
+		$gtag_cross_domains = ! empty ( self::get( 'ga_linker_cross_domains' ) )  ? array_map( 'esc_js', explode( ',', self::get( 'ga_linker_cross_domains' ) ) ) : [];
 		
 		$gtag_snippet = '<script async src="https://www.googletagmanager.com/gtag/js?id=' . esc_js( $gtag_id ) . '"></script>';
 		$gtag_snippet .= "


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [x] Have you successfully run tests with your changes locally?

### Changes proposed in this Pull Request:

Adds support for Google Analytics cross domain tracking features (automatic link decoration and accepting linker parameters) for both Global Site Tag and Universal Analytics.

### How to test the changes in this Pull Request:

1. There is a new section in the settings with the cross domain options. Adding in a domain such as example.com to the cross domain text field will automatically decorate any outbound links to example.com with a tracking parameter upon click. 
2. To test automatic acceptance of linker parameters the Google Analytics Debugger Chrome extension will show when incoming linker parameters (?_ga) in the query string have been used to set the Google Analytics Client ID.

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changelog entry

> Add - Support for Google Analytics cross domain tracking features.