### PR TITLE
Don't trigger WooCommerce translation server after release

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "npm": ">=5.5.1"
   },
   "config": {
-    "wp_org_slug": "woocommerce-google-analytics-integration",
-    "translate": true
+    "wp_org_slug": "woocommerce-google-analytics-integration"
   }
 }


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [ ] (N/A) Have you written new tests for your changes, as applicable?
* [ ] (N/A) Have you successfully run tests with your changes locally?

### Changes proposed in this Pull Request:

Remove Woo's translation configuration since the .org plugin shouldn't trigger translation in this way.

### How to test the changes in this Pull Request:

N/A

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changelog entry

>
