### PR TITLE
Custom Order Table Compatibility

### DIFF
--- a/includes/class-wc-abstract-google-analytics-js.php
+++ b/includes/class-wc-abstract-google-analytics-js.php
@@ -160,16 +160,16 @@ abstract class WC_Abstract_Google_Analytics_JS {
 	 * Returns a 'category' JSON line based on $product
 	 *
 	 * @param  WC_Product $_product  Product to pull info for
-	 * @return string               Line of JSON
+	 * @return string                Line of JSON
 	 */
 	protected static function product_get_category_line( $_product ) {
-		$out            = array();
-		$variation_data = version_compare( WC_VERSION, '3.0', '<' ) ? $_product->variation_data : ( $_product->is_type( 'variation' ) ? wc_get_product_variation_attributes( $_product->get_id() ) : '' );
+		$out            = [];
+		$variation_data = $_product->is_type( 'variation' ) ? wc_get_product_variation_attributes( $_product->get_id() ) : false;
 		$categories     = get_the_terms( $_product->get_id(), 'product_cat' );
 
 		if ( is_array( $variation_data ) && ! empty( $variation_data ) ) {
-			$parent_product = wc_get_product( version_compare( WC_VERSION, '3.0', '<' ) ? $_product->parent->id : $_product->get_parent_id() );
-			$categories = get_the_terms( $parent_product->get_id(), 'product_cat' );
+			$parent_product = wc_get_product( $_product->get_parent_id() );
+			$categories     = get_the_terms( $parent_product->get_id(), 'product_cat' );
 		}
 
 		if ( $categories ) {
@@ -178,18 +178,18 @@ abstract class WC_Abstract_Google_Analytics_JS {
 			}
 		}
 
-		return "'" . esc_js( join( "/", $out ) ) . "',";
+		return "'" . esc_js( join( '/', $out ) ) . "',";
 	}
 
 	/**
 	 * Returns a 'variant' JSON line based on $product
 	 *
 	 * @param  WC_Product $_product  Product to pull info for
-	 * @return string               Line of JSON
+	 * @return string                Line of JSON
 	 */
 	protected static function product_get_variant_line( $_product ) {
 		$out            = '';
-		$variation_data = version_compare( WC_VERSION, '3.0', '<' ) ? $_product->variation_data : ( $_product->is_type( 'variation' ) ? wc_get_product_variation_attributes( $_product->get_id() ) : '' );
+		$variation_data = $_product->is_type( 'variation' ) ? wc_get_product_variation_attributes( $_product->get_id() ) : false;
 
 		if ( is_array( $variation_data ) && ! empty( $variation_data ) ) {
 			$out = "'" . esc_js( wc_get_formatted_variation( $variation_data, true ) ) . "',";

--- a/includes/class-wc-google-analytics.php
+++ b/includes/class-wc-google-analytics.php
@@ -381,7 +381,8 @@ class WC_Google_Analytics extends WC_Integration {
 		// Check if is order received page and stop when the products and not tracked
 		if ( is_order_received_page() && 'yes' === $this->ga_ecommerce_tracking_enabled ) {
 			$order_id = isset( $wp->query_vars['order-received'] ) ? $wp->query_vars['order-received'] : 0;
-			if ( 0 < $order_id && 1 != get_post_meta( $order_id, '_ga_tracked', true ) ) {
+			$order    = wc_get_order( $order_id );
+			if ( $order && ! (bool) $order->get_meta( '_ga_tracked' ) ) {
 				$display_ecommerce_tracking = true;
 				echo $this->get_ecommerce_tracking_code( $order_id );
 			}
@@ -433,7 +434,8 @@ class WC_Google_Analytics extends WC_Integration {
 		$code = $this->get_tracking_instance()->add_transaction( $order );
 
 		// Mark the order as tracked.
-		update_post_meta( $order_id, '_ga_tracked', 1 );
+		$order->update_meta_data( '_ga_tracked', 1 );
+		$order->save();
 
 		return '
 		<!-- WooCommerce Google Analytics Integration -->

--- a/includes/class-wc-google-gtag-js.php
+++ b/includes/class-wc-google-gtag-js.php
@@ -164,14 +164,14 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 		}
 		$items .= "]";
 
-		$code  = "" . self::tracker_var() . "( 'event', 'purchase', {
+		$code = self::tracker_var() . "( 'event', 'purchase', {
 			'transaction_id': '" . esc_js( $order->get_order_number() ) . "',
 			'affiliation': '" . esc_js( get_bloginfo( 'name' ) ) . "',
 			'value': '" . esc_js( $order->get_total() ) . "',
 			'tax': '" . esc_js( $order->get_total_tax() ) . "',
 			'shipping': '" . esc_js( $order->get_total_shipping() ) . "',
-			'currency': '" . esc_js( version_compare( WC_VERSION, '3.0', '<' ) ? $order->get_order_currency() : $order->get_currency() ) . "',  // Currency,
-			'items': " . $items . ",
+			'currency': '" . esc_js( $order->get_currency() ) . "',
+			'items': {$items},
 		} );";
 
 		return $code;
@@ -184,7 +184,7 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 	 * @param WC_Order_Item $item    The item to add to a transaction/order
 	 */
 	protected function add_item( $order, $item ) {
-		$_product = version_compare( WC_VERSION, '3.0', '<' ) ? $order->get_product_from_item( $item ) : $item->get_product();
+		$_product = $item->get_product();
 		$variant  = self::product_get_variant_line( $_product );
 
 		$code = "{";

--- a/includes/class-wc-google-gtag-js.php
+++ b/includes/class-wc-google-gtag-js.php
@@ -180,14 +180,14 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 	/**
 	 * Add Item
 	 *
-	 * @param WC_Order $order WC_Order Object
-	 * @param WC_Order_Item $item    The item to add to a transaction/order
+	 * @param WC_Order      $order WC_Order Object
+	 * @param WC_Order_Item $item  The item to add to a transaction/order
 	 */
 	protected function add_item( $order, $item ) {
 		$_product = $item->get_product();
 		$variant  = self::product_get_variant_line( $_product );
 
-		$code = "{";
+		$code  = '{';
 		$code .= "'id': '" . esc_js( $_product->get_sku() ? $_product->get_sku() : $_product->get_id() ) . "',";
 		$code .= "'name': '" . esc_js( $item['name'] ) . "',";
 		$code .= "'category': " . self::product_get_category_line( $_product );
@@ -198,7 +198,7 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 
 		$code .= "'price': '" . esc_js( $order->get_item_total( $item ) ) . "',";
 		$code .= "'quantity': '" . esc_js( $item['qty'] ) . "'";
-		$code .= "},";
+		$code .= '},';
 
 		return $code;
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR add compatibility for the custom order tables by ensuring we use the CRUD functions when handling orders.

Closes #221 

### Detailed test instructions:
1. Setup tracking with a GA4 account. 
2. Purchase a product and complete the order (as a non admin user).
3. On the order received page confirm that we see a request to https://region1.google-analytics.com/g/collect with `en=purchase`
4. Confirm that the source of the order received page contains a snippet like the following:
5. Refresh the order received page and confirm the purchase event is not sent a second time, postmeta `_ga_tracked` should be set to 1.
```
gtag( 'event', 'purchase', {
	'transaction_id': '98',
	'affiliation': 'domain.test',
	'value': '170.00',
	'tax': '0',
	'shipping': '10',
	'currency': 'EUR',  // Currency,
	'items': [{'id': '19','name': 'Product Name','category': 'Main','price': '80','quantity': '2'},],
} );
```
### Additional details
WC < 3.0 compatibility code was only removed for the GA4 (GTag) implementation. There is already an issue for handling code for Universal Analytics, #215 

### Changelog entry
- Fix - Custom Order table compatibility.
