### PR TITLE
WIP: redo "Assert the type of global $product before calling its methods" to debug tests

### DIFF
--- a/includes/class-wc-google-gtag-js.php
+++ b/includes/class-wc-google-gtag-js.php
@@ -49,7 +49,7 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 	public function setup_frontend_scripts() {
 		global $product;
 
-		if ( $product->is_type( 'variable' ) ) {
+		if ( $product instanceof WC_Product_Variable ) {
 			// Filter variation data to include formatted strings required for add_to_cart event
 			add_filter( 'woocommerce_available_variation', array( $this, 'variant_data' ), 10, 3 );
 			// Add default inline product data for add to cart tracking

--- a/tests/unit-tests/ProductDetail.php
+++ b/tests/unit-tests/ProductDetail.php
@@ -3,6 +3,7 @@
 namespace GoogleAnalyticsIntegration\Tests;
 
 use WC_Google_Gtag_JS;
+use WC_Helper_Product;
 
 /**
  * Class ProductDetail
@@ -40,6 +41,94 @@ class ProductDetail extends EventsDataTest {
 
 		// Confirm data structure matches what's expected.
 		$this->assertEquals( $expected_data, $this->get_event_data(), 'Event data does not match expected data structure for view_item (product_detail()) event' );
+	}
+
+	/**
+	 * Check that `WC_Google_Gtag_JS` registers
+	 * the `assets/js/ga-integration.js` script
+	 * as `woocommerce-google-analytics-integration` (`->script_handle`)
+	 * on `wp_enqueue_scripts` action.
+	 *
+	 * @return void
+	 */
+	public function test_variation_scripts_is_registered() {
+		$gtag = new WC_Google_Gtag_JS();
+
+		// Mimic WC action
+		do_action( 'wp_enqueue_scripts' );
+
+		// Assert the handle is regeistered with the correct name, but not yet enqueued.
+		$this->assertEquals( 'woocommerce-google-analytics-integration', $gtag->script_handle, '`WC_Google_Gtag_JS->script_handle` is not equal `woocommerce-google-analytics-integration`' );
+		$registered_url = wp_scripts()->registered[ $gtag->script_handle ]->src;
+		$this->assertStringContainsString( 'assets/js/ga-integration.js', $registered_url, 'The script does not point to the correct URL' );
+		$this->assertEquals( true, wp_script_is( $gtag->script_handle, 'registered' ), '`woocommerce-google-analytics-integration` script was not registered' );
+		$this->assertEquals( false, wp_script_is( $gtag->script_handle, 'enqueued' ), 'the script is enqueued too early' );
+	}
+
+	/**
+	 * Check that `WC_Google_Gtag_JS` does not enqueue
+	 * the `woocommerce-google-analytics-integration` script
+	 * on `wp_enqueue_scripts` action, for a simple product.
+	 *
+	 * @return void
+	 */
+	public function test_variation_scripts_are_not_enqueued_for_simple() {
+		global $product;
+		$product = WC_Helper_Product::create_simple_product();
+
+		$gtag = new WC_Google_Gtag_JS();
+
+		// Mimic WC action
+		do_action( 'wp_enqueue_scripts' );
+		do_action( 'woocommerce_before_single_product' );
+
+		// Assert the handle is regeistered with the correct name, but not yet enqueued.
+		$this->assertEquals( true, wp_script_is( $gtag->script_handle, 'registered' ), '`woocommerce-google-analytics-integration` script was not registered' );
+		$this->assertEquals( false, wp_script_is( $gtag->script_handle, 'enqueued' ), 'the script is enqueued' );
+	}
+
+	/**
+	 * Check that `WC_Google_Gtag_JS` does not enqueue
+	 * the `woocommerce-google-analytics-integration` script
+	 * on `wp_enqueue_scripts` action, for a bool as a `global $product`.
+	 *
+	 * @return void
+	 */
+	public function test_variation_scripts_are_not_enqueued_for_bool() {
+		global $product;
+		$product = false;
+
+		$gtag = new WC_Google_Gtag_JS();
+
+		// Mimic WC action
+		do_action( 'wp_enqueue_scripts' );
+		do_action( 'woocommerce_before_single_product' );
+
+		// Assert the handle is regeistered with the correct name, but not yet enqueued.
+		$this->assertEquals( true, wp_script_is( $gtag->script_handle, 'registered' ), '`woocommerce-google-analytics-integration` script was not registered' );
+		$this->assertEquals( false, wp_script_is( $gtag->script_handle, 'enqueued' ), 'the script is enqueued' );
+	}
+
+	/**
+	 * Check that `WC_Google_Gtag_JS` enqueue
+	 * the `woocommerce-google-analytics-integration` script
+	 * on `wp_enqueue_scripts` action, for a variable product.
+	 *
+	 * @return void
+	 */
+	public function test_variation_scripts_are_enqueued() {
+		global $product;
+		$product = WC_Helper_Product::create_variation_product();
+
+		$gtag = new WC_Google_Gtag_JS();
+
+		// Mimic WC action
+		do_action( 'wp_enqueue_scripts' );
+		do_action( 'woocommerce_before_single_product' );
+
+		// Assert the handle is regeistered with the correct name, but not yet enqueued.
+		$this->assertEquals( true, wp_script_is( $gtag->script_handle, 'registered' ), '`woocommerce-google-analytics-integration` script was not registered' );
+		$this->assertEquals( true, wp_script_is( $gtag->script_handle, 'enqueued' ), 'the script is not enqueued' );
 	}
 
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes # .

_Replace this with a good description of your changes & reasoning._

### Checks:
<!-- Mark completed items with an [x] -->
* [ ] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. 
2. 
3. 


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
