### PR TITLE
Update tested to WordPress 6.0 and WooCommerce 6.5

### DIFF
--- a/woocommerce-google-analytics-integration.php
+++ b/woocommerce-google-analytics-integration.php
@@ -7,8 +7,8 @@
  * Author URI: https://woocommerce.com
  * Version: 1.5.8
  * WC requires at least: 3.2
- * WC tested up to: 6.1
- * Tested up to: 5.9
+ * WC tested up to: 6.5
+ * Tested up to: 6.0
  * License: GPLv2 or later
  * Text Domain: woocommerce-google-analytics-integration
  * Domain Path: languages/


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Bumping the WooCommerce and WordPress tested up to tags after testing with **WooCommerce 6.5.0-rc.1** and **WordPress 6.0.0-beta.1**.


### Changelog entry

> Tweak - WC 6.5 compatibility.
> Tweak - WordPress 6.0 compatibility.
