### PR TITLE
Add common events method

### DIFF
--- a/includes/class-wc-google-analytics.php
+++ b/includes/class-wc-google-analytics.php
@@ -479,7 +479,7 @@ class WC_Google_Analytics extends WC_Integration {
 			$this->get_tracking_instance()->add_to_cart( $product );
 			return;
 		}
-		
+
 		// Add single quotes to allow jQuery to be substituted into _trackEvent parameters
 		$parameters             = array();
 		$parameters['category'] = "'" . __( 'Products', 'woocommerce-google-analytics-integration' ) . "'";
@@ -504,7 +504,7 @@ class WC_Google_Analytics extends WC_Integration {
 
 			$parameters['item'] = $item;
 
-			$code                   = $this->get_tracking_instance()->tracker_var() . "( 'ec:addProduct', " . $item . ' );';
+			$code                   = $this->get_tracking_instance()->tracker_var() . "( 'ec:addProduct', {$item} );";
 			$parameters['enhanced'] = $code;
 		}
 

--- a/includes/class-wc-google-analytics.php
+++ b/includes/class-wc-google-analytics.php
@@ -465,7 +465,7 @@ class WC_Google_Analytics extends WC_Integration {
 	/**
 	 * Google Analytics event tracking for single product add to cart
 	 */
-	public function add_to_cart() { 
+	public function add_to_cart() {
 		if ( $this->disable_tracking( $this->ga_event_tracking_enabled ) ) {
 			return;
 		}
@@ -479,14 +479,14 @@ class WC_Google_Analytics extends WC_Integration {
 			$this->get_tracking_instance()->add_to_cart( $product );
 		} else {
 			// Add single quotes to allow jQuery to be substituted into _trackEvent parameters
-			$parameters = array();
+			$parameters             = array();
 			$parameters['category'] = "'" . __( 'Products', 'woocommerce-google-analytics-integration' ) . "'";
 			$parameters['action']   = "'" . __( 'Add to Cart', 'woocommerce-google-analytics-integration' ) . "'";
-			$parameters['label']    = "'" . esc_js( $product->get_sku() ? __( 'ID:', 'woocommerce-google-analytics-integration' ) . ' ' . $product->get_sku() : "#" . $product->get_id() ) . "'";
+			$parameters['label']    = "'" . esc_js( $product->get_sku() ? __( 'ID:', 'woocommerce-google-analytics-integration' ) . ' ' . $product->get_sku() : '#' . $product->get_id() ) . "'";
 
 			if ( ! $this->disable_tracking( $this->ga_enhanced_ecommerce_tracking_enabled ) ) {
 
-				$item = "{";
+				$item = '{';
 
 				if ( $product->is_type( 'variable' ) ) {
 					$item .= "'id': google_analytics_integration_product_data[ $('input[name=\"variation_id\"]').val() ] !== undefined ? google_analytics_integration_product_data[ $('input[name=\"variation_id\"]').val() ].id : false,";
@@ -498,11 +498,11 @@ class WC_Google_Analytics extends WC_Integration {
 				$item .= "'name': '" . esc_js( $product->get_title() ) . "',";
 				$item .= "'category': " . $this->get_tracking_instance()->product_get_category_line( $product );
 				$item .= "'quantity': $( 'input.qty' ).val() ? $( 'input.qty' ).val() : '1'";
-				$item .= "}";
+				$item .= '}';
 
 				$parameters['item'] = $item;
 
-				$code = "" . $this->get_tracking_instance()->tracker_var() . "( 'ec:addProduct', " . $item . " );";
+				$code                   = $this->get_tracking_instance()->tracker_var() . "( 'ec:addProduct', " . $item . ' );';
 				$parameters['enhanced'] = $code;
 			}
 

--- a/includes/class-wc-google-analytics.php
+++ b/includes/class-wc-google-analytics.php
@@ -477,37 +477,38 @@ class WC_Google_Analytics extends WC_Integration {
 
 		if ( 'yes' === $this->ga_gtag_enabled ) {
 			$this->get_tracking_instance()->add_to_cart( $product );
-		} else {
-			// Add single quotes to allow jQuery to be substituted into _trackEvent parameters
-			$parameters             = array();
-			$parameters['category'] = "'" . __( 'Products', 'woocommerce-google-analytics-integration' ) . "'";
-			$parameters['action']   = "'" . __( 'Add to Cart', 'woocommerce-google-analytics-integration' ) . "'";
-			$parameters['label']    = "'" . esc_js( $product->get_sku() ? __( 'ID:', 'woocommerce-google-analytics-integration' ) . ' ' . $product->get_sku() : '#' . $product->get_id() ) . "'";
+			return;
+		}
+		
+		// Add single quotes to allow jQuery to be substituted into _trackEvent parameters
+		$parameters             = array();
+		$parameters['category'] = "'" . __( 'Products', 'woocommerce-google-analytics-integration' ) . "'";
+		$parameters['action']   = "'" . __( 'Add to Cart', 'woocommerce-google-analytics-integration' ) . "'";
+		$parameters['label']    = "'" . esc_js( $product->get_sku() ? __( 'ID:', 'woocommerce-google-analytics-integration' ) . ' ' . $product->get_sku() : '#' . $product->get_id() ) . "'";
 
-			if ( ! $this->disable_tracking( $this->ga_enhanced_ecommerce_tracking_enabled ) ) {
+		if ( ! $this->disable_tracking( $this->ga_enhanced_ecommerce_tracking_enabled ) ) {
 
-				$item = '{';
+			$item = '{';
 
-				if ( $product->is_type( 'variable' ) ) {
-					$item .= "'id': google_analytics_integration_product_data[ $('input[name=\"variation_id\"]').val() ] !== undefined ? google_analytics_integration_product_data[ $('input[name=\"variation_id\"]').val() ].id : false,";
-					$item .= "'variant': google_analytics_integration_product_data[ $('input[name=\"variation_id\"]').val() ] !== undefined ? google_analytics_integration_product_data[ $('input[name=\"variation_id\"]').val() ].variant : false,";
-				} else {
-					$item .= "'id': '" . $this->get_tracking_instance()->get_product_identifier( $product ) . "',";
-				}
-
-				$item .= "'name': '" . esc_js( $product->get_title() ) . "',";
-				$item .= "'category': " . $this->get_tracking_instance()->product_get_category_line( $product );
-				$item .= "'quantity': $( 'input.qty' ).val() ? $( 'input.qty' ).val() : '1'";
-				$item .= '}';
-
-				$parameters['item'] = $item;
-
-				$code                   = $this->get_tracking_instance()->tracker_var() . "( 'ec:addProduct', " . $item . ' );';
-				$parameters['enhanced'] = $code;
+			if ( $product->is_type( 'variable' ) ) {
+				$item .= "'id': google_analytics_integration_product_data[ $('input[name=\"variation_id\"]').val() ] !== undefined ? google_analytics_integration_product_data[ $('input[name=\"variation_id\"]').val() ].id : false,";
+				$item .= "'variant': google_analytics_integration_product_data[ $('input[name=\"variation_id\"]').val() ] !== undefined ? google_analytics_integration_product_data[ $('input[name=\"variation_id\"]').val() ].variant : false,";
+			} else {
+				$item .= "'id': '" . $this->get_tracking_instance()->get_product_identifier( $product ) . "',";
 			}
 
-			$this->get_tracking_instance()->event_tracking_code( $parameters, '.single_add_to_cart_button' );
+			$item .= "'name': '" . esc_js( $product->get_title() ) . "',";
+			$item .= "'category': " . $this->get_tracking_instance()->product_get_category_line( $product );
+			$item .= "'quantity': $( 'input.qty' ).val() ? $( 'input.qty' ).val() : '1'";
+			$item .= '}';
+
+			$parameters['item'] = $item;
+
+			$code                   = $this->get_tracking_instance()->tracker_var() . "( 'ec:addProduct', " . $item . ' );';
+			$parameters['enhanced'] = $code;
 		}
+
+		$this->get_tracking_instance()->event_tracking_code( $parameters, '.single_add_to_cart_button' );
 	}
 
 	/**

--- a/includes/class-wc-google-analytics.php
+++ b/includes/class-wc-google-analytics.php
@@ -553,7 +553,7 @@ class WC_Google_Analytics extends WC_Integration {
 	 * Google Analytics event tracking for loop add to cart
 	 */
 	public function loop_add_to_cart() {
-		if ( $this->disable_tracking( $this->ga_event_tracking_enabled ) ) {
+		if ( $this->disable_tracking( $this->ga_event_tracking_enabled ) || 'yes' === $this->ga_gtag_enabled ) {
 			return;
 		}
 

--- a/includes/class-wc-google-gtag-js.php
+++ b/includes/class-wc-google-gtag-js.php
@@ -86,6 +86,37 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 	}
 
 	/**
+	 * Returns Javascript string for Google Analytics events
+	 * 
+	 * @param string $event The type of event
+	 * @param array  $data  Event data to be sent
+	 * @return string
+	 */
+	public static function get_event_code( string $event, array $data ): string {
+		return sprintf( "%s('event', '%s', %s)", self::tracker_var(), esc_js( $event ), self::format_event_data( $data ) );
+	}
+	
+	/**
+	 * Escape and encode event data
+	 *
+	 * @param array $data Event data to processed and formatted
+	 * @return string
+	 */
+	public static function format_event_data( array $data ): string {
+		$data = apply_filters( 'woocommerce_gtag_event_data', $data );
+
+		// Recursively walk through $data array and escape all values that will be used in JS.
+		array_walk_recursive(
+			$data,
+			function( &$value, $key ) {
+				$value = esc_js( $value );
+			}
+		);
+
+		return wp_json_encode( $data );
+	}
+
+	/**
 	 * Enqueues JavaScript to build the addImpression event
 	 *
 	 * @param WC_Product $product

--- a/includes/class-wc-google-gtag-js.php
+++ b/includes/class-wc-google-gtag-js.php
@@ -117,6 +117,31 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 	}
 
 	/**
+	 * Returns an array of category names the product is atttributed to
+	 *
+	 * @param  WC_Product $_product  Product to pull info for
+	 * @return array
+	 */
+	public static function product_get_category_line( $_product ) {
+		$out            = [];
+		$variation_data = $_product->is_type( 'variation' ) ? wc_get_product_variation_attributes( $_product->get_id() ) : false;
+		$categories     = get_the_terms( $_product->get_id(), 'product_cat' );
+
+		if ( is_array( $variation_data ) && ! empty( $variation_data ) ) {
+			$parent_product = wc_get_product( $_product->get_parent_id() );
+			$categories     = get_the_terms( $parent_product->get_id(), 'product_cat' );
+		}
+
+		if ( $categories ) {
+			foreach ( $categories as $category ) {
+				$out[] = $category->name;
+			}
+		}
+
+		return join( '/', $out );
+	}
+
+	/**
 	 * Enqueues JavaScript to build the view_item_list event
 	 *
 	 * @param WC_Product $product

--- a/includes/class-wc-google-gtag-js.php
+++ b/includes/class-wc-google-gtag-js.php
@@ -148,26 +148,26 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 	 * @param int        $position
 	 */
 	public static function listing_click( $product, $position ) {
-		if ( isset( $_GET['s'] ) ) {
-			$list = "Search Results";
-		} else {
-			$list = "Product List";
-		}
+		$event_code = self::get_event_code(
+			'select_content',
+			array(
+				'items' => array(
+					array(
+						'id'            => self::get_product_identifier( $product ),
+						'name'          => $product->get_title(),
+						'category'      => self::product_get_category_line( $product ),
+						'list_position' => $position,
+					),
+				),
+			)
+		);
 
 		wc_enqueue_js( "
 			$( '.products .post-" . esc_js( $product->get_id() ) . " a' ).on('click', function() {
 				if ( true === $(this).hasClass( 'add_to_cart_button' ) ) {
 					return;
 				}
-				" . self::tracker_var() . "( 'event', 'select_content', {
-					'content_type': 'product',
-					'items': [ {
-						'id': '" . self::get_product_identifier( $product ) . "',
-						'name': '" . esc_js( $product->get_title() ) . "',
-						'category': " . self::product_get_category_line( $product ) . "
-						'list_position': '" . esc_js( $position ) . "'
-					} ],
-				} );
+				$event_code
 			});
 		" );
 	}

--- a/includes/class-wc-google-gtag-js.php
+++ b/includes/class-wc-google-gtag-js.php
@@ -342,15 +342,21 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 			return;
 		}
 
-		wc_enqueue_js( "
-			" . self::tracker_var() . "( 'event', 'view_item', {
-				'items': [ {
-					'id': '" . self::get_product_identifier( $product ) . "',
-					'name': '" . esc_js( $product->get_title() ) . "',
-					'category': " . self::product_get_category_line( $product ) . "
-					'price': '" . esc_js( $product->get_price() ) . "',
-				} ]
-			} );" );
+		$event_code = self::get_event_code(
+			'view_item',
+			array(
+				'items' => array(
+					array(
+						'id'       => self::get_product_identifier( $product ),
+						'name'     => $product->get_title(),
+						'category' => self::product_get_category_line( $product ),
+						'price'    => $product->get_price(),
+					),
+				),
+			)
+		);
+
+		wc_enqueue_js( $event_code );
 	}
 
 	/**

--- a/includes/class-wc-google-gtag-js.php
+++ b/includes/class-wc-google-gtag-js.php
@@ -117,28 +117,27 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 	}
 
 	/**
-	 * Returns an array of category names the product is atttributed to
+	 * Returns a list of category names the product is atttributed to
 	 *
-	 * @param  WC_Product $_product  Product to pull info for
-	 * @return array
+	 * @param  WC_Product $product Product to generate category line for
+	 * @return string
 	 */
-	public static function product_get_category_line( $_product ) {
-		$out            = [];
-		$variation_data = $_product->is_type( 'variation' ) ? wc_get_product_variation_attributes( $_product->get_id() ) : false;
-		$categories     = get_the_terms( $_product->get_id(), 'product_cat' );
+	public static function product_get_category_line( $product ) {
+		$category_names = array();
+		$categories     = get_the_terms( $product->get_id(), 'product_cat' );
 
+		$variation_data = $product->is_type( 'variation' ) ? wc_get_product_variation_attributes( $product->get_id() ) : false;
 		if ( is_array( $variation_data ) && ! empty( $variation_data ) ) {
-			$parent_product = wc_get_product( $_product->get_parent_id() );
-			$categories     = get_the_terms( $parent_product->get_id(), 'product_cat' );
+			$categories = get_the_terms( $product->get_parent_id(), 'product_cat' );
 		}
 
-		if ( $categories ) {
+		if ( false !== $categories && ! is_wp_error( $categories ) ) {
 			foreach ( $categories as $category ) {
-				$out[] = $category->name;
+				$category_names[] = $category->name;
 			}
 		}
 
-		return join( '/', $out );
+		return join( '/', $category_names );
 	}
 
 	/**

--- a/includes/class-wc-google-gtag-js.php
+++ b/includes/class-wc-google-gtag-js.php
@@ -309,16 +309,23 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 	 * Output JavaScript to track an enhanced ecommerce remove from cart action
 	 */
 	public function remove_from_cart() {
+		$event_code = self::get_event_code(
+			'remove_from_cart',
+			array(
+				'items' => array(
+					array(
+						'id'       => "($(this).data('product_sku')) ? ($(this).data('product_sku')) : ('#' + $(this).data('product_id'))",
+						'quantity' => "$(this).parent().parent().find( '.qty' ).val() ? $(this).parent().parent().find( '.qty' ).val() : '1',",
+					),
+				),
+			)
+		);
+
 		echo( "
 			<script>
 			(function($) {
 				$( '.remove' ).off('click', '.remove').on( 'click', function() {
-					" . self::tracker_var() . "( 'event', 'remove_from_cart', {
-						'items': [ {
-							'id': ($(this).data('product_sku')) ? ($(this).data('product_sku')) : ('#' + $(this).data('product_id')),
-							'quantity': $(this).parent().parent().find( '.qty' ).val() ? $(this).parent().parent().find( '.qty' ).val() : '1',
-						} ]
-					} );
+					$event_code
 				});
 			})(jQuery);
 			</script>

--- a/includes/class-wc-google-gtag-js.php
+++ b/includes/class-wc-google-gtag-js.php
@@ -314,7 +314,7 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 		$order_items = $order->get_items();
 		if ( ! empty( $order_items ) ) {
 			foreach ( $order_items as $item ) {
-				$event_items += self::add_item( $order, $item );
+				$event_items[] = self::add_item( $order, $item );
 			}
 		}
 
@@ -327,7 +327,7 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 				'tax'            => $order->get_total_tax(),
 				'shipping'       => $order->get_total_shipping(),
 				'currency'       => $order->get_currency(),
-				'items'          => array( $event_items ),
+				'items'          => $event_items,
 			)
 		);
 	}
@@ -434,7 +434,7 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 				$item_data['variant'] = $variant;
 			}
 
-			$items[] += $item_data;
+			$items[] = $item_data;
 		}
 
 		$event_code = self::get_event_code(

--- a/includes/class-wc-google-gtag-js.php
+++ b/includes/class-wc-google-gtag-js.php
@@ -339,13 +339,13 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 	 * @param WC_Order_Item $item  The item to add to a transaction/order
 	 */
 	protected function add_item( $order, $item ) {
-		$_product = $item->get_product();
-		$variant  = self::product_get_variant_line( $_product );
+		$product = $item->get_product();
+		$variant  = self::product_get_variant_line( $product );
 
 		$event_item = array(
-			'id'       => self::get_product_identifier( $_product ),
+			'id'       => self::get_product_identifier( $product ),
 			'name'     => $item['name'],
-			'category' => self::product_get_category_line( $_product ),
+			'category' => self::product_get_category_line( $product ),
 			'price'    => $order->get_item_total( $item ),
 			'quantity' => $item['qty'],
 		);

--- a/includes/class-wc-google-gtag-js.php
+++ b/includes/class-wc-google-gtag-js.php
@@ -363,25 +363,17 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 	public function remove_from_cart() {
 		$event_code = self::get_event_code(
 			'remove_from_cart',
-			array(
-				'items' => array(
-					array(
-						'id'       => "($(this).data('product_sku')) ? ($(this).data('product_sku')) : ('#' + $(this).data('product_id'))",
-						'quantity' => "$(this).parent().parent().find( '.qty' ).val() ? $(this).parent().parent().find( '.qty' ).val() : '1',",
-					),
-				),
-			)
+			'{"items": {
+				"id": $(this).data("product_sku") ? $(this).data("product_sku") : "#" + $(this).data("product_id"),
+				"quantity": $(this).parent().parent().find(".qty").val() ? $(this).parent().parent().find(".qty").val() : "1"
+			 }}'
 		);
 
-		echo( "
-			<script>
-			(function($) {
-				$( '.remove' ).off('click', '.remove').on( 'click', function() {
-					$event_code
-				});
-			})(jQuery);
-			</script>
-		" );
+		wc_enqueue_js(
+			"$( '.remove' ).off('click', '.remove').on( 'click', function() {
+				$event_code
+			});"
+		);
 	}
 
 	/**

--- a/includes/class-wc-google-gtag-js.php
+++ b/includes/class-wc-google-gtag-js.php
@@ -178,7 +178,7 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 			'name'          => $product->get_title(),
 			'category'      => self::product_get_category_line( $product ),
 			'list_position' => $position,
-			'quantity'      => 1
+			'quantity'      => 1,
 		);
 
 		$select_content_event_code = self::get_event_code(
@@ -202,13 +202,13 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 				} else {
 					$select_content_event_code
 				}
-			});
-		" );
+			});"
+		);
 	}
 
 	/**
 	 * Output Javascript to track add_to_cart event on single product page
-	 * 
+	 *
 	 * @param WC_Product $product The product currently being viewed
 	 */
 	public static function add_to_cart( WC_Product $product ) {
@@ -216,13 +216,13 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 			'id'       => self::get_product_identifier( $product ),
 			'name'     => $product->get_title(),
 			'category' => self::product_get_category_line( $product ),
-			'quantity' => 1
+			'quantity' => 1,
 		);
 
 		// Set item data as Javascript variable so that quantity, variant, and ID can be updated before sending the event
-		$event_code = "
-			const item_data    = ". self::format_event_data( $items ) .";
-			item_data.quantity = $( 'input.qty' ).val() ? $('input.qty').val() : '1';";
+		$event_code = '
+			const item_data    = ' . self::format_event_data( $items ) . ';
+			item_data.quantity = $("input.qty").val() ? $("input.qty").val() : 1;';
 
 		if ( $product->is_type( 'variable' ) ) {
 			// Check the global google_analytics_integration_product_data Javascript variable contains data
@@ -241,11 +241,11 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 			false
 		);
 
-		wc_enqueue_js("
-			$( '.single_add_to_cart_button' ).on('click', function() {
+		wc_enqueue_js(
+			"$( '.single_add_to_cart_button' ).on('click', function() {
 				$event_code
-			});
-		" );
+			});"
+		);
 	}
 
 	/**
@@ -448,11 +448,11 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 
 	/**
 	 * @deprecated x.x.x
-	 * 
+	 *
 	 * Enqueue JavaScript for Add to cart tracking
 	 *
-	 * @param array $parameters associative array of _trackEvent parameters
-	 * @param string $selector jQuery selector for binding click event
+	 * @param array  $parameters Associative array of _trackEvent parameters
+	 * @param string $selector   jQuery selector for binding click event
 	 */
 	public function event_tracking_code( $parameters, $selector ) {
 		wc_deprecated_function( 'event_tracking_code', '1.6.0', 'get_event_code' );

--- a/includes/class-wc-google-gtag-js.php
+++ b/includes/class-wc-google-gtag-js.php
@@ -340,7 +340,7 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 	 */
 	protected function add_item( $order, $item ) {
 		$product = $item->get_product();
-		$variant  = self::product_get_variant_line( $product );
+		$variant = self::product_get_variant_line( $product );
 
 		$event_item = array(
 			'id'       => self::get_product_identifier( $product ),

--- a/includes/class-wc-google-gtag-js.php
+++ b/includes/class-wc-google-gtag-js.php
@@ -169,32 +169,41 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 	}
 
 	/**
-	 * Enqueues JavaScript to build an addProduct and click event
+	 * Enqueues JavaScript for select_content and add_to_cart events for the product archive
 	 *
 	 * @param WC_Product $product
 	 * @param int        $position
 	 */
 	public static function listing_click( $product, $position ) {
-		$event_code = self::get_event_code(
+		$items = array(
+			'id'            => self::get_product_identifier( $product ),
+			'name'          => $product->get_title(),
+			'category'      => self::product_get_category_line( $product ),
+			'list_position' => $position,
+			'quantity'      => 1
+		);
+
+		$select_content_event_code = self::get_event_code(
 			'select_content',
 			array(
-				'items' => array(
-					array(
-						'id'            => self::get_product_identifier( $product ),
-						'name'          => $product->get_title(),
-						'category'      => self::product_get_category_line( $product ),
-						'list_position' => $position,
-					),
-				),
+				'items' => array( $items ),
+			)
+		);
+
+		$add_to_cart_event_code = self::get_event_code(
+			'add_to_cart',
+			array(
+				'items' => array( $items ),
 			)
 		);
 
 		wc_enqueue_js( "
 			$( '.products .post-" . esc_js( $product->get_id() ) . " a' ).on('click', function() {
 				if ( true === $(this).hasClass( 'add_to_cart_button' ) ) {
-					return;
+					$add_to_cart_event_code
+				} else {
+					$select_content_event_code
 				}
-				$event_code
 			});
 		" );
 	}

--- a/includes/class-wc-google-gtag-js.php
+++ b/includes/class-wc-google-gtag-js.php
@@ -365,37 +365,34 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 	 * @param array $cart items/contents of the cart
 	 */
 	public function checkout_process( $cart ) {
-		$items = "[";
-
+		$items = array();
 		foreach ( $cart as $cart_item_key => $cart_item ) {
-			$product     = apply_filters( 'woocommerce_cart_item_product', $cart_item['data'], $cart_item, $cart_item_key );
+			$product = apply_filters( 'woocommerce_cart_item_product', $cart_item['data'], $cart_item, $cart_item_key );
 
-			$items .= "
-				{
-					'id': '" . self::get_product_identifier( $product ) . "',
-					'name': '" . esc_js( $product->get_title() ) . "',
-					'category': " . self::product_get_category_line( $product );
+			$item_data = array(
+				'id'       => self::get_product_identifier( $product ),
+				'name'     => $product->get_title(),
+				'category' => self::product_get_category_line( $product ),
+				'price'    => $product->get_price(),
+				'quantity' => $cart_item['quantity'],
+			);
 
-			$variant     = self::product_get_variant_line( $product );
+			$variant = self::product_get_variant_line( $product );
 			if ( '' !== $variant ) {
-				$items .= "
-					'variant': " . $variant;
+				$item_data['variant'] = $variant;
 			}
 
-			$items .= "
-					'price': '" . esc_js( $product->get_price() ) . "',
-					'quantity': '" . esc_js( $cart_item['quantity'] ) . "'
-				},";
+			$items[] += $item_data;
 		}
 
-		$items .= '
-			]';
+		$event_code = self::get_event_code(
+			'begin_checkout',
+			array(
+				'items' => $items
+			)
+		);
 
-		$code  = "" . self::tracker_var() . "( 'event', 'begin_checkout', {
-			'items': " . $items . ",
-		} );";
-
-		wc_enqueue_js( $code );
+		wc_enqueue_js( $event_code );
 	}
 
 	/**

--- a/includes/class-wc-google-gtag-js.php
+++ b/includes/class-wc-google-gtag-js.php
@@ -228,9 +228,10 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 			// Check the global google_analytics_integration_product_data Javascript variable contains data
 			// for the current variation selection and if it does update the item_data to be sent for this event
 			$event_code .= "
-			if ( google_analytics_integration_product_data[ $('input[name=\"variation_id\"]').val() ] !== undefined ) {
-				item_data.id       = google_analytics_integration_product_data[ $('input[name=\"variation_id\"]').val() ].id;
-				item_data.variant  = google_analytics_integration_product_data[ $('input[name=\"variation_id\"]').val() ].variant;
+			const selected_variation = google_analytics_integration_product_data[ $('input[name=\"variation_id\"]').val() ];
+			if ( selected_variation !== undefined ) {
+				item_data.id       = selected_variation.id;
+				item_data.variant  = selected_variation.variant;
 			}
 			";
 		}

--- a/includes/class-wc-google-gtag-js.php
+++ b/includes/class-wc-google-gtag-js.php
@@ -117,27 +117,28 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 	}
 
 	/**
-	 * Enqueues JavaScript to build the addImpression event
+	 * Enqueues JavaScript to build the view_item_list event
 	 *
 	 * @param WC_Product $product
 	 * @param int        $position
 	 */
 	public static function listing_impression( $product, $position ) {
-		if ( isset( $_GET['s'] ) ) {
-			$list = "Search Results";
-		} else {
-			$list = "Product List";
-		}
+		$event_code = self::get_event_code(
+			'view_item_list',
+			array(
+				'items' => array(
+					array(
+						'id'            => $product->get_id(),
+						'name'          => $product->get_title(),
+						'category'      => self::product_get_category_line( $product ),
+						'list'          => isset( $_GET['s'] ) ? __( 'Search Results', 'woocommerce-google-analytics-integration' ) : __( 'Product List', 'woocommerce-google-analytics-integration' ),
+						'list_position' => $position,
+					),
+				),
+			)
+		);
 
-		wc_enqueue_js( "
-			" . self::tracker_var() . "( 'event', 'view_item_list', { 'items': [ {
-				'id': '" . self::get_product_identifier( $product ) . "',
-				'name': '" . esc_js( $product->get_title() ) . "',
-				'category': " . self::product_get_category_line( $product ) . "
-				'list': '" . esc_js( $list ) . "',
-				'list_position': '" . esc_js( $position ) . "'
-			} ] } );
-		" );
+		wc_enqueue_js( $event_code );
 	}
 
 	/**

--- a/includes/class-wc-google-gtag-js.php
+++ b/includes/class-wc-google-gtag-js.php
@@ -156,9 +156,8 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 						'id'            => $product->get_id(),
 						'name'          => $product->get_title(),
 						'category'      => self::product_get_category_line( $product ),
-						// @codingStandardsIgnoreStart
+						// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 						'list'          => isset( $_GET['s'] ) ? __( 'Search Results', 'woocommerce-google-analytics-integration' ) : __( 'Product List', 'woocommerce-google-analytics-integration' ),
-						// @codingStandardsIgnoreEnd
 						'list_position' => $position,
 					),
 				),

--- a/includes/class-wc-google-gtag-js.php
+++ b/includes/class-wc-google-gtag-js.php
@@ -87,7 +87,7 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 
 	/**
 	 * Returns Javascript string for Google Analytics events
-	 * 
+	 *
 	 * @param string $event The type of event
 	 * @param array  $data  Event data to be sent
 	 * @return string
@@ -95,7 +95,7 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 	public static function get_event_code( string $event, array $data ): string {
 		return sprintf( "%s('event', '%s', %s)", self::tracker_var(), esc_js( $event ), self::format_event_data( $data ) );
 	}
-	
+
 	/**
 	 * Escape and encode event data
 	 *
@@ -156,7 +156,9 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 						'id'            => $product->get_id(),
 						'name'          => $product->get_title(),
 						'category'      => self::product_get_category_line( $product ),
+						// @codingStandardsIgnoreStart
 						'list'          => isset( $_GET['s'] ) ? __( 'Search Results', 'woocommerce-google-analytics-integration' ) : __( 'Product List', 'woocommerce-google-analytics-integration' ),
+						// @codingStandardsIgnoreEnd
 						'list_position' => $position,
 					),
 				),
@@ -260,8 +262,8 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 	protected function add_transaction_enhanced( $order ) {
 		$event_items = array();
 		$order_items = $order->get_items();
-		if( ! empty( $order_items ) ) {
-			foreach( $order_items as $item ) {
+		if ( ! empty( $order_items ) ) {
+			foreach ( $order_items as $item ) {
 				$event_items += self::add_item( $order, $item );
 			}
 		}
@@ -295,7 +297,7 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 			'name'     => $item['name'],
 			'category' => self::product_get_category_line( $_product ),
 			'price'    => $order->get_item_total( $item ),
-			'quantity' => $item['qty']
+			'quantity' => $item['qty'],
 		);
 
 		if ( '' !== $variant ) {
@@ -388,7 +390,7 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 		$event_code = self::get_event_code(
 			'begin_checkout',
 			array(
-				'items' => $items
+				'items' => $items,
 			)
 		);
 

--- a/includes/class-wc-google-gtag-js.php
+++ b/includes/class-wc-google-gtag-js.php
@@ -440,12 +440,15 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 	}
 
 	/**
+	 * @deprecated x.x.x
+	 * 
 	 * Enqueue JavaScript for Add to cart tracking
 	 *
 	 * @param array $parameters associative array of _trackEvent parameters
 	 * @param string $selector jQuery selector for binding click event
 	 */
 	public function event_tracking_code( $parameters, $selector ) {
+		wc_deprecated_function( 'event_tracking_code', '1.6.0', 'get_event_code' );
 
 		// Called with invalid 'Add to Cart' action, update to sync with Default Google Analytics Event 'add_to_cart'
 		$parameters['action']   = '\'add_to_cart\'';

--- a/includes/class-wc-google-gtag-js.php
+++ b/includes/class-wc-google-gtag-js.php
@@ -363,10 +363,10 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 	public function remove_from_cart() {
 		$event_code = self::get_event_code(
 			'remove_from_cart',
-			'{"items": {
+			'{"items": [{
 				"id": $(this).data("product_sku") ? $(this).data("product_sku") : "#" + $(this).data("product_id"),
 				"quantity": $(this).parent().parent().find(".qty").val() ? $(this).parent().parent().find(".qty").val() : "1"
-			 }}'
+			 }]}'
 		);
 
 		wc_enqueue_js(

--- a/includes/class-wc-google-gtag-js.php
+++ b/includes/class-wc-google-gtag-js.php
@@ -238,7 +238,7 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 
 		$event_code .= self::get_event_code(
 			'add_to_cart',
-			'{"items": item_data}',
+			'{"items": [item_data]}',
 			false
 		);
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds a [common method](https://github.com/woocommerce/woocommerce-google-analytics-integration/blob/cdc92f526fe095f3c31cf9c4b63cc56aa624d4cb/includes/class-wc-google-gtag-js.php#L95) that is used to generate gtag javascript event code and format data for that event.

The main benefits this brings to the extension is:

1. Consistent usage of `woocommerce_gtag_tracker_variable` filter #185 
2. Adds a [filter](https://github.com/woocommerce/woocommerce-google-analytics-integration/blob/cdc92f526fe095f3c31cf9c4b63cc56aa624d4cb/includes/class-wc-google-gtag-js.php#L106) for event data which can be used in unit tests and by third-party developers to manipulate event data #171 

### Checks:

- [x] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
- [ ] Have you written new tests for your changes, as applicable?
- [x] Have you successfully run tests with your changes locally?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/pulls) for the same update/change?

### Detailed test instructions:

1. Setup extension with `Enable Enhanced eCommerce` enabled
2. Checkout branch
3. Make sure [Google Analytics Debugger](https://chrome.google.com/webstore/detail/google-analytics-debugger/jnkmfdileelhofjcijamephohjechhna) is **on**
4. In the developer console make sure `Preserve log` is enabled
5. View main product archive with test products published
6. Filter console for `view_item_list` and check event config and data matches current structure (_See below for table detailing existing event data_)
7. Click on a product
8. Filter console for `select_content` and check event config and data matches current structure
9. Filter console for `view_item` and check event config and data matches current structure
10. Add product to cart and then goto checkout page
11. Filter console for `begin_checkout` and check event config and data matches current structure
12. Place order
13. Filter console for `purchase` and check event config and data matches current structure
14. Visit product archive, add a product to cart, and then remove the item from cart
15. Filter console for `remove_from_cart` and check event config and data matches current structure

<img width="1140" alt="Markup 2022-12-01 at 22 08 23" src="https://user-images.githubusercontent.com/40762232/205169465-82e2bfcc-e3e4-4f50-aeb8-9919b11d9fc9.png">

### Additional Details

An [existing method](https://github.com/woocommerce/woocommerce-google-analytics-integration/blob/cdc92f526fe095f3c31cf9c4b63cc56aa624d4cb/includes/class-wc-google-gtag-js.php#L406) has similar functionality, however, it insists on an element selector and javascript click event to trigger the Google Analytics event. While there is some aspect of duplication in this PR I have left the existing function as is because we will eventually want to move the `add_to_cart` functionality out of the abstract class and have it follow the same structure as the events in this PR.

Additionally, a follow-up PR will be required to address other [inconsistent usage of the `woocommerce_gtag_tracker_variable` filter](https://github.com/woocommerce/woocommerce-google-analytics-integration/issues/185).

<hr />
<details>
<summary><b>View table of existing gtag events</b></summary>
<br />
<p><i>This PR doesn't aim to change any of the existing data structures in the extension and so they should exactly match what currently exists. This table outlines what data is currently being sent with each event in <a href="https://github.com/woocommerce/woocommerce-google-analytics-integration/tree/d855d7ef7e80b1623efa7873740a3d6abdeab949">trunk</a>.</i></p>
<table>
<thead>
<tr>
<th>Event</th>
<th>Existing data</th>
</tr>
</thead>
<tbody>
<tr>
<td><a href="https://github.com/woocommerce/woocommerce-google-analytics-integration/blob/d855d7ef7e80b1623efa7873740a3d6abdeab949/includes/class-wc-google-gtag-js.php#L48">view_item_list</a></td>
<td>
<pre><code>gtag( 'event', 'view_item_list', { 'items': [ {
  'id': '',
  'name': '',
  'category': '',
  'list': '',
  'list_position': ''
} ] } );</code></pre>
</td>
</tr>
<tr>
<td><a href="https://github.com/woocommerce/woocommerce-google-analytics-integration/blob/d855d7ef7e80b1623efa7873740a3d6abdeab949/includes/class-wc-google-gtag-js.php#L72">select_content</a></td>
<td>
<pre><code>gtag( 'event', 'select_content', {
  'content_type': 'product',
  'items': [ {
    'id': '',
    'name': '',
    'category': '',
    'list_position': ''
  } ],
} );</code></pre>
</td>
</tr>
<tr>
<td><a href="https://github.com/woocommerce/woocommerce-google-analytics-integration/blob/d855d7ef7e80b1623efa7873740a3d6abdeab949/includes/class-wc-google-gtag-js.php#L231">view_item</a></td>
<td>
<pre><code>gtag( 'event', 'view_item', {
  'content_type': 'product',
  'items': [ {
    'id': '',
    'name': '',
    'category': '',
    'price': ''
  } ],
} );</code></pre>
</td>
</tr>
<tr>
<td><a href="https://github.com/woocommerce/woocommerce-google-analytics-integration/blob/d855d7ef7e80b1623efa7873740a3d6abdeab949/includes/class-wc-google-gtag-js.php#L252">begin_checkout</a></td>
<td>
<pre><code>gtag( 'event', 'begin_checkout', {
  'content_type': 'product',
  'items': [ {
    'id': '',
    'name': '',
    'category': '',
    'variant': '', (conditional)
    'price': '',
    'quantity': '',
  } ],
} );</code></pre>
</td>
</tr>
<tr>
<td><a href="https://github.com/woocommerce/woocommerce-google-analytics-integration/blob/d855d7ef7e80b1623efa7873740a3d6abdeab949/includes/class-wc-google-gtag-js.php#L157">purchase</a></td>
<td>
<pre><code>gtag( 'event', 'purchase', {
  'transaction_id': '',
  'affiliation': '',
  'value': '',
  'tax': '',
  'shipping': '',
  'currency': 'USD',
  'items': [{
    'id': '',
    'name': '',
    'category': '',
    'price': '',
    'quantity': ''
  },],
} );</code></pre>
</td>
</tr>
<tr>
<td><a href="https://github.com/woocommerce/woocommerce-google-analytics-integration/blob/d855d7ef7e80b1623efa7873740a3d6abdeab949/includes/class-wc-google-gtag-js.php#L209"> remove_from_cart</a></td>
<td>
<pre><code>gtag( 'event', 'remove_from_cart', {
  'items': [ {
    'id': '',
    'quantity': '',
  } ]
} );</code></pre>
</td>
</tr>
</tbody>
</table>
</details>
<hr />

### Changelog entry
> Add - Common function for event code