### PR TITLE
Add PHP 8.2 support.

### DIFF
--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [7.4]
+        php: [8.1]
         wp-version: [latest]
         # Please note that wc-versions is a string contains versions separated by commas.
         # It will be split and loop within the run unit test step below to reduce the time spent.
@@ -36,6 +36,10 @@ jobs:
           - php: 7.4
             wp-version: 5.9
             wc-versions: 7.1.0
+          # Latest PHP support and latest WP/WC version
+          - php: 8.2
+            wp-version: latest
+            wc-versions: latest
 
     steps:
       - name: Checkout repository

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ build
 !/logs/.htaccess
 
 tests/e2e/config/local-*
+.phpunit.result.cache
 .eslintcache
 
 /vendor/

--- a/includes/class-wc-google-analytics.php
+++ b/includes/class-wc-google-analytics.php
@@ -14,28 +14,65 @@ use Automattic\WooCommerce\Admin\Features\OnboardingTasks\TaskLists;
  *
  * @class   WC_Google_Analytics
  * @extends WC_Integration
- *
- * @property $ga_id
- * @property $ga_set_domain_name
- * @property $ga_gtag_enabled
- * @property $ga_standard_tracking_enabled
- * @property $ga_support_display_advertising
- * @property $ga_support_enhanced_link_attribution
- * @property $ga_use_universal_analytics
- * @property $ga_anonymize_enabled
- * @property $ga_404_tracking_enabled
- * @property $ga_ecommerce_tracking_enabled
- * @property $ga_enhanced_ecommerce_tracking_enabled
- * @property $ga_enhanced_remove_from_cart_enabled
- * @property $ga_enhanced_product_impression_enabled
- * @property $ga_enhanced_product_click_enabled
- * @property $ga_enhanced_checkout_process_enabled
- * @property $ga_enhanced_product_detail_view_enabled
- * @property $ga_event_tracking_enabled
- * @property $ga_linker_cross_domains
- * @property $ga_linker_allow_incoming_enabled
  */
 class WC_Google_Analytics extends WC_Integration {
+
+	/** @var string $ga_id Google Analytics Tracking ID */
+	public $ga_id;
+
+	/** @var string $ga_set_domain_name Domain Name (legacy setting) */
+	public $ga_set_domain_name;
+
+	/** @var string $ga_use_universal_analytics Use Legacy Universal Analytics (yes|no) */
+	public $ga_use_universal_analytics;
+
+	/** @var string $ga_gtag_enable Is GA4 enabled (yes|no) */
+	public $ga_gtag_enabled;
+
+	/** @var string $ga_standard_tracking_enabled Is standard tracking enabled (yes|no) */
+	public $ga_standard_tracking_enabled;
+
+	/** @var string $ga_support_display_advertising Supports display advertising (yes|no) */
+	public $ga_support_display_advertising;
+
+	/** @var string $ga_support_enhanced_link_attribution Use enhanced link attribution (yes|no) */
+	public $ga_support_enhanced_link_attribution;
+
+	/** @var string $ga_anonymize_enabled Anonymize IP addresses (yes|no) */
+	public $ga_anonymize_enabled;
+
+	/** @var string $ga_404_tracking_enabled Track 404 errors (yes|no) */
+	public $ga_404_tracking_enabled;
+
+	/** @var string $ga_ecommerce_tracking_enabled Purchase transactions (yes|no) */
+	public $ga_ecommerce_tracking_enabled;
+
+	/** @var string $ga_enhanced_ecommerce_tracking_enabled Enhanced ecommerce tracking (yes|no) */
+	public $ga_enhanced_ecommerce_tracking_enabled;
+
+	/** @var string $ga_enhanced_remove_from_cart_enabled Track remove from cart events (yes|no) */
+	public $ga_enhanced_remove_from_cart_enabled;
+
+	/** @var string $ga_enhanced_product_impression_enabled Track product impressions (yes|no) */
+	public $ga_enhanced_product_impression_enabled;
+
+	/** @var string $ga_enhanced_product_click_enabled Track product clicks (yes|no) */
+	public $ga_enhanced_product_click_enabled;
+
+	/** @var string $ga_enhanced_checkout_process_enabled Track checkout initiated (yes|no) */
+	public $ga_enhanced_checkout_process_enabled;
+
+	/** @var string $ga_enhanced_product_detail_view_enabled Track product detail views (yes|no) */
+	public $ga_enhanced_product_detail_view_enabled;
+
+	/** @var string $ga_event_tracking_enabled Track add to cart events (yes|no) */
+	public $ga_event_tracking_enabled;
+
+	/** @var string $ga_linker_cross_domains Domains for automatic linking */
+	public $ga_linker_cross_domains;
+
+	/** @var string $ga_linker_allow_incoming_enabled Accept incoming linker (yes|no) */
+	public $ga_linker_allow_incoming_enabled;
 
 	/**
 	 * Defines the script handles that should be async.

--- a/includes/class-wc-google-analytics.php
+++ b/includes/class-wc-google-analytics.php
@@ -74,9 +74,6 @@ class WC_Google_Analytics extends WC_Integration {
 	/** @var string $ga_linker_allow_incoming_enabled Accept incoming linker (yes|no) */
 	public $ga_linker_allow_incoming_enabled;
 
-
-	protected $dismissed_info_banner;
-
 	/**
 	 * Defines the script handles that should be async.
 	 */

--- a/includes/class-wc-google-analytics.php
+++ b/includes/class-wc-google-analytics.php
@@ -74,6 +74,9 @@ class WC_Google_Analytics extends WC_Integration {
 	/** @var string $ga_linker_allow_incoming_enabled Accept incoming linker (yes|no) */
 	public $ga_linker_allow_incoming_enabled;
 
+
+	protected $dismissed_info_banner;
+
 	/**
 	 * Defines the script handles that should be async.
 	 */
@@ -98,10 +101,9 @@ class WC_Google_Analytics extends WC_Integration {
 	 * Init and hook in the integration.
 	 */
 	public function __construct() {
-		$this->id                    = 'google_analytics';
-		$this->method_title          = __( 'Google Analytics', 'woocommerce-google-analytics-integration' );
-		$this->method_description    = __( 'Google Analytics is a free service offered by Google that generates detailed statistics about the visitors to a website.', 'woocommerce-google-analytics-integration' );
-		$this->dismissed_info_banner = get_option( 'woocommerce_dismissed_info_banner' );
+		$this->id                 = 'google_analytics';
+		$this->method_title       = __( 'Google Analytics', 'woocommerce-google-analytics-integration' );
+		$this->method_description = __( 'Google Analytics is a free service offered by Google that generates detailed statistics about the visitors to a website.', 'woocommerce-google-analytics-integration' );
 
 		// Load the settings
 		$this->init_form_fields();


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR fixes some deprecation messages when run on a site with PHP 8.2. This was mostly resolved by declaring the class properties for all the settings.

In addition to that the dismissed_info_banner property was removed as it was no longer present and had been removed in PR #260

I've also modified the phpunit workflow to test with newer PHP versions including PHP 8.2.

> **Note**
The workflow change will conflict with PR #290 when it's merged, but this should be relatively straightforward to merge.

Closes #291


### Detailed test instructions:
1. Test extension on a site with PHP 8.2 and WP_DEBUG enabled 
2. Setup some basic settings
3. Purchase a product (in an incognito window)
4. Confirm that tracking events are being recorded
5. Ensure there aren't any warnings / deprecation messages showing up at any stage
6. Check the automated PR tests and confirm they ran for PHP 8.2 without errors

### Changelog entry
* Compat - Add PHP 8.2 support.
