### PR TITLE
Declare compatibility for High Performance Order Storage

### DIFF
--- a/woocommerce-google-analytics-integration.php
+++ b/woocommerce-google-analytics-integration.php
@@ -14,6 +14,8 @@
  * Domain Path: languages/
  */
 
+use Automattic\WooCommerce\Utilities\FeaturesUtil;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -27,6 +29,16 @@ if ( ! class_exists( 'WC_Google_Analytics_Integration' ) ) {
 		__FILE__,
 		function () {
 			WC_Google_Analytics_Integration::get_instance()->maybe_show_ga_pro_notices();
+		}
+	);
+
+	// HPOS compatibility declaration.
+	add_action(
+		'before_woocommerce_init',
+		function () {
+			if ( class_exists( FeaturesUtil::class ) ) {
+				FeaturesUtil::declare_compatibility( 'custom_order_tables', __FILE__ );
+			}
 		}
 	);
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Declares the extension as compatible with High Performance Order Storage. Which means the feature can be enabled while the plugin is activated.

Compatibility snippet: https://github.com/woocommerce/woocommerce/wiki/High-Performance-Order-Storage-Upgrade-Recipe-Book#declaring-extension-incompatibility

### Detailed test instructions:
1. Install WC 7.1 (beta or release candidate)
2. Go to WooCommerce > Settings > Advanced > Features
3. Confirm WooCommerce Google Analytics Integration is not on the list of incompatible plugins preventing HPOS from being enabled.


### Changelog entry
* Add - Declare compatibility for High Performance Order Storage.
