### PR TITLE
Fix activation error when WooCommerce is missing

### DIFF
--- a/woocommerce-google-analytics-integration.php
+++ b/woocommerce-google-analytics-integration.php
@@ -26,6 +26,9 @@ if ( ! class_exists( 'WC_Google_Analytics_Integration' ) ) {
 	register_activation_hook(
 		__FILE__,
 		function () {
+			if ( ! class_exists( 'WooCommerce' ) ) {
+				return;
+			}
 			WC_Google_Analytics_Integration::get_instance()->maybe_show_ga_pro_notices();
 		}
 	);


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [x] Have you successfully run tests with your changes locally?

### Changes proposed in this Pull Request:

Fixes the fatal error on activation that's caused by `maybe_show_ga_pro_notices()` calling `wc_orders_count()` without checking if WooCommerce is first available.

Closes # .

### How to test the changes in this Pull Request:

1. Activate the plugin for the first time without WooCommerce installed. The fatal error will be gone.

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changelog entry

> Fix activation error when WooCommerce is missing