### PR TITLE
Add `release.yml`, update PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -40,7 +40,7 @@ Each line should start with change type prefix`(Fix|Add|…) - `, for example:
 > Dev - Developer-facing only change.
 > Doc - Updated customer or developer facing documentation
 
-If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
+If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.
 
 Add the `changelog: none` label if no changelog entry is needed.
 -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -31,14 +31,18 @@ _Replace this with a good description of your changes & reasoning._
 <!--
 Optional.
 Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
-Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
-> Fix - I took care of something that wasn't working.
-> Add - I added something new that's pretty cool.
-> Tweak - I made a small change.
-> Update - I made big changes to something that wasn't broken.
+Each line should start with change type prefix`(Fix|Add|…) - `, for example:
+> Break - A change breaking previous API or functionality.
+> Add - A new feature, function or functionality was added.
+> Update - Big changes to something that wasn't broken.
+> Fix - Took care of something that wasn't working.
+> Tweak - Small change, that isn't actually very important.
+> Dev - Developer-facing only change.
+> Doc - Updated customer or developer facing documentation
 
-Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
 If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
+
+Add the `changelog: none` label if no changelog entry is needed.
 -->
 ### Changelog entry
 

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,45 @@
+changelog:
+  exclude:
+    labels:
+      - "changelog: none"
+    authors:
+      - dependabot
+      - github-actions
+
+  categories:
+    # Major level
+    - title: "[Breaking] Breaking Changes 🚨"
+      labels:
+        - "changelog: breaking"
+
+    # Minor level
+    - title: "[Add] New Features 🎉"
+      labels:
+        - "changelog: add"
+        - "type: enhancement"
+
+    - title: "[Update] Updated ✨"
+      labels:
+        - "changelog: update"
+
+    # Patch level
+    - title: "[Fix] Fixes 🛠"
+      labels:
+        - "changelog: fix"
+        - "type: bug"
+
+    - title: "[Tweak] Tweaked 🔧"
+      labels:
+        - "changelog: tweak"
+
+    - title: "[Dev] Developer-facing changes 🧑‍💻"
+      labels:
+        - "changelog: dev"
+
+    - title: "[Doc] Documentation 📚"
+      labels:
+        - "changelog: docs"
+
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -39,6 +39,7 @@ changelog:
     - title: "[Doc] Documentation 📚"
       labels:
         - "changelog: doc"
+        - "type: documentation"
 
     - title: Other Changes
       labels:

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -38,7 +38,7 @@ changelog:
 
     - title: "[Doc] Documentation 📚"
       labels:
-        - "changelog: docs"
+        - "changelog: doc"
 
     - title: Other Changes
       labels:


### PR DESCRIPTION
### Changes proposed in this Pull Request:


Add `release.yml`, update PR template

Introduce `changelog: none` exclusions, and new change types.
(Created with updated `yo grow` generator
https://github.com/woocommerce/grow/pull/38)


### Screenshots:

![gh rn 2](https://user-images.githubusercontent.com/17435/182618898-2c7311ba-a540-4740-88d0-a954dccb844c.gif)


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Review PR template
2. See GH release notes generated from `trunk`, since 1.5.10: https://github.com/woocommerce/woocommerce-google-analytics-integration/releases/new?tag=1.5.14&target=trunk - choose "Previous tag" 1.5.10, click "Generate release notes"
3. Check notes generated with this config https://github.com/woocommerce/woocommerce-google-analytics-integration/releases/new?tag=1.5.14&target=add/release.yml -  choose "Previous tag" 1.5.10, click "Generate release notes"
4. Add/remove `changelog: none` to [one of the PR](https://github.com/woocommerce/woocommerce-google-analytics-integration/pull/218)s
6. Check notes generated after the label change https://github.com/woocommerce/woocommerce-google-analytics-integration/releases/new?tag=1.5.14&target=add/release.yml -  choose "Previous tag" 1.5.10, click "Generate release notes"


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

> Dev - GH release config and the new PR template.