### PR TITLE
Refactor products tracking for clicks and impression

### DIFF
--- a/includes/class-wc-abstract-google-analytics-js.php
+++ b/includes/class-wc-abstract-google-analytics-js.php
@@ -69,17 +69,15 @@ abstract class WC_Abstract_Google_Analytics_JS {
 	 * Enqueues JavaScript to build the addImpression object
 	 *
 	 * @param WC_Product $product
-	 * @param int        $position
 	 */
-	abstract public static function listing_impression( $product, $position );
+	abstract public static function listing_impression( $product );
 
 	/**
 	 * Enqueues JavaScript to build an addProduct and click object
 	 *
 	 * @param WC_Product $product
-	 * @param int        $position
 	 */
-	abstract public static function listing_click( $product, $position );
+	abstract public static function listing_click( $product );
 
 	/**
 	 * Loads the correct Google Gtag code (classic or universal)

--- a/includes/class-wc-google-analytics-js.php
+++ b/includes/class-wc-google-analytics-js.php
@@ -142,17 +142,14 @@ class WC_Google_Analytics_JS extends WC_Abstract_Google_Analytics_JS {
 
 		wc_enqueue_js(
 			"
-			$( '.products .post-" . esc_js( $product->get_id() ) . " a' ).on( 'click', function() {
-				if ( true === $(this).hasClass( 'add_to_cart_button' ) ) {
-					return;
+			$( '.product.post-" . esc_js( $product->get_id() ) . ' a , .product.post-' . esc_js( $product->get_id() ) . " button' ).on('click', function() {
+				if ( false === $(this).hasClass( 'product_type_variable' ) && false === $(this).hasClass( 'product_type_grouped' ) ) {
+					" . self::tracker_var() . "( 'ec:addProduct', {
+						'id': '" . esc_js( $product->get_id() ) . "',
+						'name': '" . esc_js( $product->get_title() ) . "',
+						'category': " . self::product_get_category_line( $product ) . '
+					});
 				}
-
-				" . self::tracker_var() . "( 'ec:addProduct', {
-					'id': '" . esc_js( $product->get_id() ) . "',
-					'name': '" . esc_js( $product->get_title() ) . "',
-					'category': " . self::product_get_category_line( $product ) . '
-				});
-
 				' . self::tracker_var() . "( 'ec:setAction', 'click', { list: '" . esc_js( $list ) . "' });
 				" . self::tracker_var() . "( 'send', 'event', 'UX', 'click', ' " . esc_js( $list ) . "' );
 			});

--- a/includes/class-wc-google-analytics-js.php
+++ b/includes/class-wc-google-analytics-js.php
@@ -109,9 +109,8 @@ class WC_Google_Analytics_JS extends WC_Abstract_Google_Analytics_JS {
 	 * Enqueues JavaScript to build the addImpression object
 	 *
 	 * @param WC_Product $product
-	 * @param int        $position
 	 */
-	public static function listing_impression( $product, $position ) {
+	public static function listing_impression( $product ) {
 		if ( is_search() ) {
 			$list = 'Search Results';
 		} else {
@@ -123,8 +122,7 @@ class WC_Google_Analytics_JS extends WC_Abstract_Google_Analytics_JS {
 				'id': '" . esc_js( $product->get_id() ) . "',
 				'name': '" . esc_js( $product->get_title() ) . "',
 				'category': " . self::product_get_category_line( $product ) . "
-				'list': '" . esc_js( $list ) . "',
-				'position': '" . esc_js( $position ) . "'
+				'list': '" . esc_js( $list ) . "'
 			} );
 		"
 		);
@@ -134,9 +132,8 @@ class WC_Google_Analytics_JS extends WC_Abstract_Google_Analytics_JS {
 	 * Enqueues JavaScript to build an addProduct and click object
 	 *
 	 * @param WC_Product $product
-	 * @param int        $position
 	 */
-	public static function listing_click( $product, $position ) {
+	public static function listing_click( $product ) {
 		if ( is_search() ) {
 			$list = 'Search Results';
 		} else {
@@ -153,11 +150,10 @@ class WC_Google_Analytics_JS extends WC_Abstract_Google_Analytics_JS {
 				" . self::tracker_var() . "( 'ec:addProduct', {
 					'id': '" . esc_js( $product->get_id() ) . "',
 					'name': '" . esc_js( $product->get_title() ) . "',
-					'category': " . self::product_get_category_line( $product ) . "
-					'position': '" . esc_js( $position ) . "'
+					'category': " . self::product_get_category_line( $product ) . '
 				});
 
-				" . self::tracker_var() . "( 'ec:setAction', 'click', { list: '" . esc_js( $list ) . "' });
+				' . self::tracker_var() . "( 'ec:setAction', 'click', { list: '" . esc_js( $list ) . "' });
 				" . self::tracker_var() . "( 'send', 'event', 'UX', 'click', ' " . esc_js( $list ) . "' );
 			});
 		"

--- a/includes/class-wc-google-analytics.php
+++ b/includes/class-wc-google-analytics.php
@@ -131,8 +131,7 @@ class WC_Google_Analytics extends WC_Integration {
 		add_action( 'woocommerce_after_cart', array( $this, 'remove_from_cart' ) );
 		add_action( 'woocommerce_after_mini_cart', array( $this, 'remove_from_cart' ) );
 		add_filter( 'woocommerce_cart_item_remove_link', array( $this, 'remove_from_cart_attributes' ), 10, 2 );
-		add_action( 'woocommerce_after_shop_loop_item_title', array( $this, 'listing_click' ) );
-		add_action( 'woocommerce_after_shop_loop_item_title', array( $this, 'listing_impression' ) );
+		add_filter( 'woocommerce_loop_add_to_cart_link', array( $this, 'track_product' ), 10, 2 );
 		add_action( 'woocommerce_after_single_product', array( $this, 'product_detail' ) );
 		add_action( 'woocommerce_after_checkout_form', array( $this, 'checkout_process' ) );
 
@@ -651,27 +650,18 @@ class WC_Google_Analytics extends WC_Integration {
 	}
 
 	/**
-	 * Measures a listing impression (from search results)
+	 * Measure a product click and impression from a Product list
+	 *
+	 * @param string     $link The Add To Cart Link
+	 * @param WC_Product $product The Product
 	 */
-	public function listing_impression() {
-		if ( ! $this->enhanced_ecommerce_enabled( $this->ga_enhanced_product_impression_enabled ) ) {
-			return;
+	public function track_product( $link, $product ) {
+		if ( $this->enhanced_ecommerce_enabled( $this->ga_enhanced_product_click_enabled ) ) {
+			$this->get_tracking_instance()->listing_impression( $product );
+			$this->get_tracking_instance()->listing_click( $product );
 		}
 
-		global $product, $woocommerce_loop;
-		$this->get_tracking_instance()->listing_impression( $product, $woocommerce_loop['loop'] );
-	}
-
-	/**
-	 * Measure a product click from a listing page
-	 */
-	public function listing_click() {
-		if ( ! $this->enhanced_ecommerce_enabled( $this->ga_enhanced_product_click_enabled ) ) {
-			return;
-		}
-
-		global $product, $woocommerce_loop;
-		$this->get_tracking_instance()->listing_click( $product, $woocommerce_loop['loop'] );
+		return $link;
 	}
 
 	/**

--- a/includes/class-wc-google-gtag-js.php
+++ b/includes/class-wc-google-gtag-js.php
@@ -174,19 +174,17 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 	 * Enqueues JavaScript to build the view_item_list event
 	 *
 	 * @param WC_Product $product
-	 * @param int        $position
 	 */
-	public static function listing_impression( $product, $position ) {
+	public static function listing_impression( $product ) {
 		$event_code = self::get_event_code(
 			'view_item_list',
 			array(
 				'items' => array(
 					array(
-						'id'            => self::get_product_identifier( $product ),
-						'name'          => $product->get_title(),
-						'category'      => self::product_get_category_line( $product ),
-						'list'          => self::get_list_name(),
-						'list_position' => $position,
+						'id'       => self::get_product_identifier( $product ),
+						'name'     => $product->get_title(),
+						'category' => self::product_get_category_line( $product ),
+						'list'     => self::get_list_name(),
 					),
 				),
 			)
@@ -199,35 +197,33 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 	 * Enqueues JavaScript for select_content and add_to_cart events for the product archive
 	 *
 	 * @param WC_Product $product
-	 * @param int        $position
 	 */
-	public static function listing_click( $product, $position ) {
-		$items = array(
-			'id'            => self::get_product_identifier( $product ),
-			'name'          => $product->get_title(),
-			'category'      => self::product_get_category_line( $product ),
-			'list_position' => $position,
-			'quantity'      => 1,
+	public static function listing_click( $product ) {
+		$item = array(
+			'id'       => self::get_product_identifier( $product ),
+			'name'     => $product->get_title(),
+			'category' => self::product_get_category_line( $product ),
+			'quantity' => 1,
 		);
 
 		$select_content_event_code = self::get_event_code(
 			'select_content',
 			array(
-				'items' => array( $items ),
+				'items' => array( $item ),
 			)
 		);
 
 		$add_to_cart_event_code = self::get_event_code(
 			'add_to_cart',
 			array(
-				'items' => array( $items ),
+				'items' => array( $item ),
 			)
 		);
 
 		wc_enqueue_js(
 			"
 			$( '.product.post-" . esc_js( $product->get_id() ) . ' a , .product.post-' . esc_js( $product->get_id() ) . " button' ).on('click', function() {
-				if ( true === $(this).hasClass( 'add_to_cart_button' ) ) {
+				if ( false === $(this).hasClass( 'product_type_variable' ) && false === $(this).hasClass( 'product_type_grouped' ) ) {
 					$add_to_cart_event_code
 				} else {
 					$select_content_event_code

--- a/tests/unit-tests/ListingClick.php
+++ b/tests/unit-tests/ListingClick.php
@@ -19,7 +19,7 @@ class ListingClick extends EventsDataTest {
 	 * @return void
 	 */
 	public function test_select_content_and_add_to_cart_event() {
-		$product  = $this->get_product();
+		$product = $this->get_product();
 
 		( new WC_Google_Gtag_JS() )->listing_click( $product );
 
@@ -30,10 +30,10 @@ class ListingClick extends EventsDataTest {
 		$expected_data = array(
 			'items' => array(
 				array(
-					'id'            => WC_Google_Gtag_JS::get_product_identifier( $product ),
-					'name'          => $product->get_title(),
-					'category'      => WC_Google_Gtag_JS::product_get_category_line( $product ),
-					'quantity'      => 1,
+					'id'       => WC_Google_Gtag_JS::get_product_identifier( $product ),
+					'name'     => $product->get_title(),
+					'category' => WC_Google_Gtag_JS::product_get_category_line( $product ),
+					'quantity' => 1,
 				),
 			),
 		);

--- a/tests/unit-tests/ListingClick.php
+++ b/tests/unit-tests/ListingClick.php
@@ -20,9 +20,8 @@ class ListingClick extends EventsDataTest {
 	 */
 	public function test_select_content_and_add_to_cart_event() {
 		$product  = $this->get_product();
-		$position = 1;
 
-		( new WC_Google_Gtag_JS() )->listing_click( $product, $position );
+		( new WC_Google_Gtag_JS() )->listing_click( $product );
 
 		// Code is generated for two events in listing_click() so we would expect the filter is called twice.
 		$this->assertEquals( 2, $this->get_event_data_filter_call_count(), 'woocommerce_gtag_event_data filter was not called for select_content and add_to_cart (listing_click()) events' );
@@ -34,7 +33,6 @@ class ListingClick extends EventsDataTest {
 					'id'            => WC_Google_Gtag_JS::get_product_identifier( $product ),
 					'name'          => $product->get_title(),
 					'category'      => WC_Google_Gtag_JS::product_get_category_line( $product ),
-					'list_position' => $position,
 					'quantity'      => 1,
 				),
 			),

--- a/tests/unit-tests/ListingImpression.php
+++ b/tests/unit-tests/ListingImpression.php
@@ -19,7 +19,7 @@ class ListingImpression extends EventsDataTest {
 	 * @return void
 	 */
 	public function test_view_item_list_event() {
-		$product  = $this->get_product();
+		$product = $this->get_product();
 
 		( new WC_Google_Gtag_JS() )->listing_impression( $product );
 
@@ -30,10 +30,10 @@ class ListingImpression extends EventsDataTest {
 		$expected_data = array(
 			'items' => array(
 				array(
-					'id'            => WC_Google_Gtag_JS::get_product_identifier( $product ),
-					'name'          => $product->get_title(),
-					'category'      => WC_Google_Gtag_JS::product_get_category_line( $product ),
-					'list'          => WC_Google_Gtag_JS::get_list_name()
+					'id'       => WC_Google_Gtag_JS::get_product_identifier( $product ),
+					'name'     => $product->get_title(),
+					'category' => WC_Google_Gtag_JS::product_get_category_line( $product ),
+					'list'     => WC_Google_Gtag_JS::get_list_name(),
 				),
 			),
 		);

--- a/tests/unit-tests/ListingImpression.php
+++ b/tests/unit-tests/ListingImpression.php
@@ -20,9 +20,8 @@ class ListingImpression extends EventsDataTest {
 	 */
 	public function test_view_item_list_event() {
 		$product  = $this->get_product();
-		$position = 1;
 
-		( new WC_Google_Gtag_JS() )->listing_impression( $product, $position );
+		( new WC_Google_Gtag_JS() )->listing_impression( $product );
 
 		// Confirm woocommerce_gtag_event_data is called by listing_impression().
 		$this->assertEquals( 1, $this->get_event_data_filter_call_count(), 'woocommerce_gtag_event_data filter was not called for view_item_list (listing_impression()) event' );
@@ -34,8 +33,7 @@ class ListingImpression extends EventsDataTest {
 					'id'            => WC_Google_Gtag_JS::get_product_identifier( $product ),
 					'name'          => $product->get_title(),
 					'category'      => WC_Google_Gtag_JS::product_get_category_line( $product ),
-					'list'          => WC_Google_Gtag_JS::get_list_name(),
-					'list_position' => $position,
+					'list'          => WC_Google_Gtag_JS::get_list_name()
 				),
 			),
 		);


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #299 
Follow up for #298 

* This PR refactors Product Impression and Add To Cart on the product list page using:

Traditional Theme with no blocks (ie TT1)
Blocks theme (ie TT3)
All Products Block
Products (Beta) Block

* It also fixes a bug when select_content in GTAG (ie product variable or grouped) was not being tracked... triggering add_to_cart event instead 

* Removes support for list_position. As it seems not available in blocks.

* It works for AJAX Add to Cart as well as link Add To Cart

### Checks:
<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Screenshots:
<img width="557" alt="Screenshot 2023-09-14 at 12 06 36" src="https://github.com/woocommerce/woocommerce-google-analytics-integration/assets/5908855/0965714d-55dd-4772-928d-c51ef8fddf14">
<img width="550" alt="Screenshot 2023-09-14 at 12 00 45" src="https://github.com/woocommerce/woocommerce-google-analytics-integration/assets/5908855/c9e1bdfe-f8a4-4ba2-8faf-84a5fe91649d">


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

**GTAG**
1. Install Google Analytics Debugger Extension for your browser
2. In WooComemrce -> Settings -> Products. Activate "Enable AJAX add to cart buttons on archives"
3. Go to WooCommerce -> Settings -> Integration -> Google Analytics.  And check everything 
4. Install some theme that supports blocks, like TT3
5. Go to Shop page
6. See that "view_item_list" event is being triggered for each product in the console. 
7. Add one simple product to cart clicking on Add To Cart.
8. See that "add_to_cart" event is being triggered in the console.
9. Click one variable product "Select options" button
10. See that "select_content" event is being triggered in the console.
11. Repeat these tests for a theme not supporting blocks, like TT1
12. A page with "All products block"
13. A page with "Products Beta Block"
14. With WooComemrce -> Settings -> Products. And Disable "Enable AJAX add to cart buttons on archives"

**Universal Analytics**
1. Go to WooCommerce -> Settings -> Integration -> Google Analytics.  And disable "Use Global Site Tag"
2. Repeat all the test for GTAG the only difference is in the name of events: 'add_to_cart' is 'ec:addProduct' and 'view_item_list' is ''ec:addImpression'. (Notice select_content is not available in Universal Analaytics, so for variable products we just don't trigger  'ec:addProduct' )


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Tweak - Tracking for Products ( Add To Cart and Impression) when using Products (Beta) Block
> Fix - Track select_content instead of add_to_cart for variations. 
