### PR TITLE
Add GH workflow for release PR & checklist

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,39 @@
+name: 'Prepare New Release'
+run-name:  Prepare New Release `${{ github.event.inputs.type }}/${{ github.event.inputs.version }}` from by @${{ github.actor }}
+
+# **What it does**: Does release preparation: creates the release branch and the PR with a checklist.
+# **Why we have it**: To support devs automating a few manual steps, and to leave a nice reference for consumers.
+
+on:
+  workflow_dispatch:
+    inputs:
+      ## In the future we could infer that version from the changelog, or bump it via major|minor|patch.
+      version:
+        description: 'Version number to be released'
+        required: true
+      type:
+        description: 'Type of the release (release|hotfix)'
+        required: true
+        default: 'release'
+      wp-version:
+        description: 'WordPress tested up to'
+      wc-version:
+        description: 'WooCommerce tested up to'
+
+
+jobs:
+  PrepareRelease:
+    name: Prepare Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Create branch & PR
+        uses: woocommerce/grow/prepare-extension-release@actions-v1
+        with:
+          version: ${{ github.event.inputs.version }}
+          type: ${{ github.event.inputs.type }}
+          wp-version: ${{ github.event.inputs.wp-version }}
+          wc-version: ${{ github.event.inputs.wc-version }}
+          main-branch: 'trunk'

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -37,3 +37,5 @@ jobs:
           wp-version: ${{ github.event.inputs.wp-version }}
           wc-version: ${{ github.event.inputs.wc-version }}
           main-branch: 'trunk'
+          pre-steps: |
+            1. [ ] Remove older changelog entries from `readme.txt` (keep the last two versions, since we will be adding a third during the release), commit changes.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Add a manual GH workflow that takes versions, then starts a branch and creates a PR with the checklist.
The aim is to automate and unify the release process across our repos.

### Screenshots:

![image](https://github.com/woocommerce/woocommerce-google-analytics-integration/assets/17435/685aaa36-0165-4164-8346-cda3a6ba8b69)




### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

Unfortunately, you cannot test a manually triggered workflow, until it's merged to the default branch :( 
But this PR follows,
 https://github.com/woocommerce/automatewoo/pull/1435/ and https://github.com/woocommerce/google-listings-and-ads/pull/1982


### Additional details:


<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Dev - Add release preparation GH workflow.
