### PR TITLE
Add Google Analytics into Things to do next list

### DIFF
--- a/includes/class-wc-google-analytics-task.php
+++ b/includes/class-wc-google-analytics-task.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Set up Google Analytics Integration task.
+ *
+ * Adds a set up Google Analytics Integration task to the task list.
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Task;
+
+/**
+ * Setup Task class.
+ *
+ * @phpcs:disable Squiz.Classes.ClassFileName.NoMatch
+ */
+class GoogleAnalyticsTask extends Task {
+
+	/**
+	 * Get the ID of the task.
+	 *
+	 * @return string
+	 */
+	public function get_id() {
+		return 'setup-google-analytics-integration';
+	}
+
+	/**
+	 * Get the title for the task.
+	 *
+	 * @return string
+	 */
+	public function get_title() {
+		return esc_html__( 'Set up Google Analytics', 'woocommerce-google-analytics-integration' );
+	}
+
+	/**
+	 * Get the content for the task.
+	 *
+	 * @return string
+	 */
+	public function get_content() {
+		return esc_html__( 'Provides the integration between WooCommerce and Google Analytics.', 'woocommerce-google-analytics-integration' );
+	}
+
+	/**
+	 * Get the time required to perform the task.
+	 *
+	 * @return string
+	 */
+	public function get_time() {
+		return esc_html__( '5 minutes', 'woocommerce-google-analytics-integration' );
+	}
+
+	/**
+	 * Get the action URL for the task.
+	 *
+	 * @return string
+	 */
+	public function get_action_url() {
+		return WC_Google_Analytics_Integration::get_instance()->get_settings_url();
+	}
+
+	/**
+	 * Check if the task is complete.
+	 *
+	 * @return bool
+	 */
+	public function is_complete() {
+		return WC_Google_Analytics_Integration::get_integration()->is_setup_complete();
+	}
+
+}
+
+

--- a/includes/class-wc-google-analytics-task.php
+++ b/includes/class-wc-google-analytics-task.php
@@ -13,8 +13,9 @@ use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Task;
  * Setup Task class.
  *
  * @phpcs:disable Squiz.Classes.ClassFileName.NoMatch
+ * @phpcs:disable Squiz.Classes.ValidClassName.NotCamelCaps
  */
-class GoogleAnalyticsTask extends Task {
+class WC_Google_Analytics_Task extends Task {
 
 	/**
 	 * Get the ID of the task.

--- a/includes/class-wc-google-analytics.php
+++ b/includes/class-wc-google-analytics.php
@@ -684,7 +684,7 @@ class WC_Google_Analytics extends WC_Integration {
 
 		TaskLists::add_task(
 			'extended',
-			new GoogleAnalyticsIntegrationTask(
+			new GoogleAnalyticsTask(
 				TaskLists::get_list( 'extended' )
 			)
 		);

--- a/includes/class-wc-google-analytics.php
+++ b/includes/class-wc-google-analytics.php
@@ -684,7 +684,7 @@ class WC_Google_Analytics extends WC_Integration {
 
 		TaskLists::add_task(
 			'extended',
-			new GoogleAnalyticsTask(
+			new WC_Google_Analytics_Task(
 				TaskLists::get_list( 'extended' )
 			)
 		);

--- a/includes/class-wc-google-analytics.php
+++ b/includes/class-wc-google-analytics.php
@@ -3,6 +3,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
 }
 
+use Automattic\WooCommerce\Admin\Features\OnboardingTasks\TaskLists;
+
 /**
  * Google Analytics Integration
  *
@@ -68,12 +70,8 @@ class WC_Google_Analytics extends WC_Integration {
 		include_once( 'class-wc-google-gtag-js.php' );
 		$this->get_tracking_instance( $constructor );
 
-		// Display an info banner on how to configure WooCommerce
-		if ( is_admin() ) {
-			include_once( 'class-wc-google-analytics-info-banner.php' );
-			WC_Google_Analytics_Info_Banner::get_instance( $this->dismissed_info_banner, $this->ga_id );
-		}
-
+		// Display a task on  "Things to do next section"
+		add_action( 'init', array( $this, 'add_wc_setup_task' ), 20 );
 		// Admin Options
 		add_filter( 'woocommerce_tracker_data', array( $this, 'track_options' ) );
 		add_action( 'woocommerce_update_options_integration_google_analytics', array( $this, 'process_admin_options') );
@@ -662,5 +660,34 @@ class WC_Google_Analytics extends WC_Integration {
 		$return_url = add_query_arg( 'utm_nooverride', '1', $return_url );
 
 		return $return_url;
+	}
+
+	/**
+	 * Check if the Google Analytics Tracking ID has been set up.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return bool Whether the Google Analytics setup is completed.
+	 */
+	public function is_setup_complete() {
+		return (bool) $this->get_option( 'ga_id' );
+	}
+
+
+	/**
+	 * Adds the setup task to the Tasklists.
+	 *
+	 * @since x.x.x
+	 */
+	public function add_wc_setup_task() {
+		require_once 'class-wc-google-analytics-task.php';
+
+		TaskLists::add_task(
+			'extended',
+			new GoogleAnalyticsIntegrationTask(
+				TaskLists::get_list( 'extended' )
+			)
+		);
+
 	}
 }

--- a/woocommerce-google-analytics-integration.php
+++ b/woocommerce-google-analytics-integration.php
@@ -6,7 +6,7 @@
  * Author: WooCommerce
  * Author URI: https://woocommerce.com
  * Version: 1.5.15
- * WC requires at least: 3.2
+ * WC requires at least: 6.8
  * WC tested up to: 7.0
  * Tested up to: 6.0
  * License: GPLv2 or later
@@ -21,6 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 if ( ! class_exists( 'WC_Google_Analytics_Integration' ) ) {
 
 	define( 'WC_GOOGLE_ANALYTICS_INTEGRATION_VERSION', '1.5.15' ); // WRCS: DEFINED_VERSION.
+	define( 'WC_GOOGLE_ANALYTICS_INTEGRATION_MIN_WC_VER', '6.8' );
 
 	// Maybe show the GA Pro notice on plugin activation.
 	register_activation_hook(
@@ -54,7 +55,7 @@ if ( ! class_exists( 'WC_Google_Analytics_Integration' ) ) {
 			add_action( 'woocommerce_order_status_completed', array( $this, 'maybe_show_ga_pro_notices' ) );
 
 			// Checks which WooCommerce is installed.
-			if ( class_exists( 'WC_Integration' ) && defined( 'WOOCOMMERCE_VERSION' ) && version_compare( WOOCOMMERCE_VERSION, '3.2', '>=' ) ) {
+			if ( class_exists( 'WC_Integration' ) && defined( 'WOOCOMMERCE_VERSION' ) && version_compare( WOOCOMMERCE_VERSION, WC_GOOGLE_ANALYTICS_INTEGRATION_MIN_WC_VER, '>=' ) ) {
 				include_once 'includes/class-wc-google-analytics.php';
 
 				// Register the integration.
@@ -129,7 +130,9 @@ if ( ! class_exists( 'WC_Google_Analytics_Integration' ) ) {
 		 * WooCommerce fallback notice.
 		 */
 		public function woocommerce_missing_notice() {
-			echo '<div class="error"><p>' . sprintf( __( 'WooCommerce Google Analytics depends on the last version of %s to work!', 'woocommerce-google-analytics-integration' ), '<a href="https://woocommerce.com/" target="_blank">' . __( 'WooCommerce', 'woocommerce-google-analytics-integration' ) . '</a>' ) . '</p></div>';
+			/* translators: 1 is the required component */
+			$error = sprintf( 'WooCommerce Google Analytics requires WooCommerce version %1$s or higher. You are using version %2$s', WC_GOOGLE_ANALYTICS_INTEGRATION_MIN_WC_VER, WOOCOMMERCE_VERSION );
+			echo '<div class="error"><p><strong>' . wp_kses_post( $error ) . '</strong></p></div>';
 		}
 
 		/**

--- a/woocommerce-google-analytics-integration.php
+++ b/woocommerce-google-analytics-integration.php
@@ -67,13 +67,14 @@ if ( ! class_exists( 'WC_Google_Analytics_Integration' ) ) {
 		}
 
 		/**
-		 * Add links on the plugins page (Settings & Support)
+		 * Gets the settings page URL.
 		 *
-		 * @param  array $links Default links
-		 * @return array        Default + added links
+		 * @since x.x.x
+		 *
+		 * @return string Settings URL
 		 */
-		public function plugin_links( $links ) {
-			$settings_url = add_query_arg(
+		public function get_settings_url(){
+			return add_query_arg(
 				array(
 					'page'    => 'wc-settings',
 					'tab'     => 'integration',
@@ -81,6 +82,16 @@ if ( ! class_exists( 'WC_Google_Analytics_Integration' ) ) {
 				),
 				admin_url( 'admin.php' )
 			);
+		}
+
+		/**
+		 * Add links on the plugins page (Settings & Support)
+		 *
+		 * @param  array $links Default links
+		 * @return array        Default + added links
+		 */
+		public function plugin_links( $links ) {
+			$settings_url = $this->get_settings_url();
 
 			$plugin_links = array(
 				'<a href="' . esc_url( $settings_url ) . '">' . __( 'Settings', 'woocommerce-google-analytics-integration' ) . '</a>',
@@ -132,6 +143,18 @@ if ( ! class_exists( 'WC_Google_Analytics_Integration' ) ) {
 
 			return $integrations;
 		}
+
+		/**
+		 * Get Google Analytics Integration
+		 *
+		 * @since x.x.x
+		 *
+		 * @return WC_Google_Analytics The Google Analytics integration.
+		 */
+		public static function get_integration() {
+			return \WooCommerce::instance()->integrations->get_integration( 'google_analytics' );
+		}
+
 
 		/**
 		 * Logic for Google Analytics Pro notices.

--- a/woocommerce-google-analytics-integration.php
+++ b/woocommerce-google-analytics-integration.php
@@ -73,7 +73,7 @@ if ( ! class_exists( 'WC_Google_Analytics_Integration' ) ) {
 		 *
 		 * @return string Settings URL
 		 */
-		public function get_settings_url(){
+		public function get_settings_url() {
 			return add_query_arg(
 				array(
 					'page'    => 'wc-settings',


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes  peeuvX-6w-p2

This PR adds a new task in WooCommerce's "Things to do next" section.

![image](https://user-images.githubusercontent.com/2488994/198992982-b7c1be60-542b-4bbf-aac5-faea4438629e.png)

The configuration is completed once is set the "Google Analytics Tracking ID".

![image](https://user-images.githubusercontent.com/2488994/198993170-2b8d1d96-7459-4db5-b27e-e8692f28a920.png)

In order to give a more consistent experience through the different extensions the following banner has been removed:

![image](https://user-images.githubusercontent.com/2488994/198994159-c0f7f0f3-cd4c-4e66-80f3-606bbee2cb90.png)


### Checks:
<!-- Mark completed items with an [x] -->
* [X] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [X] Have you successfully run tests with your changes locally?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Go to Woocomme Dashboard - wp-admin/admin.php?page=wc-admin
2. A new task should be displayed: Set up Google Analytics
3. Google Analytics should be completed if a "Google Analytics Tracking ID" has been set previously otherwise will be uncompleted.
4. Click on the task. It should go to the settings page.
5. Add or remove "Google Analytics Tracking ID" and the status of the task should change to complete/uncompleted.
6. No banners should be displayed if the Google Analytics Tracking ID is not set.

### Aditional details

I thought to delete `class-wc-google-analytics-info-banner.php` as is not used anymore in the plugin however I am not sure if other plugins are using this class so I decided to keep the file to be safe.

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry
> Add - New Google Analytics task in WC