### PR TITLE
Add composer.lock export-ignore to .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,6 +6,7 @@ bin export-ignore
 tests export-ignore
 Gruntfile.js export-ignore
 README.md export-ignore
+.nvmrc export-ignore
 package.json export-ignore
 package-lock.json export-ignore
 composer.json export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -9,6 +9,7 @@ README.md export-ignore
 package.json export-ignore
 package-lock.json export-ignore
 composer.json export-ignore
+composer.lock export-ignore
 phpunit.xml.dist export-ignore
 phpunit.xml export-ignore
 .eslintrc export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -12,6 +12,7 @@ composer.json export-ignore
 composer.lock export-ignore
 phpunit.xml.dist export-ignore
 phpunit.xml export-ignore
+phpcs.xml.dist export-ignore
 .eslintrc export-ignore
 .eslintignore export-ignore
 .tx export-ignore


### PR DESCRIPTION
### Changes proposed in this Pull Request:
Add export-ignore rule for `composer.lock` to `.gitattributes` to prevent the file being included in future releases.

Closes #250 

### Checks:
<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Detailed test instructions:
1. Checkout `fix/add-composer.lock-to-ignore-rules`
2. Run:
   - `composer install`
   - `npm install`
   - `npm run build`
3. Check archive generated by build process and confirm `composer.lock` isn't included