### PR TITLE
Add new actions for tracking

### DIFF
--- a/assets/js/src/actions.js
+++ b/assets/js/src/actions.js
@@ -1,75 +1,190 @@
 import { addAction } from '@wordpress/hooks';
 import { __ } from '@wordpress/i18n';
+
 import { NAMESPACE, ACTION_PREFIX } from './constants';
 import {
+	trackListProducts,
+	trackAddToCart,
+	trackChangeCartItemQuantity,
+	trackRemoveCartItem,
+	trackCheckoutStep,
+	trackCheckoutOption,
 	trackEvent,
-	getProductFieldObject,
-	getProductImpressionObject,
-} from './utils';
+	trackSelectContent,
+	trackSearch,
+	trackViewItem,
+	trackException,
+} from './tracking';
 
-const trackListProducts = ( {
-	products,
-	listName = __( 'Product List', 'woocommerce-google-analytics-integration' ),
-} ) => {
-	trackEvent( 'view_item_list', {
-		event_category: 'engagement',
-		event_label: __(
-			'Viewing products',
-			'woocommerce-google-analytics-integration'
-		),
-		items: products.map( ( product, index ) => ( {
-			...getProductImpressionObject( product, listName ),
-			list_position: index + 1,
-		} ) ),
-	} );
-};
+/**
+ * Track customer progress through steps of the checkout. Triggers the event when the step changes:
+ * 	1 - Contact information
+ * 	2 - Shipping address
+ * 	3 - Billing address
+ * 	4 - Shipping options
+ * 	5 - Payment options
+ *
+ * @summary Track checkout progress with begin_checkout and checkout_progress
+ * @see https://developers.google.com/analytics/devguides/collection/gtagjs/enhanced-ecommerce#1_measure_checkout_steps
+ */
+addAction(
+	`${ ACTION_PREFIX }-checkout-render-checkout-form`,
+	NAMESPACE,
+	trackCheckoutStep( 0 )
+);
+addAction(
+	`${ ACTION_PREFIX }-checkout-set-email-address`,
+	NAMESPACE,
+	trackCheckoutStep( 1 )
+);
+addAction(
+	`${ ACTION_PREFIX }-checkout-set-shipping-address`,
+	NAMESPACE,
+	trackCheckoutStep( 2 )
+);
+addAction(
+	`${ ACTION_PREFIX }-checkout-set-billing-address`,
+	NAMESPACE,
+	trackCheckoutStep( 3 )
+);
+addAction(
+	`${ ACTION_PREFIX }-checkout-set-phone-number`,
+	NAMESPACE,
+	( { step, ...storeCart } ) => {
+		trackCheckoutStep( step === 'shipping' ? 2 : 3 )( storeCart );
+	}
+);
 
-const trackAddToCart = ( { product, quantity = 1 } ) => {
-	trackEvent( 'add_to_cart', {
-		event_category: 'ecommerce',
-		event_label: __(
-			'Add to Cart',
-			'woocommerce-google-analytics-integration'
-		),
-		items: [ getProductFieldObject( product, quantity ) ],
-	} );
-};
+/**
+ * Choose a shipping rate
+ *
+ * @summary Track the shipping rate being set using set_checkout_option
+ * @see https://developers.google.com/analytics/devguides/collection/gtagjs/enhanced-ecommerce#2_measure_checkout_options
+ */
+addAction(
+	`${ ACTION_PREFIX }-checkout-set-selected-shipping-rate`,
+	NAMESPACE,
+	( { shippingRateId } ) => {
+		trackCheckoutOption( {
+			step: 4,
+			option: __( 'Shipping Method', 'woo-gutenberg-products-block' ),
+			value: shippingRateId,
+		} )();
+	}
+);
 
-const trackRemoveCartItem = ( { product, quantity = 1 } ) => {
-	trackEvent( 'remove_from_cart', {
-		event_category: 'ecommerce',
-		event_label: __(
-			'Remove Cart Item',
-			'woocommerce-google-analytics-integration'
-		),
-		items: [ getProductFieldObject( product, quantity ) ],
-	} );
-};
+/**
+ * Choose a payment method
+ *
+ * @summary Track the payment method being set using set_checkout_option
+ * @see https://developers.google.com/analytics/devguides/collection/gtagjs/enhanced-ecommerce#2_measure_checkout_options
+ */
+addAction(
+	`${ ACTION_PREFIX }-checkout-set-active-payment-method`,
+	NAMESPACE,
+	( { paymentMethodSlug } ) => {
+		trackCheckoutOption( {
+			step: 5,
+			option: __( 'Payment Method', 'woo-gutenberg-products-block' ),
+			value: paymentMethodSlug,
+		} )();
+	}
+);
 
-const trackChangeCartItemQuantity = ( { product, quantity = 1 } ) => {
-	trackEvent( 'change_cart_quantity', {
-		event_category: 'ecommerce',
-		event_label: __(
-			'Change Cart Item Quantity',
-			'woocommerce-google-analytics-integration'
-		),
-		items: [ getProductFieldObject( product, quantity ) ],
-	} );
-};
-
+/**
+ * Product List View
+ *
+ * @summary Track the view_item_list event
+ * @see https://developers.google.com/gtagjs/reference/ga4-events#view_item_list
+ */
 addAction(
 	`${ ACTION_PREFIX }-product-list-render`,
 	NAMESPACE,
 	trackListProducts
 );
+
+/**
+ * Add to cart.
+ *
+ * This event signifies that an item was added to a cart for purchase.
+ *
+ * @summary Track the add_to_cart event
+ * @see https://developers.google.com/gtagjs/reference/ga4-events#add_to_cart
+ */
 addAction( `${ ACTION_PREFIX }-cart-add-item`, NAMESPACE, trackAddToCart );
+
+/**
+ * Change cart item quantities
+ *
+ * @summary Custom change_cart_quantity event.
+ */
 addAction(
 	`${ ACTION_PREFIX }-cart-set-item-quantity`,
 	NAMESPACE,
 	trackChangeCartItemQuantity
 );
+
+/**
+ * Remove item from the cart
+ *
+ * @summary Track the remove_from_cart event
+ * @see https://developers.google.com/gtagjs/reference/ga4-events#remove_from_cart
+ */
 addAction(
 	`${ ACTION_PREFIX }-cart-remove-item`,
 	NAMESPACE,
 	trackRemoveCartItem
+);
+
+/**
+ * Add Payment Information
+ *
+ * This event signifies a user has submitted their payment information. Note, this is used to indicate checkout
+ * submission, not `purchase` which is triggered on the thanks page.
+ *
+ * @summary Track the add_payment_info event
+ * @see https://developers.google.com/gtagjs/reference/ga4-events#add_payment_info
+ */
+addAction( `${ ACTION_PREFIX }-checkout-submit`, NAMESPACE, () => {
+	trackEvent( 'add_payment_info' );
+} );
+
+/**
+ * Product View Link Clicked
+ *
+ * @summary Track the select_content event
+ * @see https://developers.google.com/gtagjs/reference/ga4-events#select_content
+ */
+addAction(
+	`${ ACTION_PREFIX }-product-view-link`,
+	NAMESPACE,
+	trackSelectContent
+);
+
+/**
+ * Product Search
+ *
+ * @summary Track the search event
+ * @see https://developers.google.com/gtagjs/reference/ga4-events#search
+ */
+addAction( `${ ACTION_PREFIX }-product-search`, NAMESPACE, trackSearch );
+
+/**
+ * Single Product View
+ *
+ * @summary Track the view_item event
+ * @see https://developers.google.com/gtagjs/reference/ga4-events#view_item
+ */
+addAction( `${ ACTION_PREFIX }-product-render`, NAMESPACE, trackViewItem );
+
+/**
+ * Track notices as Exception events.
+ *
+ * @summary Track the exception event
+ * @see https://developers.google.com/analytics/devguides/collection/gtagjs/exceptions
+ */
+addAction(
+	`${ ACTION_PREFIX }-store-notice-create`,
+	NAMESPACE,
+	trackException
 );

--- a/assets/js/src/actions.js
+++ b/assets/js/src/actions.js
@@ -1,4 +1,3 @@
-import { addAction } from '@wordpress/hooks';
 import { __ } from '@wordpress/i18n';
 
 import { NAMESPACE, ACTION_PREFIX } from './constants';
@@ -15,6 +14,7 @@ import {
 	trackViewItem,
 	trackException,
 } from './tracking';
+import { addUniqueAction } from './utils';
 
 /**
  * Track customer progress through steps of the checkout. Triggers the event when the step changes:
@@ -27,27 +27,27 @@ import {
  * @summary Track checkout progress with begin_checkout and checkout_progress
  * @see https://developers.google.com/analytics/devguides/collection/gtagjs/enhanced-ecommerce#1_measure_checkout_steps
  */
-addAction(
+addUniqueAction(
 	`${ ACTION_PREFIX }-checkout-render-checkout-form`,
 	NAMESPACE,
-	trackCheckoutStep( 0 )
+	( { ...storeCart } ) => trackCheckoutStep( 0 )( storeCart )
 );
-addAction(
+addUniqueAction(
 	`${ ACTION_PREFIX }-checkout-set-email-address`,
 	NAMESPACE,
-	trackCheckoutStep( 1 )
+	( { ...storeCart } ) => trackCheckoutStep( 1 )( storeCart )
 );
-addAction(
+addUniqueAction(
 	`${ ACTION_PREFIX }-checkout-set-shipping-address`,
 	NAMESPACE,
-	trackCheckoutStep( 2 )
+	( { ...storeCart } ) => trackCheckoutStep( 2 )( storeCart )
 );
-addAction(
+addUniqueAction(
 	`${ ACTION_PREFIX }-checkout-set-billing-address`,
 	NAMESPACE,
-	trackCheckoutStep( 3 )
+	( { ...storeCart } ) => trackCheckoutStep( 3 )( storeCart )
 );
-addAction(
+addUniqueAction(
 	`${ ACTION_PREFIX }-checkout-set-phone-number`,
 	NAMESPACE,
 	( { step, ...storeCart } ) => {
@@ -61,7 +61,7 @@ addAction(
  * @summary Track the shipping rate being set using set_checkout_option
  * @see https://developers.google.com/analytics/devguides/collection/gtagjs/enhanced-ecommerce#2_measure_checkout_options
  */
-addAction(
+addUniqueAction(
 	`${ ACTION_PREFIX }-checkout-set-selected-shipping-rate`,
 	NAMESPACE,
 	( { shippingRateId } ) => {
@@ -79,7 +79,7 @@ addAction(
  * @summary Track the payment method being set using set_checkout_option
  * @see https://developers.google.com/analytics/devguides/collection/gtagjs/enhanced-ecommerce#2_measure_checkout_options
  */
-addAction(
+addUniqueAction(
 	`${ ACTION_PREFIX }-checkout-set-active-payment-method`,
 	NAMESPACE,
 	( { paymentMethodSlug } ) => {
@@ -97,7 +97,7 @@ addAction(
  * @summary Track the view_item_list event
  * @see https://developers.google.com/gtagjs/reference/ga4-events#view_item_list
  */
-addAction(
+addUniqueAction(
 	`${ ACTION_PREFIX }-product-list-render`,
 	NAMESPACE,
 	trackListProducts
@@ -111,14 +111,18 @@ addAction(
  * @summary Track the add_to_cart event
  * @see https://developers.google.com/gtagjs/reference/ga4-events#add_to_cart
  */
-addAction( `${ ACTION_PREFIX }-cart-add-item`, NAMESPACE, trackAddToCart );
+addUniqueAction(
+	`${ ACTION_PREFIX }-cart-add-item`,
+	NAMESPACE,
+	trackAddToCart
+);
 
 /**
  * Change cart item quantities
  *
  * @summary Custom change_cart_quantity event.
  */
-addAction(
+addUniqueAction(
 	`${ ACTION_PREFIX }-cart-set-item-quantity`,
 	NAMESPACE,
 	trackChangeCartItemQuantity
@@ -130,7 +134,7 @@ addAction(
  * @summary Track the remove_from_cart event
  * @see https://developers.google.com/gtagjs/reference/ga4-events#remove_from_cart
  */
-addAction(
+addUniqueAction(
 	`${ ACTION_PREFIX }-cart-remove-item`,
 	NAMESPACE,
 	trackRemoveCartItem
@@ -145,7 +149,7 @@ addAction(
  * @summary Track the add_payment_info event
  * @see https://developers.google.com/gtagjs/reference/ga4-events#add_payment_info
  */
-addAction( `${ ACTION_PREFIX }-checkout-submit`, NAMESPACE, () => {
+addUniqueAction( `${ ACTION_PREFIX }-checkout-submit`, NAMESPACE, () => {
 	trackEvent( 'add_payment_info' );
 } );
 
@@ -155,7 +159,7 @@ addAction( `${ ACTION_PREFIX }-checkout-submit`, NAMESPACE, () => {
  * @summary Track the select_content event
  * @see https://developers.google.com/gtagjs/reference/ga4-events#select_content
  */
-addAction(
+addUniqueAction(
 	`${ ACTION_PREFIX }-product-view-link`,
 	NAMESPACE,
 	trackSelectContent
@@ -167,7 +171,7 @@ addAction(
  * @summary Track the search event
  * @see https://developers.google.com/gtagjs/reference/ga4-events#search
  */
-addAction( `${ ACTION_PREFIX }-product-search`, NAMESPACE, trackSearch );
+addUniqueAction( `${ ACTION_PREFIX }-product-search`, NAMESPACE, trackSearch );
 
 /**
  * Single Product View
@@ -175,7 +179,11 @@ addAction( `${ ACTION_PREFIX }-product-search`, NAMESPACE, trackSearch );
  * @summary Track the view_item event
  * @see https://developers.google.com/gtagjs/reference/ga4-events#view_item
  */
-addAction( `${ ACTION_PREFIX }-product-render`, NAMESPACE, trackViewItem );
+addUniqueAction(
+	`${ ACTION_PREFIX }-product-render`,
+	NAMESPACE,
+	trackViewItem
+);
 
 /**
  * Track notices as Exception events.
@@ -183,7 +191,7 @@ addAction( `${ ACTION_PREFIX }-product-render`, NAMESPACE, trackViewItem );
  * @summary Track the exception event
  * @see https://developers.google.com/analytics/devguides/collection/gtagjs/exceptions
  */
-addAction(
+addUniqueAction(
 	`${ ACTION_PREFIX }-store-notice-create`,
 	NAMESPACE,
 	trackException

--- a/assets/js/src/constants.js
+++ b/assets/js/src/constants.js
@@ -1,2 +1,2 @@
-export const NAMESPACE = 'woocommerce-google-analytics-integration';
+export const NAMESPACE = 'woocommerce-google-analytics';
 export const ACTION_PREFIX = 'experimental__woocommerce_blocks';

--- a/assets/js/src/tracking.js
+++ b/assets/js/src/tracking.js
@@ -17,7 +17,7 @@ let currentStep = -1;
  *
  * @param {Object} params The function params
  * @param {Array} params.products The products to track
- * @param {string} params.listName The name of the list in which the item was presented to the user.
+ * @param {string} [params.listName] The name of the list in which the item was presented to the user.
  */
 export const trackListProducts = ( {
 	products,
@@ -41,7 +41,7 @@ export const trackListProducts = ( {
  *
  * @param {Object} params The function params
  * @param {Array} params.product The product to track
- * @param {string} params.quantity The quantity of that product in the cart.
+ * @param {number} [params.quantity=1] The quantity of that product in the cart.
  */
 export const trackAddToCart = ( { product, quantity = 1 } ) => {
 	trackEvent( 'add_to_cart', {
@@ -59,7 +59,7 @@ export const trackAddToCart = ( { product, quantity = 1 } ) => {
  *
  * @param {Object} params The function params
  * @param {Array} params.product The product to track
- * @param {string} params.quantity The quantity of that product in the cart.
+ * @param {number} [params.quantity=1] The quantity of that product in the cart.
  */
 export const trackRemoveCartItem = ( { product, quantity = 1 } ) => {
 	trackEvent( 'remove_from_cart', {
@@ -77,7 +77,7 @@ export const trackRemoveCartItem = ( { product, quantity = 1 } ) => {
  *
  * @param {Object} params The function params
  * @param {Array} params.product The product to track
- * @param {string} params.quantity The quantity of that product in the cart.
+ * @param {number} [params.quantity=1] The quantity of that product in the cart.
  */
 export const trackChangeCartItemQuantity = ( { product, quantity = 1 } ) => {
 	trackEvent( 'change_cart_quantity', {
@@ -95,7 +95,7 @@ export const trackChangeCartItemQuantity = ( { product, quantity = 1 } ) => {
  * Notice calling this will set the current checkout step as the step provided in the parameter.
  *
  * @param {number} step The checkout step for to track
- * @return {(function({storeCart: Object}): void)} A callable receiving the cart to track the checkout event.
+ * @return {(function( { storeCart: Object } ): void)} A callable receiving the cart to track the checkout event.
  */
 export const trackCheckoutStep =
 	( step ) =>
@@ -148,7 +148,10 @@ export const trackCheckoutOption =
  * @param {Object} params.product The product to track
  * @param {string} params.listName The name of the list in which the item was presented to the user.
  */
-export const trackSelectContent = ( { product, listName } ) => {
+export const trackSelectContent = ( {
+	product,
+	listName = __( 'Product List', 'woocommerce-google-analytics-integration' ),
+} ) => {
 	trackEvent( 'select_content', {
 		content_type: 'product',
 		items: [ getProductImpressionObject( product, listName ) ],
@@ -172,9 +175,12 @@ export const trackSearch = ( { searchTerm } ) => {
  *
  * @param {Object} params The function params
  * @param {Object} params.product The product to track
- * @param {string} params.listName The name of the list in which the item was presented to the user.
+ * @param {string} [params.listName] The name of the list in which the item was presented to the user.
  */
-export const trackViewItem = ( { product, listName } ) => {
+export const trackViewItem = ( {
+	product,
+	listName = __( 'Product List', 'woocommerce-google-analytics-integration' ),
+} ) => {
 	if ( product ) {
 		trackEvent( 'view_item', {
 			items: [ getProductImpressionObject( product, listName ) ],

--- a/assets/js/src/tracking.js
+++ b/assets/js/src/tracking.js
@@ -1,0 +1,213 @@
+import { __ } from '@wordpress/i18n';
+import {
+	getProductFieldObject,
+	getProductImpressionObject,
+	formatPrice,
+} from './utils';
+
+/**
+ * Variable holding the current checkout step. It will be modified by trackCheckoutOption and trackCheckoutStep methods.
+ *
+ * @type {number}
+ */
+let currentStep = -1;
+
+/**
+ * Tracks view_item_list event
+ *
+ * @param {Object} params The function params
+ * @param {Array} params.products The products to track
+ * @param {string} params.listName The name of the list in which the item was presented to the user.
+ */
+export const trackListProducts = ( {
+	products,
+	listName = __( 'Product List', 'woocommerce-google-analytics-integration' ),
+} ) => {
+	trackEvent( 'view_item_list', {
+		event_category: 'engagement',
+		event_label: __(
+			'Viewing products',
+			'woocommerce-google-analytics-integration'
+		),
+		items: products.map( ( product, index ) => ( {
+			...getProductImpressionObject( product, listName ),
+			list_position: index + 1,
+		} ) ),
+	} );
+};
+
+/**
+ * Tracks add_to_cart event
+ *
+ * @param {Object} params The function params
+ * @param {Array} params.product The product to track
+ * @param {string} params.quantity The quantity of that product in the cart.
+ */
+export const trackAddToCart = ( { product, quantity = 1 } ) => {
+	trackEvent( 'add_to_cart', {
+		event_category: 'ecommerce',
+		event_label: __(
+			'Add to Cart',
+			'woocommerce-google-analytics-integration'
+		),
+		items: [ getProductFieldObject( product, quantity ) ],
+	} );
+};
+
+/**
+ * Tracks remove_from_cart event
+ *
+ * @param {Object} params The function params
+ * @param {Array} params.product The product to track
+ * @param {string} params.quantity The quantity of that product in the cart.
+ */
+export const trackRemoveCartItem = ( { product, quantity = 1 } ) => {
+	trackEvent( 'remove_from_cart', {
+		event_category: 'ecommerce',
+		event_label: __(
+			'Remove Cart Item',
+			'woocommerce-google-analytics-integration'
+		),
+		items: [ getProductFieldObject( product, quantity ) ],
+	} );
+};
+
+/**
+ * Tracks change_cart_quantity event
+ *
+ * @param {Object} params The function params
+ * @param {Array} params.product The product to track
+ * @param {string} params.quantity The quantity of that product in the cart.
+ */
+export const trackChangeCartItemQuantity = ( { product, quantity = 1 } ) => {
+	trackEvent( 'change_cart_quantity', {
+		event_category: 'ecommerce',
+		event_label: __(
+			'Change Cart Item Quantity',
+			'woocommerce-google-analytics-integration'
+		),
+		items: [ getProductFieldObject( product, quantity ) ],
+	} );
+};
+
+/**
+ * Track a begin_checkout and checkout_progress event
+ * Notice calling this will set the current checkout step as the step provided in the parameter.
+ *
+ * @param {number} step The checkout step for to track
+ * @return {(function({storeCart: Object}): void)} A callable receiving the cart to track the checkout event.
+ */
+export const trackCheckoutStep =
+	( step ) =>
+	( { storeCart } ) => {
+		if ( currentStep === step ) {
+			return;
+		}
+
+		trackEvent( step === 0 ? 'begin_checkout' : 'checkout_progress', {
+			items: storeCart.cartItems.map( getProductFieldObject ),
+			coupon: storeCart.cartCoupons[ 0 ]?.code || '',
+			currency: storeCart.cartTotals.currency_code,
+			value: formatPrice(
+				storeCart.cartTotals.total_price,
+				storeCart.cartTotals.currency_minor_unit
+			),
+			checkout_step: step,
+		} );
+
+		currentStep = step;
+	};
+
+/**
+ * Track a set_checkout_option event
+ * Notice calling this will set the current checkout step as the step provided in the parameter.
+ *
+ * @param {Object} params The params from the option.
+ * @param {number} params.step The step to track
+ * @param {string} params.option The option to set in checkout
+ * @param {string} params.value The value for the option
+ *
+ * @return {(function() : void)} A callable to track the checkout event.
+ */
+export const trackCheckoutOption =
+	( { step, option, value } ) =>
+	() => {
+		trackEvent( 'set_checkout_option', {
+			checkout_step: step,
+			checkout_option: option,
+			value,
+		} );
+
+		currentStep = step;
+	};
+
+/**
+ * Tracks select_content event.
+ *
+ * @param {Object} params The function params
+ * @param {Object} params.product The product to track
+ * @param {string} params.listName The name of the list in which the item was presented to the user.
+ */
+export const trackSelectContent = ( { product, listName } ) => {
+	trackEvent( 'select_content', {
+		content_type: 'product',
+		items: [ getProductImpressionObject( product, listName ) ],
+	} );
+};
+
+/**
+ * Tracks search event.
+ *
+ * @param {Object} params The function params
+ * @param {string} params.searchTerm The search term to track
+ */
+export const trackSearch = ( { searchTerm } ) => {
+	trackEvent( 'search', {
+		search_term: searchTerm,
+	} );
+};
+
+/**
+ * Tracks view_item event
+ *
+ * @param {Object} params The function params
+ * @param {Object} params.product The product to track
+ * @param {string} params.listName The name of the list in which the item was presented to the user.
+ */
+export const trackViewItem = ( { product, listName } ) => {
+	if ( product ) {
+		trackEvent( 'view_item', {
+			items: [ getProductImpressionObject( product, listName ) ],
+		} );
+	}
+};
+
+/**
+ * Track exception event
+ *
+ * @param {Object} params The function params
+ * @param {string} params.status The status of the exception. It should be "error" for tracking it.
+ * @param {string} params.content The exception description
+ */
+export const trackException = ( { status, content } ) => {
+	if ( status === 'error' ) {
+		trackEvent( 'exception', {
+			description: content,
+			fatal: false,
+		} );
+	}
+};
+
+/**
+ * Track an event using the global gtag function.
+ *
+ * @param {string} eventName - Name of the event to track
+ * @param {Object} [eventParams] - Props to send within the event
+ */
+export const trackEvent = ( eventName, eventParams ) => {
+	if ( typeof gtag !== 'function' ) {
+		throw new Error( 'Function gtag not implemented.' );
+	}
+
+	window.gtag( 'event', eventName, eventParams );
+};

--- a/assets/js/src/utils.js
+++ b/assets/js/src/utils.js
@@ -1,18 +1,4 @@
 /**
- * Track an event using the global gtag function.
- *
- * @param {string} eventName - Name of the event to track
- * @param {Object} eventParams - Props to send within the event
- */
-export const trackEvent = ( eventName, eventParams ) => {
-	if ( typeof gtag !== 'function' ) {
-		throw new Error( 'Function gtag not implemented.' );
-	}
-
-	window.gtag( 'event', eventName, eventParams );
-};
-
-/**
  * Formats data into the productFieldObject shape.
  *
  * @see https://developers.google.com/analytics/devguides/collection/gtagjs/enhanced-ecommerce#product-data
@@ -27,7 +13,10 @@ export const getProductFieldObject = ( product, quantity ) => {
 		name: product.name,
 		quantity,
 		category: getProductCategory( product ),
-		price: getPrice( product ),
+		price: formatPrice(
+			product.prices.price,
+			product.prices.currency_minor_unit
+		),
 	};
 };
 
@@ -46,8 +35,23 @@ export const getProductImpressionObject = ( product, listName ) => {
 		name: product.name,
 		list_name: listName,
 		category: getProductCategory( product ),
-		price: getPrice( product ),
+		price: formatPrice(
+			product.prices.price,
+			product.prices.currency_minor_unit
+		),
 	};
+};
+
+/**
+ * Returns the price of a product formatted as a string.
+ *
+ * @param {string} price - The price to parse
+ * @param {number} [currencyMinorUnit=2] - The number decimals to show in the currency
+ *
+ * @return {string} - The price of the product formatted
+ */
+export const formatPrice = ( price, currencyMinorUnit = 2 ) => {
+	return ( parseInt( price, 10 ) / 10 ** currencyMinorUnit ).toString();
 };
 
 /**
@@ -72,18 +76,4 @@ const getProductCategory = ( product ) => {
 	return 'categories' in product && product.categories.length
 		? product.categories[ 0 ].name
 		: '';
-};
-
-/**
- * Returns the price of a product as a string.
- *
- * @param {Object} product - The product object
- *
- * @return {string} - The price of the product
- */
-const getPrice = ( product ) => {
-	return (
-		parseInt( product.prices.price, 10 ) /
-		10 ** product.prices.currency_minor_unit
-	).toString();
 };

--- a/assets/js/src/utils.js
+++ b/assets/js/src/utils.js
@@ -1,3 +1,5 @@
+import { addAction, removeAction } from '@wordpress/hooks';
+
 /**
  * Formats data into the productFieldObject shape.
  *
@@ -52,6 +54,18 @@ export const getProductImpressionObject = ( product, listName ) => {
  */
 export const formatPrice = ( price, currencyMinorUnit = 2 ) => {
 	return ( parseInt( price, 10 ) / 10 ** currencyMinorUnit ).toString();
+};
+
+/**
+ * Removes previous actions with the same hookName and namespace and then adds the new action.
+ *
+ * @param {string} hookName The hook name for the action
+ * @param {string} namespace The unique namespace for the action
+ * @param {Function} callback The function to run when the action happens.
+ */
+export const addUniqueAction = ( hookName, namespace, callback ) => {
+	removeAction( hookName, namespace );
+	addAction( hookName, namespace, callback );
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
     "lint:php:diff": "./bin/phpcs-diff.sh",
     "archive": "composer archive --file=$npm_package_name --format=zip",
     "postarchive": "rm -rf $npm_package_name && unzip $npm_package_name.zip -d $npm_package_name && rm $npm_package_name.zip && zip -r $npm_package_name.zip $npm_package_name && rm -rf $npm_package_name",
-		"build": "NODE_ENV=production wp-scripts build && npm run makepot &&  npm run archive",
-		"prebuild": "rm -rf ./vendor"
+    "build": "NODE_ENV=production wp-scripts build && npm run makepot &&  npm run archive",
+    "prebuild": "rm -rf ./vendor"
   },
   "engines": {
     "node": ">=8.9.3",


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes part of #227 

This PR implements a set of new actions and their respective tracking functions for handling GA events with `addAction` hook.

_Replace this with a good description of your changes & reasoning._

### Checks:
<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. For testing the actions I added this list of doActions (see after), you can see how GTag events run in Google Analytics Debugger. 
2. See that are no duplicates with WC Blocks (WC Blocks shows a log in console too `console.log( `Tracking event ${ eventName }` );`)
3. Compare the actions with the ones in WC Blocks 
4. You can also test to add other actions with same name in different namespace so you can check they are not deleted.

**List of doActions.**
```
const product = {
	id: '1234',
	name: 'Test',
	list_name: 'List test',
	categories: [ { name: 'cat 1' }, { name: 'cat 2' } ],
	prices: {
		price: 2222,
		currency_minor_unit: 2,
	},
};

const product2 = {
	id: '12345',
	name: 'Test 2',
	list_name: 'List test',
	categories: [ { name: 'cat 1' }, { name: 'cat 2' } ],
	prices: {
		price: 2222,
		currency_minor_unit: 2,
	},
};

const storeCart = {
	cartItems: [ product, product2 ],
	cartCoupons: [
		{
			code: '123',
		},
	],
	cartTotals: {
		currency_code: 'EUR',
		total_price: 2222,
		currency_minor_unit: 2,
	},
};

doAction( `${ ACTION_PREFIX }-store-notice-create`, {
	status: 'error',
	content: 'test',
} );

doAction( `${ ACTION_PREFIX }-store-notice-create`, {
	status: 'other',
	content: 'test',
} );

doAction( `${ ACTION_PREFIX }-product-render`, { product, listName: 'test' } );
doAction( `${ ACTION_PREFIX }-product-search`, { searchTerm: 'joe' } );
doAction( `${ ACTION_PREFIX }-product-view-link`, {
	product,
	listName: 'test',
} );

doAction( `${ ACTION_PREFIX }-cart-add-item`, { product, quantity: 2 } );
doAction( `${ ACTION_PREFIX }-cart-remove-item`, { product, quantity: 1 } );
doAction( `${ ACTION_PREFIX }-cart-set-item-quantity`, {
	product,
	quantity: 3,
} );

doAction( `${ ACTION_PREFIX }-product-list-render`, {
	products: [ product, product2 ],
} );

doAction( `${ ACTION_PREFIX }-checkout-render-checkout-form`, { storeCart } );
doAction( `${ ACTION_PREFIX }-checkout-set-email-address`, { storeCart } );
doAction( `${ ACTION_PREFIX }-checkout-set-shipping-address`, { storeCart } );
doAction( `${ ACTION_PREFIX }-checkout-set-billing-address`, { storeCart } );
doAction( `${ ACTION_PREFIX }-checkout-set-phone-number`, {
	step: 'shipping',
	storeCart,
} );

doAction( `${ ACTION_PREFIX }-checkout-set-selected-shipping-rate`, {
	shippingRateId: 'hello',
} );

doAction( `${ ACTION_PREFIX }-checkout-set-active-payment-method`, {
	paymentMethodSlug: 'hello',
} );
```
### Additional details:

⚠️ JS Unit Tests support are not included in this PR

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Add  -  Implement tracking with Actions Hooks
