### PR TITLE
Fix `composer archive` compatibility issue of composer v2.2+

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -23,3 +23,5 @@ phpunit.xml export-ignore
 docs export-ignore
 wordpress_org_assets export-ignore
 assets/css/*.scss export-ignore
+node_modules export-ignore
+languages export-ignore


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [ ] (N/A) Have you written new tests for your changes, as applicable?
* [ ] (N/A) Have you successfully run tests with your changes locally?

### Changes proposed in this Pull Request:

Since [composer version 2.2.0](https://github.com/composer/composer/releases/tag/2.2.0), the `.gitignore` file is no longer to be taken into account as ignore patterns when running `composer archive`, this PR adds the missing pattern to ignored list in **.gitattributes** to fix the compatibility issue.

- `node_modules`
- `languages`

### How to test the changes in this Pull Request:

1. Follow the instructions in README to build this extension locally with composer version below **2.2.0**.
2. `composer self-update` to update to the latest version.
3. Build this extension locally again with composer version **2.2+**.
4. Compare the contents of two zip files to see if they are the same.
5. `composer self-update --rollback` if want to roll back to your former version of composer.

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changelog entry
