### PR TITLE
Add documentation link with UTM parameters

### DIFF
--- a/woocommerce-google-analytics-integration.php
+++ b/woocommerce-google-analytics-integration.php
@@ -105,10 +105,13 @@ if ( ! class_exists( 'WC_Google_Analytics_Integration' ) ) {
 		 */
 		public function plugin_links( $links ) {
 			$settings_url = $this->get_settings_url();
+			$support_url  = 'https://wordpress.org/support/plugin/woocommerce-google-analytics-integration';
+			$docs_url     = 'https://woocommerce.com/document/google-analytics-integration/?utm_source=wordpress&utm_medium=all-plugins-page&utm_campaign=doc-link&utm_content=woocommerce-google-analytics-integration';
 
 			$plugin_links = array(
-				'<a href="' . esc_url( $settings_url ) . '">' . __( 'Settings', 'woocommerce-google-analytics-integration' ) . '</a>',
-				'<a href="https://wordpress.org/support/plugin/woocommerce-google-analytics-integration">' . __( 'Support', 'woocommerce-google-analytics-integration' ) . '</a>',
+				'<a href="' . esc_url( $settings_url ) . '">' . esc_html__( 'Settings', 'woocommerce-google-analytics-integration' ) . '</a>',
+				'<a href="' . esc_url( $support_url ) . '">' . esc_html__( 'Support', 'woocommerce-google-analytics-integration' ) . '</a>',
+				'<a href="' . esc_url( $docs_url ) . '">' . esc_html__( 'Documentation', 'woocommerce-google-analytics-integration' ) . '</a>',
 			);
 
 			return array_merge( $plugin_links, $links );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Project: peeuvX-WJ-p2

This PR adds a documentation link with UTM parameters so we can track the incoming source from the plugins page.

### Detailed test instructions:
1. Go to the plugins page and ensure GLA is activated 
2. Ensure the plugin link Documentation is present and includes the correct UTM parameters
![image](https://github.com/woocommerce/woocommerce-google-analytics-integration/assets/11388669/b2f0bf13-2d52-4f14-923b-8bfabc64b150)

### Changelog entry
* Tweak - Add documentation link with UTM parameters.