### PR TITLE
Fix undefined constant WC warning and bump WC compatibilty version

### DIFF
--- a/woocommerce-google-analytics-integration.php
+++ b/woocommerce-google-analytics-integration.php
@@ -142,9 +142,16 @@ if ( ! class_exists( 'WC_Google_Analytics_Integration' ) ) {
 		 * WooCommerce fallback notice.
 		 */
 		public function woocommerce_missing_notice() {
-			/* translators: 1 is the required component */
-			$error = sprintf( 'WooCommerce Google Analytics requires WooCommerce version %1$s or higher. You are using version %2$s', WC_GOOGLE_ANALYTICS_INTEGRATION_MIN_WC_VER, WOOCOMMERCE_VERSION );
-			echo '<div class="error"><p><strong>' . wp_kses_post( $error ) . '</strong></p></div>';
+			if ( defined( 'WOOCOMMERCE_VERSION' ) ) {
+				/* translators: 1 is the required component, 2 the Woocommerce version */
+				$error = sprintf( 'WooCommerce Google Analytics requires WooCommerce version %1$s or higher. You are using version %2$s', WC_GOOGLE_ANALYTICS_INTEGRATION_MIN_WC_VER, WOOCOMMERCE_VERSION );
+				echo '<div class="error"><p><strong>' . wp_kses_post( $error ) . '</strong></p></div>';
+			} else {
+				/* translators: 1 is the required component */
+				$error = sprintf( 'WooCommerce Google Analytics requires WooCommerce version %1$s or higher.', WC_GOOGLE_ANALYTICS_INTEGRATION_MIN_WC_VER );
+				echo '<div class="error"><p><strong>' . wp_kses_post( $error ) . '</strong></p></div>';
+			}
+
 		}
 
 		/**

--- a/woocommerce-google-analytics-integration.php
+++ b/woocommerce-google-analytics-integration.php
@@ -7,7 +7,7 @@
  * Author URI: https://woocommerce.com
  * Version: 1.5.18
  * WC requires at least: 6.8
- * WC tested up to: 7.2
+ * WC tested up to: 7.3
  * Tested up to: 6.1
  * License: GPLv2 or later
  * Text Domain: woocommerce-google-analytics-integration

--- a/woocommerce-google-analytics-integration.php
+++ b/woocommerce-google-analytics-integration.php
@@ -144,13 +144,13 @@ if ( ! class_exists( 'WC_Google_Analytics_Integration' ) ) {
 		public function woocommerce_missing_notice() {
 			if ( defined( 'WOOCOMMERCE_VERSION' ) ) {
 				/* translators: 1 is the required component, 2 the Woocommerce version */
-				$error = sprintf( 'WooCommerce Google Analytics requires WooCommerce version %1$s or higher. You are using version %2$s', WC_GOOGLE_ANALYTICS_INTEGRATION_MIN_WC_VER, WOOCOMMERCE_VERSION );
-				echo '<div class="error"><p><strong>' . wp_kses_post( $error ) . '</strong></p></div>';
+				$error = sprintf( __( 'WooCommerce Google Analytics requires WooCommerce version %1$s or higher. You are using version %2$s', 'woocommerce-google-analytics-integration' ), WC_GOOGLE_ANALYTICS_INTEGRATION_MIN_WC_VER, WOOCOMMERCE_VERSION );
 			} else {
 				/* translators: 1 is the required component */
-				$error = sprintf( 'WooCommerce Google Analytics requires WooCommerce version %1$s or higher.', WC_GOOGLE_ANALYTICS_INTEGRATION_MIN_WC_VER );
-				echo '<div class="error"><p><strong>' . wp_kses_post( $error ) . '</strong></p></div>';
+				$error = sprintf( __( 'WooCommerce Google Analytics requires WooCommerce version %1$s or higher.', 'woocommerce-google-analytics-integration' ), WC_GOOGLE_ANALYTICS_INTEGRATION_MIN_WC_VER );
 			}
+
+			echo '<div class="error"><p><strong>' . wp_kses_post( $error ) . '</strong></p></div>';
 
 		}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

This PR fixes the warning when WC is deactivated and the Google Analytics extension is enabled. Also, it bumps the latest WC-compatible version 7.3.

`Warning: Use of undefined constant WOOCOMMERCE_VERSION - assumed 'WOOCOMMERCE_VERSION' (this will throw an Error in a future version of PHP)...`


### Checks:
<!-- Mark completed items with an [x] -->
* [X] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [X] Have you successfully run tests with your changes locally?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Disable the WC plugin, and the following notice should be displayed: `WooCommerce Google Analytics requires WooCommerce version 6.8 or higher.`
2. No warning should be displayed.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - undefined WC constant.
