### PR TITLE
Add PHPCS diff check to the local development and GitHub Actions

### DIFF
--- a/.github/workflows/php-coding-standards-diff.yml
+++ b/.github/workflows/php-coding-standards-diff.yml
@@ -1,0 +1,21 @@
+name: PHP Coding Standards - Diff
+
+on:
+  pull_request:
+    paths:
+      - "**.php"
+      - .github/workflows/php-coding-standards-diff.yml
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  CodingStandardsDiff:
+    name: PHP coding standards - diff
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run PHPCS to changed lines of code
+        uses: woocommerce/grow/phpcs-diff@actions-v1
+        with:
+          php-version: 7.4

--- a/.github/workflows/php-coding-standards-diff.yml
+++ b/.github/workflows/php-coding-standards-diff.yml
@@ -16,7 +16,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run PHPCS to changed lines of code
-        # uses: woocommerce/grow/phpcs-diff@actions-v1
-        uses: woocommerce/grow/phpcs-diff@actions-v1-pre
+        uses: woocommerce/grow/phpcs-diff@actions-v1
         with:
           php-version: 7.4

--- a/.github/workflows/php-coding-standards-diff.yml
+++ b/.github/workflows/php-coding-standards-diff.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run PHPCS to changed lines of code
-        uses: woocommerce/grow/phpcs-diff@actions-v1
+        # uses: woocommerce/grow/phpcs-diff@actions-v1
+        uses: woocommerce/grow/phpcs-diff@actions-v1-pre
         with:
           php-version: 7.4

--- a/bin/phpcs-diff.sh
+++ b/bin/phpcs-diff.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+GIT_LOG=$(git log -100 --graph --pretty=format:'%H %D')
+
+# Find the nearest commit which may be the parent of HEAD.
+# 1. Branch off from the default or another branch without any new commit.
+# 2. Branch off from the default or another branch and has new commits.
+LINE=1
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+COMMITS=$(echo "$GIT_LOG" | grep -E '^\* (  \w{40}|\w{40} .+, )')
+if echo "$COMMITS" | grep -q "origin/${CURRENT_BRANCH}"; then
+	LINE=2
+fi
+COMMIT=$(echo "$COMMITS" | sed -n "${LINE}p")
+SHA=$(echo "$COMMIT" | awk '{print $2}')
+
+echo "$COMMIT" | sed 's/* */Diff target: /'
+vendor/bin/diffFilter --phpcsStrict <(git diff $SHA) <(vendor/bin/phpcs ./* -q --report=json) 0

--- a/composer.json
+++ b/composer.json
@@ -8,5 +8,10 @@
         "exclude": [
             "!/assets"
         ]
+    },
+    "require-dev": {
+        "dealerdirect/phpcodesniffer-composer-installer": "^v0.7",
+        "wp-coding-standards/wpcs": "^2.3",
+        "exussum12/coverage-checker": "^1.0"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,307 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "e93271c1a3ad85f3c745c20de2bdc8e8",
+    "packages": [],
+    "packages-dev": [
+        {
+            "name": "dealerdirect/phpcodesniffer-composer-installer",
+            "version": "v0.7.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer.git",
+                "reference": "1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db",
+                "reference": "1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0 || ^2.0",
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2.0 || ^3.1.0 || ^4.0"
+            },
+            "require-dev": {
+                "composer/composer": "*",
+                "php-parallel-lint/php-parallel-lint": "^1.3.1",
+                "phpcompatibility/php-compatibility": "^9.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Franck Nijhof",
+                    "email": "franck.nijhof@dealerdirect.com",
+                    "homepage": "http://www.frenck.nl",
+                    "role": "Developer / IT Manager"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
+            "homepage": "http://www.dealerdirect.com",
+            "keywords": [
+                "PHPCodeSniffer",
+                "PHP_CodeSniffer",
+                "code quality",
+                "codesniffer",
+                "composer",
+                "installer",
+                "phpcbf",
+                "phpcs",
+                "plugin",
+                "qa",
+                "quality",
+                "standard",
+                "standards",
+                "style guide",
+                "stylecheck",
+                "tests"
+            ],
+            "support": {
+                "issues": "https://github.com/dealerdirect/phpcodesniffer-composer-installer/issues",
+                "source": "https://github.com/dealerdirect/phpcodesniffer-composer-installer"
+            },
+            "time": "2022-02-04T12:51:07+00:00"
+        },
+        {
+            "name": "exussum12/coverage-checker",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/exussum12/coverageChecker.git",
+                "reference": "544984601cf563003b36c8ed9a5a61a40daafa93"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/exussum12/coverageChecker/zipball/544984601cf563003b36c8ed9a5a61a40daafa93",
+                "reference": "544984601cf563003b36c8ed9a5a61a40daafa93",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-xmlreader": "*",
+                "nikic/php-parser": "^3.1||^4.0",
+                "php": ">=7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.5 || ^7.0 || ^8.0 || ^9.0"
+            },
+            "bin": [
+                "bin/diffFilter"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "exussum12\\CoverageChecker\\": "src/",
+                    "exussum12\\CoverageChecker\\tests\\": "tests/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Scott Dutton",
+                    "email": "scott@exussum.co.uk"
+                }
+            ],
+            "description": "Allows checking the code coverage of a single pull request",
+            "support": {
+                "issues": "https://github.com/exussum12/coverageChecker/issues",
+                "source": "https://github.com/exussum12/coverageChecker/tree/1.0.2"
+            },
+            "time": "2022-01-19T14:42:51+00:00"
+        },
+        {
+            "name": "nikic/php-parser",
+            "version": "v4.14.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "34bea19b6e03d8153165d8f30bba4c3be86184c1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/34bea19b6e03d8153165d8f30bba4c3be86184c1",
+                "reference": "34bea19b6e03d8153165d8f30bba4c3be86184c1",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": ">=7.0"
+            },
+            "require-dev": {
+                "ircmaxell/php-yacc": "^0.0.7",
+                "phpunit/phpunit": "^6.5 || ^7.0 || ^8.0 || ^9.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.9-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/nikic/PHP-Parser/issues",
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.14.0"
+            },
+            "time": "2022-05-31T20:59:12+00:00"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "1359e176e9307e906dc3d890bcc9603ff6d90619"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/1359e176e9307e906dc3d890bcc9603ff6d90619",
+                "reference": "1359e176e9307e906dc3d890bcc9603ff6d90619",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "bin": [
+                "bin/phpcs",
+                "bin/phpcbf"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "lead"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
+            "keywords": [
+                "phpcs",
+                "standards"
+            ],
+            "support": {
+                "issues": "https://github.com/squizlabs/PHP_CodeSniffer/issues",
+                "source": "https://github.com/squizlabs/PHP_CodeSniffer",
+                "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
+            },
+            "time": "2022-06-18T07:21:10+00:00"
+        },
+        {
+            "name": "wp-coding-standards/wpcs",
+            "version": "2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
+                "reference": "7da1894633f168fe244afc6de00d141f27517b62"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/7da1894633f168fe244afc6de00d141f27517b62",
+                "reference": "7da1894633f168fe244afc6de00d141f27517b62",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4",
+                "squizlabs/php_codesniffer": "^3.3.1"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || ^0.6",
+                "phpcompatibility/php-compatibility": "^9.0",
+                "phpcsstandards/phpcsdevtools": "^1.0",
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.6 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/WordPress/WordPress-Coding-Standards/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer rules (sniffs) to enforce WordPress coding conventions",
+            "keywords": [
+                "phpcs",
+                "standards",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/WordPress/WordPress-Coding-Standards/issues",
+                "source": "https://github.com/WordPress/WordPress-Coding-Standards",
+                "wiki": "https://github.com/WordPress/WordPress-Coding-Standards/wiki"
+            },
+            "time": "2020-05-13T23:57:56+00:00"
+        }
+    ],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": [],
+    "plugin-api-version": "2.1.0"
+}

--- a/package.json
+++ b/package.json
@@ -26,7 +26,9 @@
     "postarchive": "rm -rf $npm_package_name && unzip $npm_package_name.zip -d $npm_package_name && rm $npm_package_name.zip && zip -r $npm_package_name.zip $npm_package_name && rm -rf $npm_package_name",
     "preuglify": "rm -f $npm_package_assets_js_min",
     "uglify": "for f in $npm_package_assets_js_js; do file=${f%.js}; node_modules/.bin/uglifyjs $f -c -m > $file.min.js; done",
-    "makepot": "wpi18n makepot --domain-path languages --pot-file $npm_package_name.pot --type plugin --main-file $npm_package_name.php --exclude node_modules,tests,docs"
+    "makepot": "wpi18n makepot --domain-path languages --pot-file $npm_package_name.pot --type plugin --main-file $npm_package_name.php --exclude node_modules,tests,docs",
+    "lint:php": "vendor/bin/phpcs",
+    "lint:php:diff": "./bin/phpcs-diff.sh"
   },
   "engines": {
     "node": ">=8.9.3",

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -31,9 +31,6 @@
 		<exclude name="Squiz.Commenting.FunctionCommentThrowTag.WrongNumber"/>
 	</rule>
 
-	<!-- Disallow Yoda conditions. -->
-	<rule ref="Generic.ControlStructures.DisallowYodaConditions"/>
-
 	<!-- Include some other sniffs we want to enforce. -->
 	<rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
 	<rule ref="Generic.VersionControl.GitMergeConflict"/>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,103 @@
+<?xml version="1.0"?>
+<ruleset name="WordPress Coding Standards for Plugins">
+	<description>Generally-applicable sniffs for WordPress plugins</description>
+
+	<!-- Set the minimum WP version -->
+	<config name="minimum_supported_wp_version" value="5.8"/>
+
+	<rule ref="WordPress">
+		<!-- We don't require conforming to WP file naming -->
+		<exclude name="WordPress.Files.FileName"/>
+
+		<!-- These comments are unnecessary -->
+		<exclude name="Generic.Commenting.DocComment.MissingShort"/>
+		<exclude name="Squiz.Commenting.FileComment"/>
+		<exclude name="Squiz.Commenting.FunctionComment.MissingParamComment"/>
+		<exclude name="Squiz.Commenting.FunctionComment.ParamCommentFullStop"/>
+		<exclude name="Squiz.Commenting.InlineComment.InvalidEndChar"/>
+		<exclude name="Squiz.Commenting.LongConditionClosingComment"/>
+
+		<!-- No thanks -->
+		<exclude name="WordPress.PHP.DisallowShortTernary"/>
+		<exclude name="WordPress.PHP.YodaConditions.NotYoda"/>
+
+		<!-- These overrides are useful for code hinting -->
+		<exclude name="Generic.CodeAnalysis.UselessOverridingMethod.Found"/>
+
+		<!-- We like short array syntax -->
+		<exclude name="Generic.Arrays.DisallowShortArraySyntax"/>
+
+		<!-- Multiple throws tags are fine -->
+		<exclude name="Squiz.Commenting.FunctionCommentThrowTag.WrongNumber"/>
+	</rule>
+
+	<!-- Disallow Yoda conditions. -->
+	<rule ref="Generic.ControlStructures.DisallowYodaConditions"/>
+
+	<!-- Include some other sniffs we want to enforce. -->
+	<rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
+	<rule ref="Generic.VersionControl.GitMergeConflict"/>
+	<rule ref="Generic.WhiteSpace.SpreadOperatorSpacingAfter"/>
+	<rule ref="PSR12.Classes.AnonClassDeclaration"/>
+	<rule ref="PSR12.Classes.ClassInstantiation"/>
+	<rule ref="PSR12.Files.ImportStatement"/>
+	<rule ref="PSR12.Functions.NullableTypeDeclaration"/>
+	<rule ref="PSR12.Functions.ReturnTypeDeclaration"/>
+	<rule ref="PSR12.Properties.ConstantVisibility"/>
+	<rule ref="PSR12.Traits.UseDeclaration"/>
+	<rule ref="Squiz.Classes">
+		<exclude name="Squiz.Classes.ClassDeclaration.OpenBraceNewLine"/>
+		<exclude name="Squiz.Classes.ClassDeclaration.CloseBraceSameLine"/>
+	</rule>
+	<rule ref="Squiz.WhiteSpace.FunctionOpeningBraceSpace"/>
+
+	<!-- Set the appropriate text domain. -->
+	<rule ref="WordPress.WP.I18n">
+		<properties>
+			<property name="text_domain" type="array" value="woocommerce-google-analytics-integration"/>
+		</properties>
+	</rule>
+
+	<!-- This rule flags space indents in HTML tags, which are generally OK. -->
+	<rule ref="WordPress.WhiteSpace.PrecisionAlignment">
+		<exclude name="WordPress.WhiteSpace.PrecisionAlignment.Found"/>
+	</rule>
+
+	<!-- We allow the use of / in hooks -->
+	<rule ref="WordPress.NamingConventions.ValidHookName">
+		<properties>
+			<property name="additionalWordDelimiters" value="/"/>
+		</properties>
+	</rule>
+
+	<!-- We don't use these functions for purposes of obfuscation -->
+	<rule ref="WordPress.PHP.DiscouragedPHPFunctions">
+		<properties>
+			<property name="exclude" type="array">
+				<element value="obfuscation"/>
+			</property>
+		</properties>
+	</rule>
+
+	<!-- We'd rather use native functions -->
+	<rule ref="WordPress.WP.AlternativeFunctions">
+		<properties>
+			<property name="exclude" type="array">
+				<element value="json_encode"/>
+				<element value="rand"/>
+			</property>
+		</properties>
+	</rule>
+
+	<!-- Check PHP files -->
+	<arg name="extensions" value="php"/>
+	<file>.</file>
+
+	<!-- Show progress and sniff codes in all reports -->
+	<arg value="ps"/>
+
+	<!-- Exclusion patterns -->
+	<exclude-pattern>*/node_modules/*</exclude-pattern>
+	<exclude-pattern>*/vendor/*</exclude-pattern>
+	<exclude-pattern>./assets/*</exclude-pattern>
+</ruleset>

--- a/woocommerce-google-analytics-integration.php
+++ b/woocommerce-google-analytics-integration.php
@@ -83,7 +83,7 @@ if ( ! class_exists( 'WC_Google_Analytics_Integration' ) ) {
 			);
 
 			$plugin_links = array(
-				'<a href="' . esc_url( $settings_url ) . '">' . __( 'Settings', 'woocommerce-google-analytics-integration' ) . '</a>',
+				'<a href="' . esc_url( $settings_url ) . '">' . __( 'Settings', 'google-analytics-integration' ) . '</a>',
 				'<a href="https://wordpress.org/support/plugin/woocommerce-google-analytics-integration">' . __( 'Support', 'woocommerce-google-analytics-integration' ) . '</a>',
 			);
 
@@ -97,7 +97,7 @@ if ( ! class_exists( 'WC_Google_Analytics_Integration' ) ) {
 		 */
 		public static function get_instance() {
 			// If the single instance hasn't been set, set it now.
-			if ( null == self::$instance ) {
+			if ( null === self::$instance ) {
 				self::$instance = new self;
 			}
 

--- a/woocommerce-google-analytics-integration.php
+++ b/woocommerce-google-analytics-integration.php
@@ -83,7 +83,7 @@ if ( ! class_exists( 'WC_Google_Analytics_Integration' ) ) {
 			);
 
 			$plugin_links = array(
-				'<a href="' . esc_url( $settings_url ) . '">' . __( 'Settings', 'google-analytics-integration' ) . '</a>',
+				'<a href="' . esc_url( $settings_url ) . '">' . __( 'Settings', 'woocommerce-google-analytics-integration' ) . '</a>',
 				'<a href="https://wordpress.org/support/plugin/woocommerce-google-analytics-integration">' . __( 'Support', 'woocommerce-google-analytics-integration' ) . '</a>',
 			);
 
@@ -97,7 +97,7 @@ if ( ! class_exists( 'WC_Google_Analytics_Integration' ) ) {
 		 */
 		public static function get_instance() {
 			// If the single instance hasn't been set, set it now.
-			if ( null === self::$instance ) {
+			if ( null == self::$instance ) {
 				self::$instance = new self;
 			}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

It's a part of the progressively adding PHPCS task in this project - pb0Spc-2DL-p2#comment-5889

- Add PHPCS related packages to `require-dev` of composer config.
   - `dealerdirect/phpcodesniffer-composer-installer`
   - `wp-coding-standards/wpcs`
   - `exussum12/coverage-checker`
- Add the PHPCS config.
- Add a script for running phpcs-diff in local env.
- Add a new GitHub workflow to run PHPCS diff in GitHub Actions.

### Checks:

* [x] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Screenshots:

![image](https://user-images.githubusercontent.com/17420811/177757165-20003e4c-36fd-4211-8661-eb5d759f9a7c.png)

### Detailed test instructions:

1. `composer install`.
2. `npm run lint:php` to check if the PHPCS can be run locally.
3. Locally make some changes and run `npm run lint:php:diff` to see if the script can output the errors from the diff of working files.
4. Go to the [ee32c4b](https://github.com/woocommerce/woocommerce-google-analytics-integration/pull/218/commits/ee32c4bf8232a64bf8e6f8502db0ea98093cc0f1) commit and [the failed check](https://github.com/woocommerce/woocommerce-google-analytics-integration/runs/7231876958?check_suite_focus=true#step:2:290) for viewing the error annotations and PHPCS diff action.

### Changelog entry
