### PR TITLE
fixed domains null issue

### DIFF
--- a/includes/class-wc-google-gtag-js.php
+++ b/includes/class-wc-google-gtag-js.php
@@ -116,6 +116,10 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 
 		$gtag_id            = self::get( 'ga_id' );
 		$gtag_cross_domains = ! empty( self::get( 'ga_linker_cross_domains' ) ) ? array_map( 'esc_js', explode( ',', self::get( 'ga_linker_cross_domains' ) ) ) : array();
+		
+		if ( empty( $gtag_cross_domains ) ) {
+			$gtag_cross_domains[0] = site_url();
+		}
 
 		$gtag_snippet = '<script async src="https://www.googletagmanager.com/gtag/js?id=' . esc_js( $gtag_id ) . '"></script>';
 		$gtag_snippet .= "


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes # .

_Replace this with a good description of your changes & reasoning._

### Checks:
<!-- Mark completed items with an [x] -->
* [X] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [ ] N/A Have you written new tests for your changes, as applicable?
* [ ] N/A Have you successfully run tests with your changes locally?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Youtube video not playing if used Magnific Popup js library to a popup youtube video
if `linker.domains` inducted by a null value (line number 135 )
