### PR TITLE
Fix/activation error when WooCommerce is missing

### DIFF
--- a/woocommerce-google-analytics-integration.php
+++ b/woocommerce-google-analytics-integration.php
@@ -26,7 +26,9 @@ if ( ! class_exists( 'WC_Google_Analytics_Integration' ) ) {
 	register_activation_hook(
 		__FILE__,
 		function () {
-			WC_Google_Analytics_Integration::get_instance()->maybe_show_ga_pro_notices();
+			if ( class_exists( 'WooCommerce' ) ) {
+				WC_Google_Analytics_Integration::get_instance()->maybe_show_ga_pro_notices();
+			}
 		}
 	);
 
@@ -43,6 +45,7 @@ if ( ! class_exists( 'WC_Google_Analytics_Integration' ) ) {
 		 */
 		public function __construct() {
 			if ( ! class_exists( 'WooCommerce' ) ) {
+				add_action( 'admin_notices', [ $this, 'woocommerce_missing_notice' ] );
 				return;
 			}
 

--- a/woocommerce-google-analytics-integration.php
+++ b/woocommerce-google-analytics-integration.php
@@ -26,9 +26,7 @@ if ( ! class_exists( 'WC_Google_Analytics_Integration' ) ) {
 	register_activation_hook(
 		__FILE__,
 		function () {
-			if ( class_exists( 'WooCommerce' ) ) {
-				WC_Google_Analytics_Integration::get_instance()->maybe_show_ga_pro_notices();
-			}
+			WC_Google_Analytics_Integration::get_instance()->maybe_show_ga_pro_notices();
 		}
 	);
 
@@ -140,7 +138,7 @@ if ( ! class_exists( 'WC_Google_Analytics_Integration' ) ) {
 		 */
 		public function maybe_show_ga_pro_notices() {
 			// Notice was already shown
-			if ( get_option( 'woocommerce_google_analytics_pro_notice_shown', false ) ) {
+			if ( ! class_exists( 'WooCommerce' ) || get_option( 'woocommerce_google_analytics_pro_notice_shown', false ) ) {
 				return;
 			}
 


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

In this PR I am proposing to fix the fatal error that was caused when the following situations were happening:

-  the method WC_Google_Analytics_Integration::maybe_show_ga_pro_notices was called.
-  WC was not installed. 
-  the option `woocommerce_google_analytics_pro_notice_shown` was false.


In addition, this PR is showing a warning if WooCommerce is not installed.

Closes # .



### How to test the changes in this Pull Request:

1. Add the following line `update_option( 'woocommerce_google_analytics_pro_notice_shown', false );` on top of woocommerce-google-analytics-integration.php
2. Disabled WC plugin.
3. Disabled WC Google Analytics plugin.
4. Enable WC Google Analytics plugin.
5. Not fatal error should be shown and you should see a warning saying "WooCommerce Google Analytics depends on the last version of WooCommerce to work!" .

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Activation error when WC was disabled.
