### PR TITLE
Fix Add To Cart and Impression events when using Blocks

### DIFF
--- a/includes/class-wc-google-analytics.php
+++ b/includes/class-wc-google-analytics.php
@@ -131,8 +131,8 @@ class WC_Google_Analytics extends WC_Integration {
 		add_action( 'woocommerce_after_cart', array( $this, 'remove_from_cart' ) );
 		add_action( 'woocommerce_after_mini_cart', array( $this, 'remove_from_cart' ) );
 		add_filter( 'woocommerce_cart_item_remove_link', array( $this, 'remove_from_cart_attributes' ), 10, 2 );
-		add_action( 'woocommerce_after_shop_loop_item', array( $this, 'listing_impression' ) );
-		add_action( 'woocommerce_after_shop_loop_item', array( $this, 'listing_click' ) );
+		add_action( 'woocommerce_after_shop_loop_item_title', array( $this, 'listing_click' ) );
+		add_action( 'woocommerce_after_shop_loop_item_title', array( $this, 'listing_impression' ) );
 		add_action( 'woocommerce_after_single_product', array( $this, 'product_detail' ) );
 		add_action( 'woocommerce_after_checkout_form', array( $this, 'checkout_process' ) );
 

--- a/includes/class-wc-google-gtag-js.php
+++ b/includes/class-wc-google-gtag-js.php
@@ -226,7 +226,7 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 
 		wc_enqueue_js(
 			"
-			$( '.product.post-" . esc_js( $product->get_id() ) . " a , .product.post-" . esc_js( $product->get_id() ) . " button' ).on('click', function() {
+			$( '.product.post-" . esc_js( $product->get_id() ) . ' a , .product.post-' . esc_js( $product->get_id() ) . " button' ).on('click', function() {
 				if ( true === $(this).hasClass( 'add_to_cart_button' ) ) {
 					$add_to_cart_event_code
 				} else {

--- a/includes/class-wc-google-gtag-js.php
+++ b/includes/class-wc-google-gtag-js.php
@@ -226,7 +226,7 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 
 		wc_enqueue_js(
 			"
-			$( '.products .post-" . esc_js( $product->get_id() ) . " a' ).on('click', function() {
+			$( '.product.post-" . esc_js( $product->get_id() ) . " a , .product.post-" . esc_js( $product->get_id() ) . " button' ).on('click', function() {
 				if ( true === $(this).hasClass( 'add_to_cart_button' ) ) {
 					$add_to_cart_event_code
 				} else {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #297 

This PR fixes a bug in Products Blocks and Add To cart / Impression tracking.

### Checks:
<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Screenshots:


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Install Google Analytics Debugger and Checkout this PR
2. Install a theme supporting blocks (like tt3)
3. Go to Shop and check that the impressions are being tracked
4. Click Add To Cart and check that the event is being tracked
5. Install a theme not supporting blocks (like tt1)
6. Repeat steps 3 and 4
7. Create a new Page and add the block "All products"
8. Repeat steps 3 and 4
9. Create a new Page and add the block "Products (beta)"
10. Repeat steps 3 and 4

### Additional details:

One error is happening because the class is not covering `button` tags... only `a` tags
The second problem is because `woocommerce_after_shop_loop_item` is not happening in blocks. But yes  `woocommerce_after_shop_loop_item_title`

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Add To Cart and Impression events when using Blocks
