### PR TITLE
Include languages folder and pot file in the release

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -24,4 +24,3 @@ docs export-ignore
 wordpress_org_assets export-ignore
 assets/css/*.scss export-ignore
 node_modules export-ignore
-languages export-ignore

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,8 @@
     "license": "GPL-2.0+",
     "archive": {
         "exclude": [
-            "!/assets"
+            "!/assets",
+            "!/languages"
         ]
     }
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Fix the problem introduced by #207

The `languages` folder should be always included in the release zip file.

Since `composer` versions 1.x, 2.1.x and 2.2.x have different processing of whether or not to use **.gitignore** as one of ignore patterns source when packaging. This PR makes all these versions include the `languages` folder in the release zip file.

### Detailed test instructions:

Simple way to update composer to a specific version is to use `composer self-update <version>`

1. `npm ci`
1. `composer self-update 1.10.25`, and `npm run build`
1. Check the created zip file and confirm it contains the languages folder and the .pot file
1. `composer self-update 2.1.9`, and `npm run build`
1. Check the created zip file and confirm it contains the languages folder and the .pot file
1. `composer self-update 2.2.5`, and `npm run build`
1. Check the created zip file and confirm it contains the languages folder and the .pot file

### Changelog entry

> Fix - Include languages folder and POT file in the release.
