### PR TITLE
Fetch WC & WP Matrix 

### DIFF
--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -21,24 +21,25 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  GetMatrix:
+ GetMatrix:
     name: Get WP and WC version Matrix
     runs-on: ubuntu-latest
     outputs:
         wp-versions: ${{ steps.wp.outputs.versions }}
         wc-versions: ${{ steps.wc.outputs.versions }}
     steps:
-        -   name: Get Release versions from Wordpress
-            id: wp
-            uses: woocommerce/grow/get-plugin-releases@actions-v1
-            with:
-                slug: wordpress
-        -   name: Get Release versions from WooCommerce
-            id: wc
-            uses: woocommerce/grow/get-plugin-releases@actions-v1
-            with:
-                slug: woocommerce
-  UnitTests:
+      - name: Get Release versions from Wordpress
+        id: wp
+        uses: woocommerce/grow/get-plugin-releases@actions-v1
+        with:
+            slug: wordpress
+      - name: Get Release versions from WooCommerce
+        id: wc
+        uses: woocommerce/grow/get-plugin-releases@actions-v1
+        with:
+            slug: woocommerce
+
+ UnitTests:
     name: PHP unit tests - PHP ${{ matrix.php }}, WP ${{ matrix.wp-version || 'latest' }}, WC ${{ matrix.wc-versions || 'latest' }}
     runs-on: ubuntu-latest
     needs: GetMatrix
@@ -46,7 +47,9 @@ jobs:
       matrix:
         php: [7.4]
         wp-version: [latest]
-        wc-versions: ${{ fromJson(needs.GetMatrix.outputs.wc-versions) }}
+        # Please note that wc-versions is a string containing versions separated by commas.
+        # It will be split and loop within the run unit test step below to reduce the time spent.
+        wc-versions: [ '${{ join(fromJson(needs.GetMatrix.outputs.wc-versions)) }}' ]
         include:
           - php: 7.4
             wp-version: ${{ fromJson(needs.GetMatrix.outputs.wp-versions)[2] }} # L-2 WP Version support

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -41,6 +41,7 @@ jobs:
   UnitTests:
     name: PHP unit tests - PHP ${{ matrix.php }}, WP ${{ matrix.wp-version || 'latest' }}, WC ${{ matrix.wc-versions || 'latest' }}
     runs-on: ubuntu-latest
+    needs: GetMatrix
     strategy:
       matrix:
         php: [7.4]

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -21,21 +21,35 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  GetMatrix:
+    name: Get WP and WC version Matrix
+    runs-on: ubuntu-latest
+    outputs:
+        wp-versions: ${{ steps.wp.outputs.versions }}
+        wc-versions: ${{ steps.wc.outputs.versions }}
+    steps:
+        -   name: Get Release versions from Wordpress
+            id: wp
+            uses: woocommerce/grow/get-plugin-releases@actions-v1
+            with:
+                slug: wordpress
+        -   name: Get Release versions from WooCommerce
+            id: wc
+            uses: woocommerce/grow/get-plugin-releases@actions-v1
+            with:
+                slug: woocommerce
   UnitTests:
-    name: PHP unit tests - PHP ${{ matrix.php }}, WP ${{ matrix.wp-version }}, WC ${{ matrix.wc-versions }}
+    name: PHP unit tests - PHP ${{ matrix.php }}, WP ${{ matrix.wp-version || 'latest' }}, WC ${{ matrix.wc-versions || 'latest' }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
         php: [7.4]
         wp-version: [latest]
-        # Please note that wc-versions is a string contains versions separated by commas.
-        # It will be split and loop within the run unit test step below to reduce the time spent.
-        wc-versions: ["7.1.0, 7.2.0, latest"] # From L-2 to latest.
+        wc-versions: ${{ fromJson(needs.GetMatrix.outputs.wc-versions) }}
         include:
-          # Minimum PHP support and L-2 WP/WC version
           - php: 7.4
-            wp-version: 5.9
-            wc-versions: 7.1.0
+            wp-version: ${{ fromJson(needs.GetMatrix.outputs.wp-versions)[2] }} # L-2 WP Version support
+            wc-versions: ${{ fromJson(needs.GetMatrix.outputs.wc-versions)[2] }} # L-2 WC Version support
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR fetch WooCommerce & WP L-2 versions for our tests using https://github.com/woocommerce/grow/tree/trunk/packages/github-actions/actions/get-plugin-releases


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

- Verify both WC and WP version are properly fetched and the test passing
https://github.com/woocommerce/woocommerce-google-analytics-integration/actions/runs/5877646915/job/15938158844?pr=290
- Verify there is one Job for the matrix and in that job it iterates over versions.

### Additional details:

This is based on the approved solution in https://github.com/woocommerce/automatewoo/pull/1527

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Dev - Fetch WooCommerce and WordPress versions for our tests
