### PR TITLE
Confirm order key when injecting transaction tracking code

### DIFF
--- a/includes/class-wc-google-analytics.php
+++ b/includes/class-wc-google-analytics.php
@@ -401,6 +401,12 @@ class WC_Google_Analytics extends WC_Integration {
 			return '';
 		}
 
+		// Check order key.
+		$order_key = empty( $_GET['key'] ) ? '' : wc_clean( wp_unslash( $_GET['key'] ) );
+		if ( ! hash_equals( $order->get_order_key(), $order_key ) ) {
+			return '';
+		}
+
 		$load = $this->get_tracking_instance()->load_analytics( $order );
 		$code = $this->get_tracking_instance()->add_transaction( $order );
 

--- a/includes/class-wc-google-analytics.php
+++ b/includes/class-wc-google-analytics.php
@@ -403,7 +403,7 @@ class WC_Google_Analytics extends WC_Integration {
 
 		// Check order key.
 		$order_key = empty( $_GET['key'] ) ? '' : wc_clean( wp_unslash( $_GET['key'] ) );
-		if ( ! hash_equals( $order->get_order_key(), $order_key ) ) {
+		if ( ! $order->key_is_valid( $order_key ) ) {
 			return '';
 		}
 

--- a/includes/class-wc-google-analytics.php
+++ b/includes/class-wc-google-analytics.php
@@ -402,6 +402,7 @@ class WC_Google_Analytics extends WC_Integration {
 		}
 
 		// Check order key.
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		$order_key = empty( $_GET['key'] ) ? '' : wc_clean( wp_unslash( $_GET['key'] ) );
 		if ( ! $order->key_is_valid( $order_key ) ) {
 			return '';
@@ -413,10 +414,10 @@ class WC_Google_Analytics extends WC_Integration {
 		// Mark the order as tracked.
 		update_post_meta( $order_id, '_ga_tracked', 1 );
 
-		return "
+		return '
 		<!-- WooCommerce Google Analytics Integration -->
-		" . $this->get_tracking_instance()->header() . "
-		" . $load . "
+		' . $this->get_tracking_instance()->header() . '
+		' . $load . "
 		<script type='text/javascript'>$code</script>
 		<!-- /WooCommerce Google Analytics Integration -->
 		";


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### Changes proposed in this Pull Request:

This pull request ensures that a valid order key is present on the "Order Received" page before inserting the GA tracking code.

### How to test the changes in this Pull Request:

1. Enable a payment method in WooCommerce - either credit card processing, or Cash on Delivery.
1. Enable WooCommerce Google Analytics Integration and configure the settings:
    - Add a **Google Analytics Tracking ID** like `G-12ABCDEF3G`
    - Enable **Use Global Site Tag**
    - Enable **Purchase Transactions**
2. Complete an order in the store (NOT AS ADMIN!).

#### Purchase tracking code correctly inserted
4. On the Order Received page (`checkout/order-received/xxx/?key=…`) use the element inspector to confirm that the tracking code is inserted: 
    ```
    gtag( 'event', 'purchase', {
            'transaction_id': '…
    ```
    - Using "View Source" will not work as the page is refreshed and the tracking code no longer inserted.

#### Purchase tracking code correctly not inserted repeatedly
5. Refresh the page, and confirm that the tracking code is no longer visible.
    - WCGA sets the `_ga_tracked` postmeta value for the order to ensure that the transaction is only tracked once.

#### Purchase tracking code correctly inserted if key correct and `_ga_tracked` not set
6. Delete the `_ga_tracked` postmeta value for the order
    ``DELETE FROM `wp_postmeta` WHERE `meta_key`='_ga_tracked' AND post_id = xxx``
7. Refresh the Order Received page and confirm that the tracking code is present again.

#### Purchase tracking code correctly not inserted without key
8. Delete the `key=…` parameter from the query string and refresh the Order Received page.
9. Confirm that the transaction tracking code isn't inserted (in this instance, because of the `_ga_tracked` postmeta value).
10. Delete the `_ga_tracked` postmeta value for the order again
    ``DELETE FROM `wp_postmeta` WHERE `meta_key`='_ga_tracked' AND post_id = xxx``
11. Confirm that the transaction tracking code isn't inserted again (in this instance, because the 
 `key` for the order isn't provided).


### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?


### Changelog entry

> Fix - Confirm order key before displaying transaction tracking code.
