### PR TITLE
Add all new issues & PRs to Automata's project board.

### DIFF
--- a/.github/workflows/backlog-automation.yml
+++ b/.github/workflows/backlog-automation.yml
@@ -1,11 +1,13 @@
-name: Add all new issues & PRs to the Automata's board.
+name: Add all new issues and PRs to the Automata board.
 
 on:
   issues:
     types:
       - opened
+      - transferred
   pull_request:
-    types: opened
+    types:
+      - opened
 
 jobs:
   add-to-project:

--- a/.github/workflows/backlog-automation.yml
+++ b/.github/workflows/backlog-automation.yml
@@ -1,0 +1,18 @@
+name: Add all new issues & PRs to the Automata's board.
+
+on:
+  issues:
+    types:
+      - opened
+  pull_request:
+    types: opened
+
+jobs:
+  add-to-project:
+    name: Add issue/PR to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v0.4.0
+        with:
+          project-url: https://github.com/orgs/woocommerce/projects/119
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Add GH workflow to add new issues and PRs to [@woocommerce/automata  team project board](https://github.com/orgs/woocommerce/projects/119/views/1)

To follow the Ventures' process


### Screenshots:



### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Create a PR/issue
2. Check the project board's  New column


### Additional details:
1. I made a tiny change to Venture's one in that I added PRs as well
2. Also, the project board uses default GH-suggested colors.

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### No changelog entry
This is just GH maintenance
