### PR TITLE
Add section to privacy policy guide

### DIFF
--- a/includes/class-wc-google-analytics.php
+++ b/includes/class-wc-google-analytics.php
@@ -120,6 +120,7 @@ class WC_Google_Analytics extends WC_Integration {
 		add_action( 'woocommerce_update_options_integration_google_analytics', array( $this, 'process_admin_options' ) );
 		add_action( 'woocommerce_update_options_integration_google_analytics', array( $this, 'show_options_info' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'load_admin_assets' ) );
+		add_action( 'admin_init', array( $this, 'privacy_policy' ) );
 
 		// Tracking code
 		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_tracking_code' ), 9 );
@@ -420,6 +421,22 @@ class WC_Google_Analytics extends WC_Integration {
 			Plugin::get_instance()->get_js_asset_version( 'admin-ga-settings' ),
 			true
 		);
+	}
+
+	/**
+	 * Add suggested privacy policy content
+	 *
+	 * @return void
+	 */
+	public function privacy_policy() {
+		$content = '<p class="privacy-policy-tutorial">' . sprintf(
+			/* translators: 1) HTML anchor open tag 2) HTML anchor closing tag */
+			esc_html__( 'By using this extension, you may be storing personal data or sharing data with an external service. %1$sLearn more about what data is collected by Google and what you may want to include in your privacy policy.%2$s.', 'woocommerce-google-analytics-integration' ),
+			'<a href="https://support.google.com/analytics/answer/7318509" target="_blank">',
+			'</a>'
+		) . '</p>';
+
+		wp_add_privacy_policy_content( 'WooCommerce Google Analytics Integration', wpautop( $content, false ) );
 	}
 
 	/**

--- a/includes/class-wc-google-analytics.php
+++ b/includes/class-wc-google-analytics.php
@@ -429,12 +429,17 @@ class WC_Google_Analytics extends WC_Integration {
 	 * @return void
 	 */
 	public function privacy_policy() {
-		$content = '<p class="privacy-policy-tutorial">' . sprintf(
+		$policy_text = sprintf(
 			/* translators: 1) HTML anchor open tag 2) HTML anchor closing tag */
-			esc_html__( 'By using this extension, you may be storing personal data or sharing data with an external service. %1$sLearn more about what data is collected by Google and what you may want to include in your privacy policy.%2$s.', 'woocommerce-google-analytics-integration' ),
+			esc_html__( 'By using this extension, you may be storing personal data or sharing data with an external service. %1$sLearn more about what data is collected by Google and what you may want to include in your privacy policy%2$s.', 'woocommerce-google-analytics-integration' ),
 			'<a href="https://support.google.com/analytics/answer/7318509" target="_blank">',
 			'</a>'
-		) . '</p>';
+		);
+
+		// As the extension doesn't offer suggested privacy policy text, the button to copy it is hidden.
+		$content = '
+			<p class="privacy-policy-tutorial">' . $policy_text . '</p>
+			<style>#privacy-settings-accordion-block-woocommerce-google-analytics-integration .privacy-settings-accordion-actions { display: none }</style>';
 
 		wp_add_privacy_policy_content( 'WooCommerce Google Analytics Integration', wpautop( $content, false ) );
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Adds a section to the privacy policy guide directing merchants to the Google Analytics privacy documentation.

### Screenshots:

<img width="1011" alt="Screenshot 2023-09-20 at 18 44 30" src="https://github.com/woocommerce/woocommerce-google-analytics-integration/assets/40762232/9839a837-1d0b-4799-809e-34e9d5fe6c74">

### Detailed test instructions:

1. Checkout `add/privacy-policy-content`
2. Go to `wp-admin > Settings > Privacy > Policy Guide`
3. Check `WooCommerce Google Analytics Integration` section and confirm links work

### Changelog entry

> Add - Privacy policy guide section