### PR TITLE
Add Workflow for generating Hooks Documentation

### DIFF
--- a/.github/workflows/php-hook-documentation.yml
+++ b/.github/workflows/php-hook-documentation.yml
@@ -5,16 +5,7 @@ on:
     branches:
       - "release/**"
     paths:
-      - "**.php"
-      - .github/workflows/php-hook-documentation.yml
-  pull_request:
-    types:
-      - opened
-    branches:
-      - "release/**"
-    paths:
-      - "**.php"
-      - .github/workflows/php-hook-documentation.yml
+      - changelog.txt # Run the workflow only after the last commit of Woo Release. When it updates the changelog.
   workflow_dispatch:
 
 concurrency:
@@ -37,7 +28,6 @@ jobs:
         id: generate-hook-docs
         uses: woocommerce/grow/hook-documentation@actions-v1
         with:
-          debug-output: yes
           source-directories: includes/ woocommerce-google-analytics-integration.php
 
       - name: Commit hook documentation

--- a/.github/workflows/php-hook-documentation.yml
+++ b/.github/workflows/php-hook-documentation.yml
@@ -28,7 +28,7 @@ jobs:
         id: generate-hook-docs
         uses: woocommerce/grow/hook-documentation@actions-v1
         with:
-          source-directories: includes/ woocommerce-google-analytics-integration.php
+          source-directories: includes/,woocommerce-google-analytics-integration.php
 
       - name: Commit hook documentation
         shell: bash

--- a/.github/workflows/php-hook-documentation.yml
+++ b/.github/workflows/php-hook-documentation.yml
@@ -1,0 +1,58 @@
+name: PHP Hook Documentation Generator
+
+on:
+  push:
+    branches:
+      - "release/**"
+    paths:
+      - "**.php"
+      - .github/workflows/php-hook-documentation.yml
+  pull_request:
+    types:
+      - opened
+    branches:
+      - "release/**"
+    paths:
+      - "**.php"
+      - .github/workflows/php-hook-documentation.yml
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  HookDocumentation:
+    name: Hook Documentation Generator
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v3
+        with:
+          # Checks out a branch instead of a commit in detached HEAD state
+          ref: ${{ github.head_ref }}
+
+        # This generates the documentation string. The `id` property is used to reference the output in the next step.
+      - name: Generate hook documentation
+        id: generate-hook-docs
+        uses: woocommerce/grow/hook-documentation@actions-v1
+        with:
+          debug-output: yes
+          source-directories: includes/ woocommerce-google-analytics-integration.php
+
+      - name: Commit hook documentation
+        shell: bash
+        # Use the github-actions bot account to commit.
+        # https://api.github.com/users/github-actions%5Bbot%5D
+        run: |
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          echo "${{ steps.generate-hook-docs.outputs.hook-docs }}" > docs/Hooks.md
+          git add docs/Hooks.md
+          if git diff --cached --quiet; then
+            echo "*No documentation changes to commit.*" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "*Committing documentation changes.*" >> $GITHUB_STEP_SUMMARY
+            git commit -q -m "Update hooks documentation from ${{ github.head_ref }} branch."
+            git push
+          fi

--- a/README.md
+++ b/README.md
@@ -31,3 +31,7 @@ _For more info see: [WordPress.org > Plugin Unit Tests](https://make.wordpress.o
 2. Run `npm run lint:php`
 
 Alternatively, run `npm run lint:php:diff` to run coding standards checks agains the current git diff. An explanation of output can be [found here](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Usage#printing-progress-information) e.g. what are the S's?
+
+## Docs
+
+- [Hooks defined or used in WooCommerce Google Analytics Integration](./docs/Hooks.md)


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR creates an Action for generating PHP Hooks documentation when PHP files change on a new release/branch.

Git Bot will commit a Hooks.md in docs/Hooks.md (empty file was added to this repo)

The workflow is based in the approved solution in https://github.com/woocommerce/google-listings-and-ads/pull/2060

### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Dev - Add Workflow for generation Hooks documentation
