### PR TITLE
Fix usage of tracker_var() in load_analytics()

### DIFF
--- a/includes/class-wc-google-gtag-js.php
+++ b/includes/class-wc-google-gtag-js.php
@@ -273,11 +273,11 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 		$gtag_cross_domains = ! empty( self::get( 'ga_linker_cross_domains' ) ) ? array_map( 'esc_js', explode( ',', self::get( 'ga_linker_cross_domains' ) ) ) : array();
 
 		$gtag_snippet = '<script async src="https://www.googletagmanager.com/gtag/js?id=' . esc_js( $gtag_id ) . '"></script>';
-		$gtag_snippet .= "
+		$gtag_snippet .= '
 		<script>
 		window.dataLayer = window.dataLayer || [];
-		function " . self::tracker_var() . "(){dataLayer.push(arguments);}
-		" . self::tracker_var() . "('js', new Date());
+		function ' . self::tracker_var() . '(){dataLayer.push(arguments);}
+		' . self::tracker_var() . "('js', new Date());
 		$gtag_developer_id
 
 		" . self::tracker_var() . "('config', '" . esc_js( $gtag_id ) . "', {
@@ -476,3 +476,10 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 	}
 
 }
+
+add_filter(
+	'woocommerce_gtag_tracker_variable',
+	function( $tracker_var ) {
+		return 'filteredGtag';
+	}
+);

--- a/includes/class-wc-google-gtag-js.php
+++ b/includes/class-wc-google-gtag-js.php
@@ -266,7 +266,7 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 
 		$gtag_developer_id = '';
 		if ( ! empty( self::DEVELOPER_ID ) ) {
-			$gtag_developer_id = "gtag('set', 'developer_id." . self::DEVELOPER_ID . "', true);";
+			$gtag_developer_id = self::tracker_var() . "('set', 'developer_id." . self::DEVELOPER_ID . "', true);";
 		}
 
 		$gtag_id            = self::get( 'ga_id' );
@@ -276,11 +276,11 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 		$gtag_snippet .= "
 		<script>
 		window.dataLayer = window.dataLayer || [];
-		function gtag(){dataLayer.push(arguments);}
-		gtag('js', new Date());
+		function " . self::tracker_var() . "(){dataLayer.push(arguments);}
+		" . self::tracker_var() . "('js', new Date());
 		$gtag_developer_id
 
-		gtag('config', '" . esc_js( $gtag_id ) . "', {
+		" . self::tracker_var() . "('config', '" . esc_js( $gtag_id ) . "', {
 			'allow_google_signals': " . ( 'yes' === self::get( 'ga_support_display_advertising' ) ? 'true' : 'false' ) . ",
 			'link_attribution': " . ( 'yes' === self::get( 'ga_support_enhanced_link_attribution' ) ? 'true' : 'false' ) . ",
 			'anonymize_ip': " . ( 'yes' === self::get( 'ga_anonymize_enabled' ) ? 'true' : 'false' ) . ",

--- a/includes/class-wc-google-gtag-js.php
+++ b/includes/class-wc-google-gtag-js.php
@@ -476,10 +476,3 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 	}
 
 }
-
-add_filter(
-	'woocommerce_gtag_tracker_variable',
-	function( $tracker_var ) {
-		return 'filteredGtag';
-	}
-);


### PR DESCRIPTION
### Changes proposed in this Pull Request:

In some places, the code in `WC_Google_Gtag_JS::load_analytics()` was directly printing `gtag()` when setting up the tracking instance. This PR adjusts the code so that `tracker_var()` is used in its place to ensure the filter `woocommerce_gtag_tracker_variable` is applied consistently.

Closes #185.

### Checks:
<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Screenshots:

![Screenshot 2023-01-13 at 06 35 17](https://user-images.githubusercontent.com/40762232/212254253-ca0453f5-3b16-494c-9039-649649275304.png)

![Screenshot 2023-01-13 at 06 38 50](https://user-images.githubusercontent.com/40762232/212254263-7097fc7d-8720-421b-a7c2-593f6b4b89f9.png)

### Detailed test instructions:
1. Checkout `fix/185-usage-of-tracker_var-in-setup` on a test site that has the extension active and set up
2. Use the `woocommerce_gtag_tracker_variable` filter to alter the default tracker var
_Example:_
```
add_filter(
	'woocommerce_gtag_tracker_variable',
	function( $tracker_var ) {
		return 'filteredGtag';
	}
);
```
3. View source of the frontend of your site and search for the inline script output by [load_analytics()](https://github.com/woocommerce/woocommerce-google-analytics-integration/blob/86193d93b4973c03269b7ae603e55264dca8887c/includes/class-wc-google-gtag-js.php#L258)
4. Confirm that all instances of `gtag()` have been replaced with the filtered tracker var