### PR TITLE
Add PHP unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,21 @@ Will be required for WooCommerce shops using the integration from WooCommerce 2.
 WooCommerce Google Analytics Integration utilizes npm scripts for task management utilities.
 
 `npm run build` - Runs the tasks necessary for a release. These may include building JavaScript, SASS, CSS minification, and language files.
+
+
+## Unit tests
+### Running PHP unit tests in your local dev environment
+1. Install prerequisites: composer, git, xdebug, svn, wget or curl, mysqladmin
+2. `cd` into the `woocommerce-google-analytics-integration/` plugin directory
+3. Run `composer install`
+4. Run `bin/install-unit-tests.sh <db-name> <db-user> <db-pass> [db-host] [wp-version] [wc-version] [skip-database-creation]` e.g. `bin/install-unit-tests.sh wordpress_test root root localhost latest latest`
+5. Run `vendor/bin/phpunit` to run all unit test
+
+_For more info see: WordPress.org > Plugin Unit Tests and AutomateWoo Wiki > Setting up tests._
+
+## Coding standards checks
+
+1. Run `composer install` (_if you haven't done so already_)
+2. Run `npm run lint:php`
+
+Alternatively, run `npm run lint:php:diff` to run coding standards checks agains the current git diff. An explanation of output can be found here e.g. what are the S's?

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ WooCommerce Google Analytics Integration utilizes npm scripts for task managemen
 4. Run `bin/install-unit-tests.sh <db-name> <db-user> <db-pass> [db-host] [wp-version] [wc-version] [skip-database-creation]` e.g. `bin/install-unit-tests.sh wordpress_test root root localhost latest latest`
 5. Run `vendor/bin/phpunit` to run all unit test
 
-_For more info see: WordPress.org > Plugin Unit Tests and AutomateWoo Wiki > Setting up tests._
+_For more info see: [WordPress.org > Plugin Unit Tests](https://make.wordpress.org/cli/handbook/misc/plugin-unit-tests/#running-tests-locally)._
 
 ## Coding standards checks
 

--- a/README.md
+++ b/README.md
@@ -30,4 +30,4 @@ _For more info see: [WordPress.org > Plugin Unit Tests](https://make.wordpress.o
 1. Run `composer install` (_if you haven't done so already_)
 2. Run `npm run lint:php`
 
-Alternatively, run `npm run lint:php:diff` to run coding standards checks agains the current git diff. An explanation of output can be found here e.g. what are the S's?
+Alternatively, run `npm run lint:php:diff` to run coding standards checks agains the current git diff. An explanation of output can be [found here](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Usage#printing-progress-information) e.g. what are the S's?

--- a/bin/install-unit-tests.sh
+++ b/bin/install-unit-tests.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+if [ $# -lt 3 ]; then
+  echo "usage: $0 <db-name> <db-user> <db-pass> [db-host] [wp-version] [wc-version] [skip-database-creation]"
+  exit 1
+fi
+
+DB_NAME=$1
+DB_USER=$2
+DB_PASS=$3
+DB_HOST=${4-localhost}
+WP_VERSION=${5-latest}
+WC_VERSION=${6-latest}
+SKIP_DB_CREATE=${7-false}
+
+cd $(dirname "$0")
+source ./unit-tests-functions.sh
+cd -
+
+install_wp $WP_VERSION
+install_wc $WC_VERSION
+install_test_suite $DB_NAME $DB_USER $DB_PASS $DB_HOST $WP_VERSION
+install_db $DB_NAME $DB_USER $DB_PASS $DB_HOST $SKIP_DB_CREATE

--- a/bin/switch-wp-wc-in-unit-tests.sh
+++ b/bin/switch-wp-wc-in-unit-tests.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+if [ $# -lt 3 ]; then
+  echo "usage: $0 <db-name> <db-user> <db-pass> [db-host] [wp-version] [wc-version]"
+  exit 1
+fi
+
+DB_NAME=$1
+DB_USER=$2
+DB_PASS=$3
+DB_HOST=${4-localhost}
+WP_VERSION=${5-latest}
+WC_VERSION=${6-latest}
+
+cd $(dirname "$0")
+source ./unit-tests-functions.sh
+cd -
+
+PLUGINS_TMP_DIR="$TMPDIR/tmp_plugins"
+echo "$PLUGINS_TMP_DIR"
+
+mkdir -p "$PLUGINS_TMP_DIR"
+rm -rf "$PLUGINS_TMP_DIR"/*
+mv "$PLUGINS_DIR"/*/ "$PLUGINS_TMP_DIR" || true
+install_wp $WP_VERSION
+mv -n "$PLUGINS_TMP_DIR"/* "$PLUGINS_DIR" || true
+install_wc $WC_VERSION
+install_test_suite $DB_NAME $DB_USER $DB_PASS $DB_HOST $WP_VERSION

--- a/bin/unit-tests-functions.sh
+++ b/bin/unit-tests-functions.sh
@@ -119,7 +119,7 @@ install_test_suite() {
     local WP_TESTS_TAG="tags/$LATEST_VERSION"
   fi
 
-  echo "Install test suit ${WP_TESTS_TAG}"
+  echo "Install test suite ${WP_TESTS_TAG}"
 
   # portable in-place argument for both GNU sed and Mac OSX sed
   if [[ $(uname -s) == 'Darwin' ]]; then

--- a/bin/unit-tests-functions.sh
+++ b/bin/unit-tests-functions.sh
@@ -1,0 +1,256 @@
+#!/usr/bin/env bash
+
+TMPDIR=${TMPDIR-/tmp}
+TMPDIR=$(echo $TMPDIR | sed -e "s/\/$//")
+WP_TESTS_DIR=${WP_TESTS_DIR-$TMPDIR/wordpress-tests-lib}
+WP_CORE_DIR=${WP_CORE_DIR-$TMPDIR/wordpress}
+
+# Plugin variables.
+PLUGINS_DIR="${WP_CORE_DIR}/wp-content/plugins"
+
+download() {
+  if [ $(which curl) ]; then
+    curl -s "$1" >"$2"
+  elif [ $(which wget) ]; then
+    wget -nv -O "$2" "$1"
+  fi
+}
+
+get_latest_wp_version() {
+  # http serves a single offer, whereas https serves multiple. we only want one
+  download http://api.wordpress.org/core/version-check/1.7/ "${TMPDIR}/wp-latest.json"
+  local LATEST_VERSION=$(grep -o '"version":"[^"]*' "${TMPDIR}/wp-latest.json" | sed 's/"version":"//')
+  if [[ -z "$LATEST_VERSION" ]]; then
+    echo "Latest WordPress version could not be found"
+    exit 1
+  fi
+  echo $LATEST_VERSION
+}
+
+cleanup() {
+  if [ -d "$WP_CORE_DIR" ]; then
+    rm -rf "$WP_CORE_DIR"
+  fi
+
+  if [ -d "$WP_TESTS_DIR" ]; then
+    rm -rf "$WP_TESTS_DIR"
+  fi
+}
+
+install_wp() {
+  local WP_VERSION=$1
+
+  if [[ $WP_VERSION == 'nightly' || $WP_VERSION == 'trunk' ]]; then
+    echo "Installing WordPress ($WP_VERSION)."
+    cleanup
+    mkdir -p "$WP_CORE_DIR"
+    mkdir -p "$TMPDIR"/wordpress-trunk
+    rm -rf "$TMPDIR"/wordpress-trunk/*
+    svn export --quiet https://core.svn.wordpress.org/trunk "$TMPDIR"/wordpress-trunk/wordpress
+    mv "$TMPDIR"/wordpress-trunk/wordpress/* "$WP_CORE_DIR"
+  else
+    if [ $WP_VERSION == 'latest' ]; then
+      local ARCHIVE_NAME='latest'
+      local LATEST_VERSION=$(get_latest_wp_version)
+    elif [[ $WP_VERSION =~ [0-9]+\.[0-9]+ ]]; then
+      # https serves multiple offers, whereas http serves single.
+      download https://api.wordpress.org/core/version-check/1.7/ "$TMPDIR"/wp-latest.json
+      if [[ $WP_VERSION =~ [0-9]+\.[0-9]+\.[0] ]]; then
+        # version x.x.0 means the first release of the major version, so strip off the .0 and download version x.x
+        local LATEST_VERSION=${WP_VERSION%??}
+      else
+        # otherwise, scan the releases and get the most up to date minor version of the major release
+        local VERSION_ESCAPED=$(echo $WP_VERSION | sed 's/\./\\./g')
+        local LATEST_VERSION=$(grep -o '"version":"'$VERSION_ESCAPED'[^"]*' "$TMPDIR"/wp-latest.json | sed 's/"version":"//' | head -1)
+      fi
+      if [[ -z "$LATEST_VERSION" ]]; then
+        local ARCHIVE_NAME="wordpress-$WP_VERSION"
+      else
+        local ARCHIVE_NAME="wordpress-$LATEST_VERSION"
+      fi
+    else
+      local ARCHIVE_NAME="wordpress-$WP_VERSION"
+    fi
+
+    local TARGET_VERSION=${LATEST_VERSION:-$WP_VERSION}
+    local WP_VERSION_FILE="${WP_CORE_DIR}/version-"$(echo $TARGET_VERSION | sed -e "s/\//-/")
+
+    if [ -f "$WP_VERSION_FILE" ]; then
+      echo "WordPress ($TARGET_VERSION) already installed."
+      return 0
+    fi
+
+    echo "Installing WordPress ($TARGET_VERSION)."
+    cleanup
+    mkdir -p "$WP_CORE_DIR"
+    download https://wordpress.org/${ARCHIVE_NAME}.tar.gz "$TMPDIR"/wordpress.tar.gz
+    tar --strip-components=1 -zxmf "$TMPDIR"/wordpress.tar.gz -C "$WP_CORE_DIR"
+    touch "$WP_VERSION_FILE"
+  fi
+
+  download https://raw.github.com/markoheijnen/wp-mysqli/master/db.php "$WP_CORE_DIR"/wp-content/db.php
+}
+
+install_test_suite() {
+  local DB_NAME=$1
+  local DB_USER=$2
+  local DB_PASS=$3
+  local DB_HOST=$4
+  local WP_VERSION=$5
+
+  # resolve WP_TESTS_TAG from WP_VERSION
+  if [[ $WP_VERSION =~ ^[0-9]+\.[0-9]+\-(beta|RC)[0-9]+$ ]]; then
+    local WP_BRANCH=${WP_VERSION%\-*}
+    local WP_TESTS_TAG="branches/$WP_BRANCH"
+
+  elif [[ $WP_VERSION =~ ^[0-9]+\.[0-9]+$ ]]; then
+    local WP_TESTS_TAG="branches/$WP_VERSION"
+  elif [[ $WP_VERSION =~ [0-9]+\.[0-9]+\.[0-9]+ ]]; then
+    if [[ $WP_VERSION =~ [0-9]+\.[0-9]+\.[0] ]]; then
+      # version x.x.0 means the first release of the major version, so strip off the .0 and download version x.x
+      local WP_TESTS_TAG="tags/${WP_VERSION%??}"
+    else
+      local WP_TESTS_TAG="tags/$WP_VERSION"
+    fi
+  elif [[ $WP_VERSION == 'nightly' || $WP_VERSION == 'trunk' ]]; then
+    local WP_TESTS_TAG="trunk"
+  else
+    local LATEST_VERSION=$(get_latest_wp_version)
+    local WP_TESTS_TAG="tags/$LATEST_VERSION"
+  fi
+
+  echo "Install test suit ${WP_TESTS_TAG}"
+
+  # portable in-place argument for both GNU sed and Mac OSX sed
+  if [[ $(uname -s) == 'Darwin' ]]; then
+    local ioption='-i.bak'
+  else
+    local ioption='-i'
+  fi
+
+  if [ -d "$WP_TESTS_DIR" ]; then
+    rm -rf "$WP_TESTS_DIR"/{includes,data}
+  fi
+
+  # set up testing suite
+  mkdir -p "$WP_TESTS_DIR"
+  svn export --quiet --ignore-externals https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/includes/ "$WP_TESTS_DIR"/includes
+  svn export --quiet --ignore-externals https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/data/ "$WP_TESTS_DIR"/data
+
+  # set up wp-tests-config.php file
+  local CONFIG_FILE="${WP_TESTS_DIR}/wp-tests-config.php"
+  download https://develop.svn.wordpress.org/${WP_TESTS_TAG}/wp-tests-config-sample.php "$CONFIG_FILE"
+  # remove all forward slashes in the end
+  local WP_CORE_DIR_FOR_CONFIG=$(echo $WP_CORE_DIR | sed "s:/\+$::")
+  sed $ioption "s:dirname( __FILE__ ) . '/src/':'$WP_CORE_DIR_FOR_CONFIG/':" "$CONFIG_FILE"
+  sed $ioption "s:__DIR__ . '/src/':'$WP_CORE_DIR_FOR_CONFIG/':" "$CONFIG_FILE"
+  sed $ioption "s/youremptytestdbnamehere/$DB_NAME/" "$CONFIG_FILE"
+  sed $ioption "s/yourusernamehere/$DB_USER/" "$CONFIG_FILE"
+  sed $ioption "s/yourpasswordhere/$DB_PASS/" "$CONFIG_FILE"
+  sed $ioption "s|localhost|${DB_HOST}|" "$CONFIG_FILE"
+}
+
+recreate_db() {
+  local DB_NAME=$1
+  local DB_USER=$2
+  local DB_PASS=$3
+  local DELETE_EXISTING_DB=$4
+
+  shopt -s nocasematch
+  if [[ $DELETE_EXISTING_DB =~ ^(y|yes)$ ]]; then
+    mysqladmin drop $DB_NAME -f --user="$DB_USER" --password="$DB_PASS"$EXTRA
+    create_db $DB_NAME $DB_USER $DB_PASS
+    echo "Recreated the database ($DB_NAME)."
+  else
+    echo "Leaving the existing database ($DB_NAME) in place."
+  fi
+  shopt -u nocasematch
+}
+
+create_db() {
+  local DB_NAME=$1
+  local DB_USER=$2
+  local DB_PASS=$3
+
+  mysqladmin create $DB_NAME --user="$DB_USER" --password="$DB_PASS"$EXTRA
+}
+
+install_db() {
+  local DB_NAME=$1
+  local DB_USER=$2
+  local DB_PASS=$3
+  local DB_HOST=$4
+  local SKIP_DB_CREATE=$5
+
+  if [ ${SKIP_DB_CREATE} = "true" ]; then
+    return 0
+  fi
+
+  # parse DB_HOST for port or socket references
+  local PARTS=(${DB_HOST//\:/ })
+  local DB_HOSTNAME=${PARTS[0]}
+  local DB_SOCK_OR_PORT=${PARTS[1]}
+  local EXTRA=""
+
+  if ! [ -z $DB_HOSTNAME ]; then
+    if [ $(echo $DB_SOCK_OR_PORT | grep -e '^[0-9]\{1,\}$') ]; then
+      EXTRA=" --host=$DB_HOSTNAME --port=$DB_SOCK_OR_PORT --protocol=tcp"
+    elif ! [ -z $DB_SOCK_OR_PORT ]; then
+      EXTRA=" --socket=$DB_SOCK_OR_PORT"
+    elif ! [ -z $DB_HOSTNAME ]; then
+      EXTRA=" --host=$DB_HOSTNAME --protocol=tcp"
+    fi
+  fi
+
+  # create database
+  if [ $(mysql --user="$DB_USER" --password="$DB_PASS"$EXTRA --execute='show databases;' | grep ^$DB_NAME$) ]; then
+    echo "Reinstalling will delete the existing test database ($DB_NAME)"
+    read -p 'Are you sure you want to proceed? [y/N]: ' DELETE_EXISTING_DB
+    recreate_db $DB_NAME $DB_USER $DB_PASS $DELETE_EXISTING_DB
+  else
+    create_db $DB_NAME $DB_USER $DB_PASS
+  fi
+}
+
+install_wc() {
+  local WC_VERSION=$1
+  local WC_DIR="${PLUGINS_DIR}/woocommerce"
+
+  # Get latest WC version
+  if [[ $WC_VERSION == 'latest' ]]; then
+    download https://api.wordpress.org/plugins/info/1.0/woocommerce.json "${TMPDIR}/wc-latest.json"
+    local WC_LATEST_VERSION=$(grep -o '"version":"[^"]*' "${TMPDIR}/wc-latest.json" | sed 's/"version":"//')
+    if [[ -z "$WC_LATEST_VERSION" ]]; then
+      echo "Latest WooCommerce version could not be found"
+      exit 1
+    fi
+    local WC_VERSION=$WC_LATEST_VERSION
+  fi
+
+  local WC_VERSION_FILE="${WC_DIR}/version-"$(echo $WC_VERSION | sed -e "s/\//-/")
+  if [ ! -f "$WC_VERSION_FILE" ]; then
+    rm -rf "$WC_DIR"
+    mkdir -p "$WC_DIR"
+    echo "Installing WooCommerce ($WC_VERSION)."
+
+    local WC_TMPDIR="${TMPDIR}/woocommerce-${WC_VERSION}"
+    rm -rf "${WC_TMPDIR}"
+    git clone --quiet --depth=1 --branch="${WC_VERSION}" https://github.com/woocommerce/woocommerce.git "${WC_TMPDIR}"
+    mv "${WC_TMPDIR}"/plugins/woocommerce/* "$WC_DIR"
+    touch "$WC_VERSION_FILE"
+
+    # Install composer for WooCommerce
+    cd "${WC_DIR}"
+    composer install --ignore-platform-reqs --no-interaction --no-dev
+
+    # Generate feature config for WooCommerce
+    local GENERATE_FEATURE_CONFIG=bin/generate-feature-config.php
+    if [ -f $GENERATE_FEATURE_CONFIG ]; then
+      php $GENERATE_FEATURE_CONFIG
+    fi
+
+    cd -
+  else
+    echo "WooCommerce ($WC_VERSION) already installed."
+  fi
+}

--- a/composer.json
+++ b/composer.json
@@ -15,5 +15,8 @@
         "exussum12/coverage-checker": "^1.0",
         "phpunit/phpunit": "^9.5",
         "yoast/phpunit-polyfills": "^1.0"
+    },
+    "autoload": {
+        "psr-4": { "GoogleAnalyticsIntegration\\Tests\\": "tests/" }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,8 @@
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "^v0.7",
         "wp-coding-standards/wpcs": "^2.3",
-        "exussum12/coverage-checker": "^1.0"
+        "exussum12/coverage-checker": "^1.0",
+        "phpunit/phpunit": "^9.5",
+        "yoast/phpunit-polyfills": "^1.0"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e93271c1a3ad85f3c745c20de2bdc8e8",
+    "content-hash": "ace93dcb2663aefb52cf3f91ebc4e52c",
     "packages": [],
     "packages-dev": [
         {
@@ -76,11 +76,73 @@
                 "stylecheck",
                 "tests"
             ],
-            "support": {
-                "issues": "https://github.com/dealerdirect/phpcodesniffer-composer-installer/issues",
-                "source": "https://github.com/dealerdirect/phpcodesniffer-composer-installer"
-            },
             "time": "2022-02-04T12:51:07+00:00"
+        },
+        {
+            "name": "doctrine/instantiator",
+            "version": "1.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/instantiator.git",
+                "reference": "0a0fa9780f5d4e507415a065172d26a98d02047b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/0a0fa9780f5d4e507415a065172d26a98d02047b",
+                "reference": "0a0fa9780f5d4e507415a065172d26a98d02047b",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^9 || ^11",
+                "ext-pdo": "*",
+                "ext-phar": "*",
+                "phpbench/phpbench": "^0.16 || ^1",
+                "phpstan/phpstan": "^1.4",
+                "phpstan/phpstan-phpunit": "^1",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
+                "vimeo/psalm": "^4.30 || ^5.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com",
+                    "homepage": "https://ocramius.github.io/"
+                }
+            ],
+            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
+            "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
+            "keywords": [
+                "constructor",
+                "instantiate"
+            ],
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Finstantiator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-12-30T00:15:36+00:00"
         },
         {
             "name": "exussum12/coverage-checker",
@@ -126,11 +188,62 @@
                 }
             ],
             "description": "Allows checking the code coverage of a single pull request",
-            "support": {
-                "issues": "https://github.com/exussum12/coverageChecker/issues",
-                "source": "https://github.com/exussum12/coverageChecker/tree/1.0.2"
-            },
             "time": "2022-01-19T14:42:51+00:00"
+        },
+        {
+            "name": "myclabs/deep-copy",
+            "version": "1.11.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "14daed4296fae74d9e3201d2c4925d1acb7aa614"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/14daed4296fae74d9e3201d2c4925d1acb7aa614",
+                "reference": "14daed4296fae74d9e3201d2c4925d1acb7aa614",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "doctrine/collections": "<1.6.8",
+                "doctrine/common": "<2.13.3 || >=3,<3.2.2"
+            },
+            "require-dev": {
+                "doctrine/collections": "^1.6.8",
+                "doctrine/common": "^2.13.3 || ^3.2.2",
+                "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ],
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-03-03T13:19:32+00:00"
         },
         {
             "name": "nikic/php-parser",
@@ -182,11 +295,1406 @@
                 "parser",
                 "php"
             ],
-            "support": {
-                "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.14.0"
-            },
             "time": "2022-05-31T20:59:12+00:00"
+        },
+        {
+            "name": "phar-io/manifest",
+            "version": "2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "97803eca37d319dfa7826cc2437fc020857acb53"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/97803eca37d319dfa7826cc2437fc020857acb53",
+                "reference": "97803eca37d319dfa7826cc2437fc020857acb53",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-phar": "*",
+                "ext-xmlwriter": "*",
+                "phar-io/version": "^3.0.1",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "time": "2021-07-20T11:28:43+00:00"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "9.2.23",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "9f1f0f9a2fbb680b26d1cf9b61b6eac43a6e4e9c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/9f1f0f9a2fbb680b26d1cf9b61b6eac43a6e4e9c",
+                "reference": "9f1f0f9a2fbb680b26d1cf9b61b6eac43a6e4e9c",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-xmlwriter": "*",
+                "nikic/php-parser": "^4.14",
+                "php": ">=7.3",
+                "phpunit/php-file-iterator": "^3.0.3",
+                "phpunit/php-text-template": "^2.0.2",
+                "sebastian/code-unit-reverse-lookup": "^2.0.2",
+                "sebastian/complexity": "^2.0",
+                "sebastian/environment": "^5.1.2",
+                "sebastian/lines-of-code": "^1.0.3",
+                "sebastian/version": "^3.0.1",
+                "theseer/tokenizer": "^1.2.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-pcov": "*",
+                "ext-xdebug": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "9.2-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
+            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
+            "keywords": [
+                "coverage",
+                "testing",
+                "xunit"
+            ],
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-12-28T12:41:10+00:00"
+        },
+        {
+            "name": "phpunit/php-file-iterator",
+            "version": "3.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
+                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
+                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
+            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
+            "keywords": [
+                "filesystem",
+                "iterator"
+            ],
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-12-02T12:48:52+00:00"
+        },
+        {
+            "name": "phpunit/php-invoker",
+            "version": "3.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-invoker.git",
+                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
+                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "ext-pcntl": "*",
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-pcntl": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Invoke callables with a timeout",
+            "homepage": "https://github.com/sebastianbergmann/php-invoker/",
+            "keywords": [
+                "process"
+            ],
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T05:58:55+00:00"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Simple template engine.",
+            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
+            "keywords": [
+                "template"
+            ],
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T05:33:50+00:00"
+        },
+        {
+            "name": "phpunit/php-timer",
+            "version": "5.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Utility class for timing",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
+            "keywords": [
+                "timer"
+            ],
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:16:10+00:00"
+        },
+        {
+            "name": "phpunit/phpunit",
+            "version": "9.5.27",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit.git",
+                "reference": "a2bc7ffdca99f92d959b3f2270529334030bba38"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/a2bc7ffdca99f92d959b3f2270529334030bba38",
+                "reference": "a2bc7ffdca99f92d959b3f2270529334030bba38",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "^1.3.1",
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xml": "*",
+                "ext-xmlwriter": "*",
+                "myclabs/deep-copy": "^1.10.1",
+                "phar-io/manifest": "^2.0.3",
+                "phar-io/version": "^3.0.2",
+                "php": ">=7.3",
+                "phpunit/php-code-coverage": "^9.2.13",
+                "phpunit/php-file-iterator": "^3.0.5",
+                "phpunit/php-invoker": "^3.1.1",
+                "phpunit/php-text-template": "^2.0.3",
+                "phpunit/php-timer": "^5.0.2",
+                "sebastian/cli-parser": "^1.0.1",
+                "sebastian/code-unit": "^1.0.6",
+                "sebastian/comparator": "^4.0.8",
+                "sebastian/diff": "^4.0.3",
+                "sebastian/environment": "^5.1.3",
+                "sebastian/exporter": "^4.0.5",
+                "sebastian/global-state": "^5.0.1",
+                "sebastian/object-enumerator": "^4.0.3",
+                "sebastian/resource-operations": "^3.0.3",
+                "sebastian/type": "^3.2",
+                "sebastian/version": "^3.0.2"
+            },
+            "suggest": {
+                "ext-soap": "*",
+                "ext-xdebug": "*"
+            },
+            "bin": [
+                "phpunit"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "9.5-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Framework/Assert/Functions.php"
+                ],
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "The PHP Unit Testing framework.",
+            "homepage": "https://phpunit.de/",
+            "keywords": [
+                "phpunit",
+                "testing",
+                "xunit"
+            ],
+            "funding": [
+                {
+                    "url": "https://phpunit.de/sponsors.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-12-09T07:31:23+00:00"
+        },
+        {
+            "name": "sebastian/cli-parser",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/cli-parser.git",
+                "reference": "442e7c7e687e42adc03470c7b668bc4b2402c0b2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/442e7c7e687e42adc03470c7b668bc4b2402c0b2",
+                "reference": "442e7c7e687e42adc03470c7b668bc4b2402c0b2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for parsing CLI options",
+            "homepage": "https://github.com/sebastianbergmann/cli-parser",
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T06:08:49+00:00"
+        },
+        {
+            "name": "sebastian/code-unit",
+            "version": "1.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit.git",
+                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/code-unit",
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:08:54+00:00"
+        },
+        {
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Looks up which function or method a line of code belongs to",
+            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T05:30:19+00:00"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "4.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "fa0f136dd2334583309d32b62544682ee972b51a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/fa0f136dd2334583309d32b62544682ee972b51a",
+                "reference": "fa0f136dd2334583309d32b62544682ee972b51a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/diff": "^4.0",
+                "sebastian/exporter": "^4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                }
+            ],
+            "description": "Provides the functionality to compare PHP values for equality",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
+            "keywords": [
+                "comparator",
+                "compare",
+                "equality"
+            ],
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-09-14T12:41:17+00:00"
+        },
+        {
+            "name": "sebastian/complexity",
+            "version": "2.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/complexity.git",
+                "reference": "739b35e53379900cc9ac327b2147867b8b6efd88"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/739b35e53379900cc9ac327b2147867b8b6efd88",
+                "reference": "739b35e53379900cc9ac327b2147867b8b6efd88",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.7",
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for calculating the complexity of PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/complexity",
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T15:52:27+00:00"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "4.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "3461e3fccc7cfdfc2720be910d3bd73c69be590d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/3461e3fccc7cfdfc2720be910d3bd73c69be590d",
+                "reference": "3461e3fccc7cfdfc2720be910d3bd73c69be590d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3",
+                "symfony/process": "^4.2 || ^5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "https://github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
+            ],
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:10:38+00:00"
+        },
+        {
+            "name": "sebastian/environment",
+            "version": "5.1.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/environment.git",
+                "reference": "1b5dff7bb151a4db11d49d90e5408e4e938270f7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/1b5dff7bb151a4db11d49d90e5408e4e938270f7",
+                "reference": "1b5dff7bb151a4db11d49d90e5408e4e938270f7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-posix": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides functionality to handle HHVM/PHP environments",
+            "homepage": "http://www.github.com/sebastianbergmann/environment",
+            "keywords": [
+                "Xdebug",
+                "environment",
+                "hhvm"
+            ],
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-04-03T09:37:03+00:00"
+        },
+        {
+            "name": "sebastian/exporter",
+            "version": "4.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/exporter.git",
+                "reference": "ac230ed27f0f98f597c8a2b6eb7ac563af5e5b9d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/ac230ed27f0f98f597c8a2b6eb7ac563af5e5b9d",
+                "reference": "ac230ed27f0f98f597c8a2b6eb7ac563af5e5b9d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "ext-mbstring": "*",
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Provides the functionality to export PHP variables for visualization",
+            "homepage": "https://www.github.com/sebastianbergmann/exporter",
+            "keywords": [
+                "export",
+                "exporter"
+            ],
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-09-14T06:03:37+00:00"
+        },
+        {
+            "name": "sebastian/global-state",
+            "version": "5.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/global-state.git",
+                "reference": "0ca8db5a5fc9c8646244e629625ac486fa286bf2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/0ca8db5a5fc9c8646244e629625ac486fa286bf2",
+                "reference": "0ca8db5a5fc9c8646244e629625ac486fa286bf2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/object-reflector": "^2.0",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "ext-dom": "*",
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-uopz": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Snapshotting of global state",
+            "homepage": "http://www.github.com/sebastianbergmann/global-state",
+            "keywords": [
+                "global state"
+            ],
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-02-14T08:28:10+00:00"
+        },
+        {
+            "name": "sebastian/lines-of-code",
+            "version": "1.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/lines-of-code.git",
+                "reference": "c1c2e997aa3146983ed888ad08b15470a2e22ecc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/c1c2e997aa3146983ed888ad08b15470a2e22ecc",
+                "reference": "c1c2e997aa3146983ed888ad08b15470a2e22ecc",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.6",
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for counting the lines of code in PHP source code",
+            "homepage": "https://github.com/sebastianbergmann/lines-of-code",
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-28T06:42:11+00:00"
+        },
+        {
+            "name": "sebastian/object-enumerator",
+            "version": "4.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/5c9eeac41b290a3712d88851518825ad78f45c71",
+                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/object-reflector": "^2.0",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:12:34+00:00"
+        },
+        {
+            "name": "sebastian/object-reflector",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-reflector.git",
+                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:14:26+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "4.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "cd9d8cf3c5804de4341c283ed787f099f5506172"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/cd9d8cf3c5804de4341c283ed787f099f5506172",
+                "reference": "cd9d8cf3c5804de4341c283ed787f099f5506172",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides functionality to recursively process PHP variables",
+            "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:17:30+00:00"
+        },
+        {
+            "name": "sebastian/resource-operations",
+            "version": "3.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/resource-operations.git",
+                "reference": "0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8",
+                "reference": "0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides a list of PHP built-in functions that operate on resources",
+            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T06:45:17+00:00"
+        },
+        {
+            "name": "sebastian/type",
+            "version": "3.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/type.git",
+                "reference": "fb3fe09c5f0bae6bc27ef3ce933a1e0ed9464b6e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/fb3fe09c5f0bae6bc27ef3ce933a1e0ed9464b6e",
+                "reference": "fb3fe09c5f0bae6bc27ef3ce933a1e0ed9464b6e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.2-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the types of the PHP type system",
+            "homepage": "https://github.com/sebastianbergmann/type",
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-09-12T14:47:03+00:00"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "c6c1022351a901512170118436c764e473f6de8c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c6c1022351a901512170118436c764e473f6de8c",
+                "reference": "c6c1022351a901512170118436c764e473f6de8c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
+            "homepage": "https://github.com/sebastianbergmann/version",
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T06:39:44+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
@@ -237,12 +1745,53 @@
                 "phpcs",
                 "standards"
             ],
-            "support": {
-                "issues": "https://github.com/squizlabs/PHP_CodeSniffer/issues",
-                "source": "https://github.com/squizlabs/PHP_CodeSniffer",
-                "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
-            },
             "time": "2022-06-18T07:21:10+00:00"
+        },
+        {
+            "name": "theseer/tokenizer",
+            "version": "1.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "34a41e998c2183e22995f158c581e7b5e755ab9e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/34a41e998c2183e22995f158c581e7b5e755ab9e",
+                "reference": "34a41e998c2183e22995f158c581e7b5e755ab9e",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-07-28T10:34:58+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",
@@ -288,12 +1837,64 @@
                 "standards",
                 "wordpress"
             ],
-            "support": {
-                "issues": "https://github.com/WordPress/WordPress-Coding-Standards/issues",
-                "source": "https://github.com/WordPress/WordPress-Coding-Standards",
-                "wiki": "https://github.com/WordPress/WordPress-Coding-Standards/wiki"
-            },
             "time": "2020-05-13T23:57:56+00:00"
+        },
+        {
+            "name": "yoast/phpunit-polyfills",
+            "version": "1.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
+                "reference": "3c621ff5429d2b1ff96dc5808ad6cde99d31ea4c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/3c621ff5429d2b1ff96dc5808ad6cde99d31ea4c",
+                "reference": "3c621ff5429d2b1ff96dc5808ad6cde99d31ea4c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4",
+                "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
+            },
+            "require-dev": {
+                "yoast/yoastcs": "^2.2.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.x-dev",
+                    "dev-develop": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "phpunitpolyfills-autoload.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Team Yoast",
+                    "email": "support@yoast.com",
+                    "homepage": "https://yoast.com"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/Yoast/PHPUnit-Polyfills/graphs/contributors"
+                }
+            ],
+            "description": "Set of polyfills for changed PHPUnit functionality to allow for creating PHPUnit cross-version compatible tests",
+            "homepage": "https://github.com/Yoast/PHPUnit-Polyfills",
+            "keywords": [
+                "phpunit",
+                "polyfill",
+                "testing"
+            ],
+            "time": "2022-11-16T09:07:52+00:00"
         }
     ],
     "aliases": [],
@@ -303,5 +1904,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "1.1.0"
 }

--- a/includes/class-wc-abstract-google-analytics-js.php
+++ b/includes/class-wc-abstract-google-analytics-js.php
@@ -201,7 +201,7 @@ abstract class WC_Abstract_Google_Analytics_JS {
 	 * @param  WC_Product $_product  Product to pull info for
 	 * @return string                Line of JSON
 	 */
-	protected static function product_get_variant_line( $_product ) {
+	public static function product_get_variant_line( $_product ) {
 		$out            = '';
 		$variation_data = $_product->is_type( 'variation' ) ? wc_get_product_variation_attributes( $_product->get_id() ) : false;
 

--- a/includes/class-wc-google-gtag-js.php
+++ b/includes/class-wc-google-gtag-js.php
@@ -146,7 +146,7 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 	 * @return string
 	 */
 	public static function get_list_name(): string {
-		return isset( $_GET['s'] ) ? __( 'Search Results', 'woocommerce-google-analytics-integration' ) : __( 'Product List', 'woocommerce-google-analytics-integration' );
+		return isset( $_GET['s'] ) ? __( 'Search Results', 'woocommerce-google-analytics-integration' ) : __( 'Product List', 'woocommerce-google-analytics-integration' ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 	}
 
 	/**
@@ -164,7 +164,6 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 						'id'            => self::get_product_identifier( $product ),
 						'name'          => $product->get_title(),
 						'category'      => self::product_get_category_line( $product ),
-						// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 						'list'          => self::get_list_name(),
 						'list_position' => $position,
 					),

--- a/includes/class-wc-google-gtag-js.php
+++ b/includes/class-wc-google-gtag-js.php
@@ -318,7 +318,7 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 	 * @param  WC_Order $order
 	 * @return string
 	 */
-	protected function add_transaction_enhanced( $order ) {
+	public function add_transaction_enhanced( $order ) {
 		$event_items = array();
 		$order_items = $order->get_items();
 		if ( ! empty( $order_items ) ) {
@@ -347,7 +347,7 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 	 * @param WC_Order      $order WC_Order Object
 	 * @param WC_Order_Item $item  The item to add to a transaction/order
 	 */
-	protected function add_item( $order, $item ) {
+	public function add_item( $order, $item ) {
 		$product = $item->get_product();
 		$variant = self::product_get_variant_line( $product );
 

--- a/includes/class-wc-google-gtag-js.php
+++ b/includes/class-wc-google-gtag-js.php
@@ -146,7 +146,8 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 	 * @return string
 	 */
 	public static function get_list_name(): string {
-		return isset( $_GET['s'] ) ? __( 'Search Results', 'woocommerce-google-analytics-integration' ) : __( 'Product List', 'woocommerce-google-analytics-integration' ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		return isset( $_GET['s'] ) ? __( 'Search Results', 'woocommerce-google-analytics-integration' ) : __( 'Product List', 'woocommerce-google-analytics-integration' );
 	}
 
 	/**

--- a/includes/class-wc-google-gtag-js.php
+++ b/includes/class-wc-google-gtag-js.php
@@ -141,6 +141,15 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 	}
 
 	/**
+	 * Return list name for event
+	 *
+	 * @return string
+	 */
+	public static function get_list_name(): string {
+		return isset( $_GET['s'] ) ? __( 'Search Results', 'woocommerce-google-analytics-integration' ) : __( 'Product List', 'woocommerce-google-analytics-integration' );
+	}
+
+	/**
 	 * Enqueues JavaScript to build the view_item_list event
 	 *
 	 * @param WC_Product $product
@@ -156,7 +165,7 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 						'name'          => $product->get_title(),
 						'category'      => self::product_get_category_line( $product ),
 						// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-						'list'          => isset( $_GET['s'] ) ? __( 'Search Results', 'woocommerce-google-analytics-integration' ) : __( 'Product List', 'woocommerce-google-analytics-integration' ),
+						'list'          => self::get_list_name(),
 						'list_position' => $position,
 					),
 				),

--- a/includes/class-wc-google-gtag-js.php
+++ b/includes/class-wc-google-gtag-js.php
@@ -161,7 +161,7 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 			array(
 				'items' => array(
 					array(
-						'id'            => $product->get_id(),
+						'id'            => self::get_product_identifier( $product ),
 						'name'          => $product->get_title(),
 						'category'      => self::product_get_category_line( $product ),
 						// phpcs:ignore WordPress.Security.NonceVerification.Recommended

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -11,10 +11,11 @@
 			<directory suffix=".php">./tests/unit-tests</directory>
 		</testsuite>
 	</testsuites>
-	<filter>
-		<whitelist addUncoveredFilesFromWhitelist="true">
+	<coverage>
+		<include>
 			<directory suffix=".php">./includes</directory>
+			<directory suffix=".php">./admin</directory>
 			<file>woocommerce-google-analytics-integration.php</file>
-		</whitelist>
-	</filter>
+		</include>
+	</coverage>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,20 @@
+<phpunit
+	bootstrap="tests/bootstrap.php"
+	backupGlobals="false"
+	colors="true"
+	convertErrorsToExceptions="true"
+	convertNoticesToExceptions="true"
+	convertWarningsToExceptions="true"
+	>
+	<testsuites>
+		<testsuite name="basic">
+			<directory suffix=".php">./tests/unit-tests</directory>
+		</testsuite>
+	</testsuites>
+	<filter>
+		<whitelist addUncoveredFilesFromWhitelist="true">
+			<directory suffix=".php">./includes</directory>
+			<file>woocommerce-google-analytics-integration.php</file>
+		</whitelist>
+	</filter>
+</phpunit>

--- a/tests/EventsDataTest.php
+++ b/tests/EventsDataTest.php
@@ -13,7 +13,7 @@ use MockAction;
  *
  * @since x.x.x
  */
-abstract class UnitTest extends WP_UnitTestCase {
+abstract class EventsDataTest extends WP_UnitTestCase {
 
 	/** @var WC_Product */
 	private static $product;

--- a/tests/UnitTest.php
+++ b/tests/UnitTest.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace GoogleAnalyticsIntegration\Tests;
+
+use WP_UnitTestCase;
+use WC_Helper_Product;
+use WC_Helper_Customer;
+use WC_Helper_Order;
+use MockAction;
+
+/**
+ * Class UnitTest
+ *
+ * @since x.x.x
+ */
+abstract class UnitTest extends WP_UnitTestCase {
+
+	/** @var WC_Product */
+	private static $product;
+
+	/** @var WC_Customer */
+	private static $customer;
+
+	/** @var WC_Order */
+	private static $order;
+
+	/** @var MockAction Mock WordPress action to allow us to intercept data */
+	public $filter;
+
+	/**
+	 * Setup mock filter and dummy product, order, and customer data
+	 *
+	 * @return void
+	 */
+	public function set_up() {
+		if ( is_null( $this->filter ) ) {
+			// Mock woocommerce_gtag_event_data filter to ensure it is called and the correct data is processed.
+			$this->filter = new MockAction();
+			add_filter( 'woocommerce_gtag_event_data', array( &$this->filter, 'filter' ) );
+		}
+
+		if ( is_null( self::$product ) ) {
+			self::$product = WC_Helper_Product::create_simple_product();
+		}
+
+		if ( is_null( self::$customer ) ) {
+			self::$customer = WC_Helper_Customer::create_customer( 'JD', 'pw', 'customer@unit.test' );
+		}
+
+		if ( is_null( self::$order ) ) {
+			self::$order = WC_Helper_Order::create_order( self::get_customer()->get_id(), self::get_product() );
+		}
+	}
+
+	/**
+	 * Get dummy product to run tests against
+	 *
+	 * @return WC_Product
+	 */
+	public function get_product() {
+		return self::$product;
+	}
+
+	/**
+	 * Get dummy customer to run tests against
+	 *
+	 * @return WC_Customer
+	 */
+	public function get_customer() {
+		return self::$customer;
+	}
+
+	/**
+	 * Get dummy order to run tests against
+	 *
+	 * @return WC_Order
+	 */
+	public function get_order() {
+		return static::$order;
+	}
+
+	/**
+	 * Get filter
+	 *
+	 * @since x.x.x
+	 */
+	public function get_filter() {
+		return $this->filter;
+	}
+
+	/**
+	 * Return call count for woocommerce_gtag_event_data filter
+	 *
+	 * @return int
+	 */
+	public function get_event_data_filter_call_count() {
+		return $this->get_filter()->get_call_count();
+	}
+
+	/**
+	 * Return data passed through woocommerce_gtag_event_data filter
+	 *
+	 * @return mixed
+	 */
+	public function get_event_data() {
+		$args = $this->get_filter()->get_args();
+		return $args[0][0];
+	}
+
+}

--- a/tests/UnitTest.php
+++ b/tests/UnitTest.php
@@ -82,7 +82,7 @@ abstract class UnitTest extends WP_UnitTestCase {
 	/**
 	 * Get filter
 	 *
-	 * @since x.x.x
+	 * @return MockAction
 	 */
 	public function get_filter() {
 		return $this->filter;

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,6 +1,6 @@
 <?php
 
-require 'bootstrap-class.php';
+require 'class-unittestsbootstrap.php';
 
 $bootstrap = new GoogleAnalyticsIntegration\UnitTestsBootstrap();
 $bootstrap->init();

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,6 @@
+<?php
+
+require 'bootstrap-class.php';
+
+$bootstrap = new GoogleAnalyticsIntegration\UnitTestsBootstrap();
+$bootstrap->init();

--- a/tests/class-unittestsbootstrap.php
+++ b/tests/class-unittestsbootstrap.php
@@ -1,0 +1,153 @@
+<?php
+// phpcs:ignoreFile
+
+namespace GoogleAnalyticsIntegration;
+
+/**
+ * Class to setup WooCommerce test environment for unit testing
+ */
+class UnitTestsBootstrap {
+
+	/** @var string directory where wordpress-tests-lib is installed */
+	public $wp_tests_dir;
+
+	/** @var string testing directory */
+	public $tests_dir;
+
+	/** @var string plugin directory */
+	public $plugin_dir;
+
+	/** @var string plugins directory Directory storing dependency plugins */
+	public $plugins_dir;
+
+	/**
+	 * Setup the unit testing environment
+	 */
+	public function init() {
+		$this->set_show_errors();
+		$this->set_path_props();
+		$this->set_server_props();
+
+		// load test function so tests_add_filter() is available
+		require_once $this->wp_tests_dir . '/includes/functions.php';
+
+		// load WC
+		tests_add_filter( 'muplugins_loaded', array( $this, 'load_plugins' ) );
+		tests_add_filter( 'setup_theme', array( $this, 'install_wc' ) );
+		tests_add_filter( 'option_active_plugins', [ $this, 'filter_active_plugins' ] );
+
+		// load the WP testing environment
+		require_once $this->wp_tests_dir . '/includes/bootstrap.php';
+
+		// load testing framework
+		$this->includes();
+	}
+
+
+	/**
+	 * Show errors.
+	 */
+	public function set_show_errors() {
+		ini_set( 'display_errors', 'on' );
+		error_reporting( E_ALL );
+	}
+
+	/**
+	 * Set directory paths.
+	 */
+	public function set_path_props() {
+		$this->tests_dir    = dirname( __FILE__ );
+		$this->plugin_dir   = dirname( $this->tests_dir );
+		$this->plugins_dir  = sys_get_temp_dir() . '/wordpress/wp-content/plugins';
+		$this->wp_tests_dir = sys_get_temp_dir() . '/wordpress-tests-lib';
+	}
+
+	/**
+	 * Set server props
+	 */
+	public function set_server_props() {
+		$_SERVER['REMOTE_ADDR'] = isset( $_SERVER['REMOTE_ADDR'] ) ? $_SERVER['REMOTE_ADDR'] : '';
+		$_SERVER['SERVER_NAME'] = isset( $_SERVER['SERVER_NAME'] ) ? $_SERVER['SERVER_NAME'] : 'ga_integration_test';
+	}
+
+	/**
+	 * @param array $option
+	 * @return array
+	 */
+	public function filter_active_plugins( $option ) {
+		$option[] = 'woocommerce-google-analytics-integration/woocommerce-google-analytics-integration.php';
+		return $option;
+	}
+
+	/**
+	 * Load WooCommerce
+	 */
+	public function load_plugins() {
+		require_once $this->plugins_dir . '/woocommerce/woocommerce.php';
+		require_once $this->plugin_dir . '/woocommerce-google-analytics-integration.php';
+		
+		update_option( 'woocommerce_db_version', WC()->version );
+		update_option( 'gmt_offset', -4 );
+	}
+
+	/**
+	 * Load WooCommerce for testing
+	 *
+	 * @since 2.0
+	 */
+	public function install_wc() {
+		echo 'Installing WooCommerce...' . PHP_EOL;
+
+		define( 'WP_UNINSTALL_PLUGIN', true );
+
+		include $this->plugins_dir . '/woocommerce/uninstall.php';
+
+		global $wpdb;
+		$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}woocommerce_attribute_taxonomies" );
+		$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}woocommerce_order_items" );
+		$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}woocommerce_order_itemmeta" );
+
+		\WC_Install::install();
+
+		// Ensure wc_category_lookup table exists (WC 6.5+)
+		add_action(
+			'init',
+			function() {
+				if ( class_exists( \Automattic\WooCommerce\Internal\Admin\CategoryLookup::class ) ) {
+					\Automattic\WooCommerce\Internal\Admin\CategoryLookup::instance()->regenerate();
+				}
+			},
+			11
+		);
+
+		new \WP_Roles();
+
+		WC()->init();
+
+		echo 'WooCommerce Finished Installing...' . PHP_EOL;
+
+	}
+
+	/**
+	 * Load test cases and factories
+	 *
+	 * @since 2.0
+	 */
+	public function includes() {
+		$wc_tests_dir = $this->plugins_dir . '/woocommerce/tests';
+
+		if ( file_exists( $this->plugins_dir . '/woocommerce/tests/legacy/bootstrap.php' ) ) {
+			$wc_tests_dir .= '/legacy';
+		}
+
+		require_once $wc_tests_dir . '/includes/wp-http-testcase.php';
+
+		// Load WC Helper Functions
+		require_once $wc_tests_dir . '/framework/helpers/class-wc-helper-coupon.php';
+		require_once $wc_tests_dir . '/framework/helpers/class-wc-helper-product.php';
+		require_once $wc_tests_dir . '/framework/helpers/class-wc-helper-order.php';
+		require_once $wc_tests_dir . '/framework/helpers/class-wc-helper-shipping.php';
+		require_once $wc_tests_dir . '/framework/helpers/class-wc-helper-customer.php';
+	}
+
+}

--- a/tests/class-unittestsbootstrap.php
+++ b/tests/class-unittestsbootstrap.php
@@ -148,6 +148,8 @@ class UnitTestsBootstrap {
 		require_once $wc_tests_dir . '/framework/helpers/class-wc-helper-order.php';
 		require_once $wc_tests_dir . '/framework/helpers/class-wc-helper-shipping.php';
 		require_once $wc_tests_dir . '/framework/helpers/class-wc-helper-customer.php';
+
+		require $this->tests_dir . '/UnitTest.php';
 	}
 
 }

--- a/tests/class-unittestsbootstrap.php
+++ b/tests/class-unittestsbootstrap.php
@@ -148,8 +148,6 @@ class UnitTestsBootstrap {
 		require_once $wc_tests_dir . '/framework/helpers/class-wc-helper-order.php';
 		require_once $wc_tests_dir . '/framework/helpers/class-wc-helper-shipping.php';
 		require_once $wc_tests_dir . '/framework/helpers/class-wc-helper-customer.php';
-
-		require $this->tests_dir . '/UnitTest.php';
 	}
 
 }

--- a/tests/unit-tests/AddTransactionEnhanced.php
+++ b/tests/unit-tests/AddTransactionEnhanced.php
@@ -1,0 +1,58 @@
+<?php
+// phpcs:ignoreFile
+
+namespace GoogleAnalyticsIntegration\Tests;
+
+use MockAction;
+use WP_UnitTestCase;
+use WC_Helper_Product;
+use WC_Helper_Customer;
+use WC_Helper_Order;
+use WC_Google_Gtag_JS;
+
+class AddTransactionEnhancedTest extends WP_UnitTestCase {
+
+	public function test_purchase_event() {
+		$product  = WC_Helper_Product::create_simple_product();
+		$customer = WC_Helper_Customer::create_customer( 'JD', 'pw', 'customer@unit.test' );
+		$order    = WC_Helper_Order::create_order( $customer->get_id(), $product );
+
+		// Mock woocommerce_gtag_event_data filter to ensure it is called and the correct data is processed
+		$filter = new MockAction();
+		add_filter( 'woocommerce_gtag_event_data', array( &$filter, 'filter' ) );
+
+		$gtag = new WC_Google_Gtag_JS();
+		$gtag->add_transaction_enhanced( $order );
+
+		// Confirm woocommerce_gtag_event_data is called by add_transaction_enhanced()
+		$this->assertEquals( 1, $filter->get_call_count(), 'woocommerce_gtag_event_data filter was not called for purchase (add_transaction_enhanced()) event' );
+
+		$order_items = $order->get_items();
+		$event_items = array();
+
+		if ( ! empty( $order_items ) ) {
+			foreach ( $order_items as $item ) {
+				$event_items[] = $gtag->add_item( $order, $item );
+			}
+		}
+
+		// The expected data structure for this event
+		$expected_data = array(
+			'transaction_id' => $order->get_order_number(),
+			'affiliation'    => get_bloginfo( 'name' ),
+			'value'          => $order->get_total(),
+			'tax'            => $order->get_total_tax(),
+			'shipping'       => $order->get_total_shipping(),
+			'currency'       => $order->get_currency(),
+			'items'          => $event_items,
+		);
+
+		// Get data passed to woocommerce_gtag_event_data filter
+		$args        = $filter->get_args();
+		$actual_data = $args[0][0];
+
+		// Confirm data structure matches what's expected
+		$this->assertEquals( $expected_data, $actual_data, 'Event data does not match expected data structure for purchase (add_transaction_enhanced()) event' );
+	}
+
+}

--- a/tests/unit-tests/AddTransactionEnhanced.php
+++ b/tests/unit-tests/AddTransactionEnhanced.php
@@ -1,31 +1,31 @@
 <?php
-// phpcs:ignoreFile
 
 namespace GoogleAnalyticsIntegration\Tests;
 
-use MockAction;
-use WP_UnitTestCase;
-use WC_Helper_Product;
-use WC_Helper_Customer;
-use WC_Helper_Order;
 use WC_Google_Gtag_JS;
 
-class AddTransactionEnhancedTest extends WP_UnitTestCase {
+/**
+ * Class AddTransactionEnhanced
+ *
+ * @since x.x.x
+ *
+ * @package GoogleAnalyticsIntegration\Tests
+ */
+class AddTransactionEnhanced extends UnitTest {
 
+	/**
+	 * Run unit test against the `purchase` event
+	 *
+	 * @return void
+	 */
 	public function test_purchase_event() {
-		$product  = WC_Helper_Product::create_simple_product();
-		$customer = WC_Helper_Customer::create_customer( 'JD', 'pw', 'customer@unit.test' );
-		$order    = WC_Helper_Order::create_order( $customer->get_id(), $product );
-
-		// Mock woocommerce_gtag_event_data filter to ensure it is called and the correct data is processed
-		$filter = new MockAction();
-		add_filter( 'woocommerce_gtag_event_data', array( &$filter, 'filter' ) );
+		$order = parent::get_order();
 
 		$gtag = new WC_Google_Gtag_JS();
 		$gtag->add_transaction_enhanced( $order );
 
-		// Confirm woocommerce_gtag_event_data is called by add_transaction_enhanced()
-		$this->assertEquals( 1, $filter->get_call_count(), 'woocommerce_gtag_event_data filter was not called for purchase (add_transaction_enhanced()) event' );
+		// Confirm woocommerce_gtag_event_data is called by add_transaction_enhanced().
+		$this->assertEquals( 1, parent::get_event_data_filter_call_count(), 'woocommerce_gtag_event_data filter was not called for purchase (add_transaction_enhanced()) event' );
 
 		$order_items = $order->get_items();
 		$event_items = array();
@@ -36,7 +36,7 @@ class AddTransactionEnhancedTest extends WP_UnitTestCase {
 			}
 		}
 
-		// The expected data structure for this event
+		// The expected data structure for this event.
 		$expected_data = array(
 			'transaction_id' => $order->get_order_number(),
 			'affiliation'    => get_bloginfo( 'name' ),
@@ -47,12 +47,8 @@ class AddTransactionEnhancedTest extends WP_UnitTestCase {
 			'items'          => $event_items,
 		);
 
-		// Get data passed to woocommerce_gtag_event_data filter
-		$args        = $filter->get_args();
-		$actual_data = $args[0][0];
-
-		// Confirm data structure matches what's expected
-		$this->assertEquals( $expected_data, $actual_data, 'Event data does not match expected data structure for purchase (add_transaction_enhanced()) event' );
+		// Confirm data structure matches what's expected.
+		$this->assertEquals( $expected_data, parent::get_event_data(), 'Event data does not match expected data structure for purchase (add_transaction_enhanced()) event' );
 	}
 
 }

--- a/tests/unit-tests/AddTransactionEnhanced.php
+++ b/tests/unit-tests/AddTransactionEnhanced.php
@@ -11,7 +11,7 @@ use WC_Google_Gtag_JS;
  *
  * @package GoogleAnalyticsIntegration\Tests
  */
-class AddTransactionEnhanced extends UnitTest {
+class AddTransactionEnhanced extends EventsDataTest {
 
 	/**
 	 * Run unit test against the `purchase` event
@@ -19,13 +19,13 @@ class AddTransactionEnhanced extends UnitTest {
 	 * @return void
 	 */
 	public function test_purchase_event() {
-		$order = parent::get_order();
+		$order = $this->get_order();
 
 		$gtag = new WC_Google_Gtag_JS();
 		$gtag->add_transaction_enhanced( $order );
 
 		// Confirm woocommerce_gtag_event_data is called by add_transaction_enhanced().
-		$this->assertEquals( 1, parent::get_event_data_filter_call_count(), 'woocommerce_gtag_event_data filter was not called for purchase (add_transaction_enhanced()) event' );
+		$this->assertEquals( 1, $this->get_event_data_filter_call_count(), 'woocommerce_gtag_event_data filter was not called for purchase (add_transaction_enhanced()) event' );
 
 		$order_items = $order->get_items();
 		$event_items = array();
@@ -48,7 +48,7 @@ class AddTransactionEnhanced extends UnitTest {
 		);
 
 		// Confirm data structure matches what's expected.
-		$this->assertEquals( $expected_data, parent::get_event_data(), 'Event data does not match expected data structure for purchase (add_transaction_enhanced()) event' );
+		$this->assertEquals( $expected_data, $this->get_event_data(), 'Event data does not match expected data structure for purchase (add_transaction_enhanced()) event' );
 	}
 
 }

--- a/tests/unit-tests/CheckoutProcess.php
+++ b/tests/unit-tests/CheckoutProcess.php
@@ -11,7 +11,7 @@ use WC_Google_Gtag_JS;
  *
  * @package GoogleAnalyticsIntegration\Tests
  */
-class CheckoutProcess extends UnitTest {
+class CheckoutProcess extends EventsDataTest {
 
 	/**
 	 * Run unit test against the `begin_checkout` event
@@ -19,16 +19,16 @@ class CheckoutProcess extends UnitTest {
 	 * @return void
 	 */
 	public function test_begin_checkout_event() {
-		wp_set_current_user( parent::get_customer()->get_id() );
+		wp_set_current_user( $this->get_customer()->get_id() );
 
-		$product = parent::get_product();
+		$product = $this->get_product();
 		$cart    = WC()->cart;
 
 		$add_to = $cart->add_to_cart( $product->get_id() );
 		( new WC_Google_Gtag_JS() )->checkout_process( $cart->get_cart() );
 
 		// Confirm woocommerce_gtag_event_data is called by checkout_process().
-		$this->assertEquals( 1, parent::get_event_data_filter_call_count(), 'woocommerce_gtag_event_data filter was not called for begin_checkout (checkout_process()) event' );
+		$this->assertEquals( 1, $this->get_event_data_filter_call_count(), 'woocommerce_gtag_event_data filter was not called for begin_checkout (checkout_process()) event' );
 
 		$expected_data = array(
 			'items' => array(),
@@ -54,7 +54,7 @@ class CheckoutProcess extends UnitTest {
 		}
 
 		// Confirm data structure matches what's expected.
-		$this->assertEquals( $expected_data, parent::get_event_data(), 'Event data does not match expected data structure for begin_checkout (checkout_process()) event' );
+		$this->assertEquals( $expected_data, $this->get_event_data(), 'Event data does not match expected data structure for begin_checkout (checkout_process()) event' );
 	}
 
 }

--- a/tests/unit-tests/CheckoutProcess.php
+++ b/tests/unit-tests/CheckoutProcess.php
@@ -1,0 +1,75 @@
+<?php
+// phpcs:ignoreFile
+
+namespace GoogleAnalyticsIntegration\Tests;
+
+use MockAction;
+use WP_UnitTestCase;
+use WC_Helper_Product;
+use WC_Helper_Customer;
+use WC_Google_Gtag_JS;
+
+class CheckoutProcessTest extends WP_UnitTestCase {
+
+	public function test_begin_checkout_event() {
+		$product  = WC_Helper_Product::create_simple_product();
+		$customer = WC_Helper_Customer::create_customer( 'JD', 'pw', 'customer@unit.test' );
+
+		wp_set_current_user( $customer->get_id() );
+
+		$cart = WC()->cart;
+		$cart->add_to_cart( $product->get_id() );
+
+		// Mock woocommerce_gtag_event_data filter to ensure it is called and the correct data is processed
+		$filter = new MockAction();
+		add_filter( 'woocommerce_gtag_event_data', array( &$filter, 'filter' ) );
+
+		( new WC_Google_Gtag_JS() )->checkout_process( $cart->get_cart() );
+
+		// Confirm woocommerce_gtag_event_data is called by checkout_process()
+		$this->assertEquals( 1, $filter->get_call_count(), 'woocommerce_gtag_event_data filter was not called for begin_checkout (checkout_process()) event' );
+
+		// The expected data structure for this event
+		$expected_data = array(
+			'items' => array(
+				array(
+					'id'       => WC_Google_Gtag_JS::get_product_identifier( $product ),
+					'name'     => $product->get_title(),
+					'category' => WC_Google_Gtag_JS::product_get_category_line( $product ),
+					'price'    => $product->get_price(),
+				),
+			),
+		);
+
+		$expected_data = array(
+			'items' => array(),
+		);
+
+		foreach ( $cart->get_cart() as $cart_item_key => $cart_item ) {
+			$product = apply_filters( 'woocommerce_cart_item_product', $cart_item['data'], $cart_item, $cart_item_key );
+
+			$item_data = array(
+				'id'       => WC_Google_Gtag_JS::get_product_identifier( $product ),
+				'name'     => $product->get_title(),
+				'category' => WC_Google_Gtag_JS::product_get_category_line( $product ),
+				'price'    => $product->get_price(),
+				'quantity' => $cart_item['quantity'],
+			);
+
+			$variant = WC_Google_Gtag_JS::product_get_variant_line( $product );
+			if ( '' !== $variant ) {
+				$item_data['variant'] = $variant;
+			}
+
+			$expected_data['items'][] = $item_data;
+		}
+
+		// Get data passed to woocommerce_gtag_event_data filter
+		$args        = $filter->get_args();
+		$actual_data = $args[0][0];
+
+		// Confirm data structure matches what's expected
+		$this->assertEquals( $expected_data, $actual_data, 'Event data does not match expected data structure for begin_checkout (checkout_process()) event' );
+	}
+
+}

--- a/tests/unit-tests/CheckoutProcess.php
+++ b/tests/unit-tests/CheckoutProcess.php
@@ -1,45 +1,34 @@
 <?php
-// phpcs:ignoreFile
 
 namespace GoogleAnalyticsIntegration\Tests;
 
-use MockAction;
-use WP_UnitTestCase;
-use WC_Helper_Product;
-use WC_Helper_Customer;
 use WC_Google_Gtag_JS;
 
-class CheckoutProcessTest extends WP_UnitTestCase {
+/**
+ * Class CheckoutProcess
+ *
+ * @since x.x.x
+ *
+ * @package GoogleAnalyticsIntegration\Tests
+ */
+class CheckoutProcess extends UnitTest {
 
+	/**
+	 * Run unit test against the `begin_checkout` event
+	 *
+	 * @return void
+	 */
 	public function test_begin_checkout_event() {
-		$product  = WC_Helper_Product::create_simple_product();
-		$customer = WC_Helper_Customer::create_customer( 'JD', 'pw', 'customer@unit.test' );
+		wp_set_current_user( parent::get_customer()->get_id() );
 
-		wp_set_current_user( $customer->get_id() );
+		$product = parent::get_product();
+		$cart    = WC()->cart;
 
-		$cart = WC()->cart;
-		$cart->add_to_cart( $product->get_id() );
-
-		// Mock woocommerce_gtag_event_data filter to ensure it is called and the correct data is processed
-		$filter = new MockAction();
-		add_filter( 'woocommerce_gtag_event_data', array( &$filter, 'filter' ) );
-
+		$add_to = $cart->add_to_cart( $product->get_id() );
 		( new WC_Google_Gtag_JS() )->checkout_process( $cart->get_cart() );
 
-		// Confirm woocommerce_gtag_event_data is called by checkout_process()
-		$this->assertEquals( 1, $filter->get_call_count(), 'woocommerce_gtag_event_data filter was not called for begin_checkout (checkout_process()) event' );
-
-		// The expected data structure for this event
-		$expected_data = array(
-			'items' => array(
-				array(
-					'id'       => WC_Google_Gtag_JS::get_product_identifier( $product ),
-					'name'     => $product->get_title(),
-					'category' => WC_Google_Gtag_JS::product_get_category_line( $product ),
-					'price'    => $product->get_price(),
-				),
-			),
-		);
+		// Confirm woocommerce_gtag_event_data is called by checkout_process().
+		$this->assertEquals( 1, parent::get_event_data_filter_call_count(), 'woocommerce_gtag_event_data filter was not called for begin_checkout (checkout_process()) event' );
 
 		$expected_data = array(
 			'items' => array(),
@@ -64,12 +53,8 @@ class CheckoutProcessTest extends WP_UnitTestCase {
 			$expected_data['items'][] = $item_data;
 		}
 
-		// Get data passed to woocommerce_gtag_event_data filter
-		$args        = $filter->get_args();
-		$actual_data = $args[0][0];
-
-		// Confirm data structure matches what's expected
-		$this->assertEquals( $expected_data, $actual_data, 'Event data does not match expected data structure for begin_checkout (checkout_process()) event' );
+		// Confirm data structure matches what's expected.
+		$this->assertEquals( $expected_data, parent::get_event_data(), 'Event data does not match expected data structure for begin_checkout (checkout_process()) event' );
 	}
 
 }

--- a/tests/unit-tests/ListingClick.php
+++ b/tests/unit-tests/ListingClick.php
@@ -1,0 +1,47 @@
+<?php
+// phpcs:ignoreFile
+
+namespace GoogleAnalyticsIntegration\Tests;
+
+use MockAction;
+use WP_UnitTestCase;
+use WC_Helper_Product;
+use WC_Google_Gtag_JS;
+
+class ListingClickTest extends WP_UnitTestCase {
+
+	public function test_select_content_and_add_to_cart_event() {
+		$product  = WC_Helper_Product::create_simple_product();
+		$position = 1;
+
+		// Mock woocommerce_gtag_event_data filter to ensure it is called and the correct data is processed
+		$filter = new MockAction();
+		add_filter( 'woocommerce_gtag_event_data', array( &$filter, 'filter' ) );
+
+		( new WC_Google_Gtag_JS() )->listing_click( $product, $position );
+
+		// Code is generated for two events in listing_click() so we would expect the filter is called twice
+		$this->assertEquals( 2, $filter->get_call_count(), 'woocommerce_gtag_event_data filter was not called for select_content and add_to_cart (listing_click()) events' );
+
+		// The expected data structure for this event
+		$expected_data = array(
+			'items' => array(
+				array(
+					'id'            => WC_Google_Gtag_JS::get_product_identifier( $product ),
+					'name'          => $product->get_title(),
+					'category'      => WC_Google_Gtag_JS::product_get_category_line( $product ),
+					'list_position' => $position,
+					'quantity'      => 1,
+				),
+			),
+		);
+
+		// Get data passed to woocommerce_gtag_event_data filter
+		$args        = $filter->get_args();
+		$actual_data = $args[0][0];
+
+		// Confirm data structure matches what's expected
+		$this->assertEquals( $expected_data, $actual_data, 'Event data does not match expected data structure for select_content and add_to_cart (listing_click()) events' );
+	}
+
+}

--- a/tests/unit-tests/ListingClick.php
+++ b/tests/unit-tests/ListingClick.php
@@ -1,29 +1,33 @@
 <?php
-// phpcs:ignoreFile
 
 namespace GoogleAnalyticsIntegration\Tests;
 
-use MockAction;
-use WP_UnitTestCase;
-use WC_Helper_Product;
 use WC_Google_Gtag_JS;
 
-class ListingClickTest extends WP_UnitTestCase {
+/**
+ * Class ListingClick
+ *
+ * @since x.x.x
+ *
+ * @package GoogleAnalyticsIntegration\Tests
+ */
+class ListingClick extends UnitTest {
 
+	/**
+	 * Run unit test against the `select_content` and `add_to_cart` events
+	 *
+	 * @return void
+	 */
 	public function test_select_content_and_add_to_cart_event() {
-		$product  = WC_Helper_Product::create_simple_product();
+		$product  = parent::get_product();
 		$position = 1;
-
-		// Mock woocommerce_gtag_event_data filter to ensure it is called and the correct data is processed
-		$filter = new MockAction();
-		add_filter( 'woocommerce_gtag_event_data', array( &$filter, 'filter' ) );
 
 		( new WC_Google_Gtag_JS() )->listing_click( $product, $position );
 
-		// Code is generated for two events in listing_click() so we would expect the filter is called twice
-		$this->assertEquals( 2, $filter->get_call_count(), 'woocommerce_gtag_event_data filter was not called for select_content and add_to_cart (listing_click()) events' );
+		// Code is generated for two events in listing_click() so we would expect the filter is called twice.
+		$this->assertEquals( 2, parent::get_event_data_filter_call_count(), 'woocommerce_gtag_event_data filter was not called for select_content and add_to_cart (listing_click()) events' );
 
-		// The expected data structure for this event
+		// The expected data structure for this event.
 		$expected_data = array(
 			'items' => array(
 				array(
@@ -36,12 +40,8 @@ class ListingClickTest extends WP_UnitTestCase {
 			),
 		);
 
-		// Get data passed to woocommerce_gtag_event_data filter
-		$args        = $filter->get_args();
-		$actual_data = $args[0][0];
-
-		// Confirm data structure matches what's expected
-		$this->assertEquals( $expected_data, $actual_data, 'Event data does not match expected data structure for select_content and add_to_cart (listing_click()) events' );
+		// Confirm data structure matches what's expected.
+		$this->assertEquals( $expected_data, parent::get_event_data(), 'Event data does not match expected data structure for select_content and add_to_cart (listing_click()) events' );
 	}
 
 }

--- a/tests/unit-tests/ListingClick.php
+++ b/tests/unit-tests/ListingClick.php
@@ -11,7 +11,7 @@ use WC_Google_Gtag_JS;
  *
  * @package GoogleAnalyticsIntegration\Tests
  */
-class ListingClick extends UnitTest {
+class ListingClick extends EventsDataTest {
 
 	/**
 	 * Run unit test against the `select_content` and `add_to_cart` events
@@ -19,13 +19,13 @@ class ListingClick extends UnitTest {
 	 * @return void
 	 */
 	public function test_select_content_and_add_to_cart_event() {
-		$product  = parent::get_product();
+		$product  = $this->get_product();
 		$position = 1;
 
 		( new WC_Google_Gtag_JS() )->listing_click( $product, $position );
 
 		// Code is generated for two events in listing_click() so we would expect the filter is called twice.
-		$this->assertEquals( 2, parent::get_event_data_filter_call_count(), 'woocommerce_gtag_event_data filter was not called for select_content and add_to_cart (listing_click()) events' );
+		$this->assertEquals( 2, $this->get_event_data_filter_call_count(), 'woocommerce_gtag_event_data filter was not called for select_content and add_to_cart (listing_click()) events' );
 
 		// The expected data structure for this event.
 		$expected_data = array(
@@ -41,7 +41,7 @@ class ListingClick extends UnitTest {
 		);
 
 		// Confirm data structure matches what's expected.
-		$this->assertEquals( $expected_data, parent::get_event_data(), 'Event data does not match expected data structure for select_content and add_to_cart (listing_click()) events' );
+		$this->assertEquals( $expected_data, $this->get_event_data(), 'Event data does not match expected data structure for select_content and add_to_cart (listing_click()) events' );
 	}
 
 }

--- a/tests/unit-tests/ListingImpression.php
+++ b/tests/unit-tests/ListingImpression.php
@@ -1,0 +1,47 @@
+<?php
+// phpcs:ignoreFile
+
+namespace GoogleAnalyticsIntegration\Tests;
+
+use MockAction;
+use WP_UnitTestCase;
+use WC_Helper_Product;
+use WC_Google_Gtag_JS;
+
+class ListingImpressionTest extends WP_UnitTestCase {
+
+	public function test_view_item_list_event() {
+		$product  = WC_Helper_Product::create_simple_product();
+		$position = 1;
+
+		// Mock woocommerce_gtag_event_data filter to ensure it is called and the correct data is processed
+		$filter = new MockAction();
+		add_filter( 'woocommerce_gtag_event_data', array( &$filter, 'filter' ) );
+
+		( new WC_Google_Gtag_JS() )->listing_impression( $product, $position );
+
+		// Confirm woocommerce_gtag_event_data is called by listing_impression()
+		$this->assertEquals( 1, $filter->get_call_count(), 'woocommerce_gtag_event_data filter was not called for view_item_list (listing_impression()) event' );
+
+		// The expected data structure for this event
+		$expected_data = array(
+			'items' => array(
+				array(
+					'id'            => WC_Google_Gtag_JS::get_product_identifier( $product ),
+					'name'          => $product->get_title(),
+					'category'      => WC_Google_Gtag_JS::product_get_category_line( $product ),
+					'list'          => WC_Google_Gtag_JS::get_list_name(),
+					'list_position' => $position,
+				),
+			),
+		);
+
+		// Get data passed to woocommerce_gtag_event_data filter
+		$args        = $filter->get_args();
+		$actual_data = $args[0][0];
+
+		// Confirm data structure matches what's expected
+		$this->assertEquals( $expected_data, $actual_data, 'Event data does not match expected data structure for view_item_list (listing_impression()) event' );
+	}
+
+}

--- a/tests/unit-tests/ListingImpression.php
+++ b/tests/unit-tests/ListingImpression.php
@@ -1,29 +1,33 @@
 <?php
-// phpcs:ignoreFile
 
 namespace GoogleAnalyticsIntegration\Tests;
 
-use MockAction;
-use WP_UnitTestCase;
-use WC_Helper_Product;
 use WC_Google_Gtag_JS;
 
-class ListingImpressionTest extends WP_UnitTestCase {
+/**
+ * Class ListingImpression
+ *
+ * @since x.x.x
+ *
+ * @package GoogleAnalyticsIntegration\Tests
+ */
+class ListingImpression extends UnitTest {
 
+	/**
+	 * Run unit test against the `view_item_list` event
+	 *
+	 * @return void
+	 */
 	public function test_view_item_list_event() {
-		$product  = WC_Helper_Product::create_simple_product();
+		$product  = parent::get_product();
 		$position = 1;
-
-		// Mock woocommerce_gtag_event_data filter to ensure it is called and the correct data is processed
-		$filter = new MockAction();
-		add_filter( 'woocommerce_gtag_event_data', array( &$filter, 'filter' ) );
 
 		( new WC_Google_Gtag_JS() )->listing_impression( $product, $position );
 
-		// Confirm woocommerce_gtag_event_data is called by listing_impression()
-		$this->assertEquals( 1, $filter->get_call_count(), 'woocommerce_gtag_event_data filter was not called for view_item_list (listing_impression()) event' );
+		// Confirm woocommerce_gtag_event_data is called by listing_impression().
+		$this->assertEquals( 1, parent::get_event_data_filter_call_count(), 'woocommerce_gtag_event_data filter was not called for view_item_list (listing_impression()) event' );
 
-		// The expected data structure for this event
+		// The expected data structure for this event.
 		$expected_data = array(
 			'items' => array(
 				array(
@@ -36,12 +40,8 @@ class ListingImpressionTest extends WP_UnitTestCase {
 			),
 		);
 
-		// Get data passed to woocommerce_gtag_event_data filter
-		$args        = $filter->get_args();
-		$actual_data = $args[0][0];
-
-		// Confirm data structure matches what's expected
-		$this->assertEquals( $expected_data, $actual_data, 'Event data does not match expected data structure for view_item_list (listing_impression()) event' );
+		// Confirm data structure matches what's expected.
+		$this->assertEquals( $expected_data, parent::get_event_data(), 'Event data does not match expected data structure for view_item_list (listing_impression()) event' );
 	}
 
 }

--- a/tests/unit-tests/ListingImpression.php
+++ b/tests/unit-tests/ListingImpression.php
@@ -11,7 +11,7 @@ use WC_Google_Gtag_JS;
  *
  * @package GoogleAnalyticsIntegration\Tests
  */
-class ListingImpression extends UnitTest {
+class ListingImpression extends EventsDataTest {
 
 	/**
 	 * Run unit test against the `view_item_list` event
@@ -19,13 +19,13 @@ class ListingImpression extends UnitTest {
 	 * @return void
 	 */
 	public function test_view_item_list_event() {
-		$product  = parent::get_product();
+		$product  = $this->get_product();
 		$position = 1;
 
 		( new WC_Google_Gtag_JS() )->listing_impression( $product, $position );
 
 		// Confirm woocommerce_gtag_event_data is called by listing_impression().
-		$this->assertEquals( 1, parent::get_event_data_filter_call_count(), 'woocommerce_gtag_event_data filter was not called for view_item_list (listing_impression()) event' );
+		$this->assertEquals( 1, $this->get_event_data_filter_call_count(), 'woocommerce_gtag_event_data filter was not called for view_item_list (listing_impression()) event' );
 
 		// The expected data structure for this event.
 		$expected_data = array(
@@ -41,7 +41,7 @@ class ListingImpression extends UnitTest {
 		);
 
 		// Confirm data structure matches what's expected.
-		$this->assertEquals( $expected_data, parent::get_event_data(), 'Event data does not match expected data structure for view_item_list (listing_impression()) event' );
+		$this->assertEquals( $expected_data, $this->get_event_data(), 'Event data does not match expected data structure for view_item_list (listing_impression()) event' );
 	}
 
 }

--- a/tests/unit-tests/ProductDetail.php
+++ b/tests/unit-tests/ProductDetail.php
@@ -1,28 +1,32 @@
 <?php
-// phpcs:ignoreFile
 
 namespace GoogleAnalyticsIntegration\Tests;
 
-use MockAction;
-use WP_UnitTestCase;
-use WC_Helper_Product;
 use WC_Google_Gtag_JS;
 
-class ProductDetailTest extends WP_UnitTestCase {
+/**
+ * Class ProductDetail
+ *
+ * @since x.x.x
+ *
+ * @package GoogleAnalyticsIntegration\Tests
+ */
+class ProductDetail extends UnitTest {
 
+	/**
+	 * Run unit test against the `view_item` event
+	 *
+	 * @return void
+	 */
 	public function test_view_item_event() {
-		$product  = WC_Helper_Product::create_simple_product();
-
-		// Mock woocommerce_gtag_event_data filter to ensure it is called and the correct data is processed
-		$filter = new MockAction();
-		add_filter( 'woocommerce_gtag_event_data', array( &$filter, 'filter' ) );
+		$product = parent::get_product();
 
 		( new WC_Google_Gtag_JS() )->product_detail( $product );
 
-		// Confirm woocommerce_gtag_event_data is called by product_detail()
-		$this->assertEquals( 1, $filter->get_call_count(), 'woocommerce_gtag_event_data filter was not called for view_item (product_detail()) event' );
+		// Confirm woocommerce_gtag_event_data is called by product_detail().
+		$this->assertEquals( 1, parent::get_event_data_filter_call_count(), 'woocommerce_gtag_event_data filter was not called for view_item (product_detail()) event' );
 
-		// The expected data structure for this event
+		// The expected data structure for this event.
 		$expected_data = array(
 			'items' => array(
 				array(
@@ -34,12 +38,8 @@ class ProductDetailTest extends WP_UnitTestCase {
 			),
 		);
 
-		// Get data passed to woocommerce_gtag_event_data filter
-		$args        = $filter->get_args();
-		$actual_data = $args[0][0];
-
-		// Confirm data structure matches what's expected
-		$this->assertEquals( $expected_data, $actual_data, 'Event data does not match expected data structure for view_item (product_detail()) event' );
+		// Confirm data structure matches what's expected.
+		$this->assertEquals( $expected_data, parent::get_event_data(), 'Event data does not match expected data structure for view_item (product_detail()) event' );
 	}
 
 }

--- a/tests/unit-tests/ProductDetail.php
+++ b/tests/unit-tests/ProductDetail.php
@@ -11,7 +11,7 @@ use WC_Google_Gtag_JS;
  *
  * @package GoogleAnalyticsIntegration\Tests
  */
-class ProductDetail extends UnitTest {
+class ProductDetail extends EventsDataTest {
 
 	/**
 	 * Run unit test against the `view_item` event
@@ -19,12 +19,12 @@ class ProductDetail extends UnitTest {
 	 * @return void
 	 */
 	public function test_view_item_event() {
-		$product = parent::get_product();
+		$product = $this->get_product();
 
 		( new WC_Google_Gtag_JS() )->product_detail( $product );
 
 		// Confirm woocommerce_gtag_event_data is called by product_detail().
-		$this->assertEquals( 1, parent::get_event_data_filter_call_count(), 'woocommerce_gtag_event_data filter was not called for view_item (product_detail()) event' );
+		$this->assertEquals( 1, $this->get_event_data_filter_call_count(), 'woocommerce_gtag_event_data filter was not called for view_item (product_detail()) event' );
 
 		// The expected data structure for this event.
 		$expected_data = array(
@@ -39,7 +39,7 @@ class ProductDetail extends UnitTest {
 		);
 
 		// Confirm data structure matches what's expected.
-		$this->assertEquals( $expected_data, parent::get_event_data(), 'Event data does not match expected data structure for view_item (product_detail()) event' );
+		$this->assertEquals( $expected_data, $this->get_event_data(), 'Event data does not match expected data structure for view_item (product_detail()) event' );
 	}
 
 }

--- a/tests/unit-tests/ProductDetail.php
+++ b/tests/unit-tests/ProductDetail.php
@@ -1,0 +1,45 @@
+<?php
+// phpcs:ignoreFile
+
+namespace GoogleAnalyticsIntegration\Tests;
+
+use MockAction;
+use WP_UnitTestCase;
+use WC_Helper_Product;
+use WC_Google_Gtag_JS;
+
+class ProductDetailTest extends WP_UnitTestCase {
+
+	public function test_view_item_event() {
+		$product  = WC_Helper_Product::create_simple_product();
+
+		// Mock woocommerce_gtag_event_data filter to ensure it is called and the correct data is processed
+		$filter = new MockAction();
+		add_filter( 'woocommerce_gtag_event_data', array( &$filter, 'filter' ) );
+
+		( new WC_Google_Gtag_JS() )->product_detail( $product );
+
+		// Confirm woocommerce_gtag_event_data is called by product_detail()
+		$this->assertEquals( 1, $filter->get_call_count(), 'woocommerce_gtag_event_data filter was not called for view_item (product_detail()) event' );
+
+		// The expected data structure for this event
+		$expected_data = array(
+			'items' => array(
+				array(
+					'id'       => WC_Google_Gtag_JS::get_product_identifier( $product ),
+					'name'     => $product->get_title(),
+					'category' => WC_Google_Gtag_JS::product_get_category_line( $product ),
+					'price'    => $product->get_price(),
+				),
+			),
+		);
+
+		// Get data passed to woocommerce_gtag_event_data filter
+		$args        = $filter->get_args();
+		$actual_data = $args[0][0];
+
+		// Confirm data structure matches what's expected
+		$this->assertEquals( $expected_data, $actual_data, 'Event data does not match expected data structure for view_item (product_detail()) event' );
+	}
+
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds basic unit testing for any events making use of the `woocommerce_gtag_event_data` filter. That doesn't include events that rely on Javascript like `add_to_cart`, however, it gives us a starting point for tests.

Testing can then be revisited in the future when the core WooCommerce E2E testing implementation has been updated so that coverage can be expanded.

### Checks:
<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Screenshots:

![Screenshot 2023-01-12 at 17 04 45](https://user-images.githubusercontent.com/40762232/212132590-d0a13a3f-4524-441e-8dbe-eb570b2c4cf6.png)

### Detailed test instructions:
_The PHPUnit implementation is based on how AutomateWoo tests work._

From the plugin directory, checkout `add/php-unit-tests` and then run:

1. `composer install`
2. `bin/install-unit-tests.sh <db-name> <db-user> <db-pass> [db-host] latest latest`
3. `vendor/bin/phpunit`