### PR TITLE
Enable since tag replacement

### DIFF
--- a/includes/class-wc-google-analytics.php
+++ b/includes/class-wc-google-analytics.php
@@ -708,7 +708,7 @@ class WC_Google_Analytics extends WC_Integration {
 	/**
 	 * Check if the Google Analytics Tracking ID has been set up.
 	 *
-	 * @since x.x.x
+	 * @since 1.5.17
 	 *
 	 * @return bool Whether the Google Analytics setup is completed.
 	 */
@@ -720,7 +720,7 @@ class WC_Google_Analytics extends WC_Integration {
 	/**
 	 * Adds the setup task to the Tasklists.
 	 *
-	 * @since x.x.x
+	 * @since 1.5.17
 	 */
 	public function add_wc_setup_task() {
 		require_once 'class-wc-google-analytics-task.php';

--- a/includes/class-wc-google-gtag-js.php
+++ b/includes/class-wc-google-gtag-js.php
@@ -465,7 +465,7 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 	}
 
 	/**
-	 * @deprecated x.x.x
+	 * @deprecated 1.6.0
 	 *
 	 * Enqueue JavaScript for Add to cart tracking
 	 *

--- a/package.json
+++ b/package.json
@@ -42,6 +42,12 @@
     "npm": ">=6"
   },
   "config": {
-    "wp_org_slug": "woocommerce-google-analytics-integration"
+    "wp_org_slug": "woocommerce-google-analytics-integration",
+    "version_replace_paths": [
+      "src",
+      "tests",
+      "bin",
+      "woocommerce-google-analytics-integration.php"
+		]
   }
 }

--- a/package.json
+++ b/package.json
@@ -44,9 +44,8 @@
   "config": {
     "wp_org_slug": "woocommerce-google-analytics-integration",
     "version_replace_paths": [
-      "src",
+      "includes",
       "tests",
-      "bin",
       "woocommerce-google-analytics-integration.php"
 		]
   }

--- a/tests/EventsDataTest.php
+++ b/tests/EventsDataTest.php
@@ -9,9 +9,9 @@ use WC_Helper_Order;
 use MockAction;
 
 /**
- * Class UnitTest
+ * Class EventsDataTest
  *
- * @since x.x.x
+ * @since 1.6.0
  */
 abstract class EventsDataTest extends WP_UnitTestCase {
 

--- a/tests/unit-tests/AddTransactionEnhanced.php
+++ b/tests/unit-tests/AddTransactionEnhanced.php
@@ -7,7 +7,7 @@ use WC_Google_Gtag_JS;
 /**
  * Class AddTransactionEnhanced
  *
- * @since x.x.x
+ * @since 1.6.0
  *
  * @package GoogleAnalyticsIntegration\Tests
  */

--- a/tests/unit-tests/CheckoutProcess.php
+++ b/tests/unit-tests/CheckoutProcess.php
@@ -7,7 +7,7 @@ use WC_Google_Gtag_JS;
 /**
  * Class CheckoutProcess
  *
- * @since x.x.x
+ * @since 1.6.0
  *
  * @package GoogleAnalyticsIntegration\Tests
  */

--- a/tests/unit-tests/ListingClick.php
+++ b/tests/unit-tests/ListingClick.php
@@ -7,7 +7,7 @@ use WC_Google_Gtag_JS;
 /**
  * Class ListingClick
  *
- * @since x.x.x
+ * @since 1.6.0
  *
  * @package GoogleAnalyticsIntegration\Tests
  */

--- a/tests/unit-tests/ListingImpression.php
+++ b/tests/unit-tests/ListingImpression.php
@@ -7,7 +7,7 @@ use WC_Google_Gtag_JS;
 /**
  * Class ListingImpression
  *
- * @since x.x.x
+ * @since 1.6.0
  *
  * @package GoogleAnalyticsIntegration\Tests
  */

--- a/tests/unit-tests/ProductDetail.php
+++ b/tests/unit-tests/ProductDetail.php
@@ -7,7 +7,7 @@ use WC_Google_Gtag_JS;
 /**
  * Class ProductDetail
  *
- * @since x.x.x
+ * @since 1.6.0
  *
  * @package GoogleAnalyticsIntegration\Tests
  */

--- a/tests/unit-tests/WCGoogleGtagJS.php
+++ b/tests/unit-tests/WCGoogleGtagJS.php
@@ -8,7 +8,7 @@ use WC_Helper_Product;
 /**
  * Unit tests for `WC_Google_Gtag_JS` class.
  *
- * @since x.x.x
+ * @since 1.8.1
  *
  * @package GoogleAnalyticsIntegration\Tests
  */

--- a/woocommerce-google-analytics-integration.php
+++ b/woocommerce-google-analytics-integration.php
@@ -82,7 +82,7 @@ if ( ! class_exists( 'WC_Google_Analytics_Integration' ) ) {
 		/**
 		 * Gets the settings page URL.
 		 *
-		 * @since x.x.x
+		 * @since 1.5.17
 		 *
 		 * @return string Settings URL
 		 */
@@ -172,7 +172,7 @@ if ( ! class_exists( 'WC_Google_Analytics_Integration' ) ) {
 		/**
 		 * Get Google Analytics Integration
 		 *
-		 * @since x.x.x
+		 * @since 1.5.17
 		 *
 		 * @return WC_Google_Analytics The Google Analytics integration.
 		 */


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR enables since tag replacements for WooRelease. It also updates any of the previously missed tags to the corresponding version when the PR was released.

Closes #304

### Detailed test instructions:
1. Confirm there are no more occurrences of the string x.x.x
2. Check the version replace settings are similar to the ones we use in [other repos](https://github.com/woocommerce/google-listings-and-ads/blob/2.5.7/package.json#L127-L133)

### Changelog entry
* Dev - Enable since tag replacement.
