### PR TITLE
Add product identifier setting

### DIFF
--- a/includes/class-wc-abstract-google-analytics-js.php
+++ b/includes/class-wc-abstract-google-analytics-js.php
@@ -31,8 +31,9 @@ abstract class WC_Abstract_Google_Analytics_JS {
 	/**
 	 * Return one of our options
 	 *
-	 * @param  string $option Key/name for the option
-	 * @return string         Value of the option
+	 * @param string $option Key/name for the option
+	 *
+	 * @return string|null Value of the option or null if not found
 	 */
 	protected static function get( $option ) {
 		return self::$options[ $option ] ?? null;

--- a/includes/class-wc-abstract-google-analytics-js.php
+++ b/includes/class-wc-abstract-google-analytics-js.php
@@ -35,7 +35,7 @@ abstract class WC_Abstract_Google_Analytics_JS {
 	 * @return string         Value of the option
 	 */
 	protected static function get( $option ) {
-		return self::$options[ $option ];
+		return self::$options[ $option ] ?? null;
 	}
 
 	/**

--- a/includes/class-wc-abstract-google-analytics-js.php
+++ b/includes/class-wc-abstract-google-analytics-js.php
@@ -114,11 +114,17 @@ abstract class WC_Abstract_Google_Analytics_JS {
 	 * @return string
 	 */
 	public static function get_product_identifier( $product ) {
-		if ( ! empty( $product->get_sku() ) ) {
-			return esc_js( $product->get_sku() );
-		} else {
-			return esc_js( '#' . ( $product->is_type( 'variation' ) ? $product->get_parent_id() : $product->get_id() ) );
+		$identifier = $product->get_id();
+
+		if ( 'product_sku' === self::get( 'ga_product_identifier' ) ) {
+			if ( ! empty( $product->get_sku() ) ) {
+				$identifier = $product->get_sku();
+			} else {
+				$identifier = '#' . ( $product->is_type( 'variation' ) ? $product->get_parent_id() : $product->get_id() );
+			}
 		}
+
+		return apply_filters( 'woocommerce_ga_product_identifier', $identifier, $product );
 	}
 
 	/**

--- a/includes/class-wc-google-analytics.php
+++ b/includes/class-wc-google-analytics.php
@@ -189,6 +189,17 @@ class WC_Google_Analytics extends WC_Integration {
 		}
 
 		$this->form_fields = array(
+			'ga_product_identifier'                   => array(
+				'title'       => __( 'Product Identification', 'woocommerce-google-analytics-integration' ),
+				'description' => __( 'Specify how your products will be identified to Google Analytics. Changing this setting may cause issues with historical data if a product was previously identified using a different structure.', 'woocommerce-google-analytics-integration' ),
+				'type'        => 'select',
+				'options'     => array(
+					'product_id'  => __( 'Product ID', 'woocommerce-google-analytics-integration' ),
+					'product_sku' => __( 'Product SKU with prefixed (#) ID as fallback', 'woocommerce-google-analytics-integration' )
+				),
+				// If the option is not set then the product SKU is used as default for existing installations
+				'default'     => get_option( 'woocommerce_ga_product_identifier', 'product_sku' )
+			),
 			'ga_id'                                   => array(
 				'title'       => __( 'Google Analytics Tracking ID', 'woocommerce-google-analytics-integration' ),
 				'description' => __( 'Log into your Google Analytics account to find your ID. e.g. <code>GT-XXXXX</code> or <code>G-XXXXX</code>', 'woocommerce-google-analytics-integration' ),

--- a/includes/class-wc-google-analytics.php
+++ b/includes/class-wc-google-analytics.php
@@ -199,7 +199,7 @@ class WC_Google_Analytics extends WC_Integration {
 					'product_sku' => __( 'Product SKU with prefixed (#) ID as fallback', 'woocommerce-google-analytics-integration' )
 				),
 				// If the option is not set then the product SKU is used as default for existing installations
-				'default'     => get_option( 'woocommerce_ga_product_identifier', 'product_sku' )
+				'default'     => 'product_sku'
 			),
 			'ga_id'                                   => array(
 				'title'       => __( 'Google Analytics Tracking ID', 'woocommerce-google-analytics-integration' ),

--- a/includes/class-wc-google-analytics.php
+++ b/includes/class-wc-google-analytics.php
@@ -147,30 +147,31 @@ class WC_Google_Analytics extends WC_Integration {
 	 */
 	public function init_options() {
 		$options = array(
-			'ga_id',
-			'ga_set_domain_name',
-			'ga_gtag_enabled',
-			'ga_standard_tracking_enabled',
-			'ga_support_display_advertising',
-			'ga_support_enhanced_link_attribution',
-			'ga_use_universal_analytics',
-			'ga_anonymize_enabled',
-			'ga_404_tracking_enabled',
-			'ga_ecommerce_tracking_enabled',
-			'ga_enhanced_ecommerce_tracking_enabled',
-			'ga_enhanced_remove_from_cart_enabled',
-			'ga_enhanced_product_impression_enabled',
-			'ga_enhanced_product_click_enabled',
-			'ga_enhanced_checkout_process_enabled',
-			'ga_enhanced_product_detail_view_enabled',
-			'ga_event_tracking_enabled',
-			'ga_linker_cross_domains',
-			'ga_linker_allow_incoming_enabled',
+			'ga_product_identifier'                   => 'product_sku',
+			'ga_id'                                   => null,
+			'ga_set_domain_name'                      => null,
+			'ga_gtag_enabled'                         => null,
+			'ga_standard_tracking_enabled'            => null,
+			'ga_support_display_advertising'          => null,
+			'ga_support_enhanced_link_attribution'    => null,
+			'ga_use_universal_analytics'              => null,
+			'ga_anonymize_enabled'                    => null,
+			'ga_404_tracking_enabled'                 => null,
+			'ga_ecommerce_tracking_enabled'           => null,
+			'ga_enhanced_ecommerce_tracking_enabled'  => null,
+			'ga_enhanced_remove_from_cart_enabled'    => null,
+			'ga_enhanced_product_impression_enabled'  => null,
+			'ga_enhanced_product_click_enabled'       => null,
+			'ga_enhanced_checkout_process_enabled'    => null,
+			'ga_enhanced_product_detail_view_enabled' => null,
+			'ga_event_tracking_enabled'               => null,
+			'ga_linker_cross_domains'                 => null,
+			'ga_linker_allow_incoming_enabled'        => null,
 		);
 
 		$constructor = array();
-		foreach ( $options as $option ) {
-			$constructor[ $option ] = $this->$option = $this->get_option( $option );
+		foreach ( $options as $option => $default ) {
+			$constructor[ $option ] = $this->$option = $this->get_option( $option, $default );
 		}
 
 		return $constructor;

--- a/includes/class-wc-google-analytics.php
+++ b/includes/class-wc-google-analytics.php
@@ -196,10 +196,10 @@ class WC_Google_Analytics extends WC_Integration {
 				'type'        => 'select',
 				'options'     => array(
 					'product_id'  => __( 'Product ID', 'woocommerce-google-analytics-integration' ),
-					'product_sku' => __( 'Product SKU with prefixed (#) ID as fallback', 'woocommerce-google-analytics-integration' )
+					'product_sku' => __( 'Product SKU with prefixed (#) ID as fallback', 'woocommerce-google-analytics-integration' ),
 				),
 				// If the option is not set then the product SKU is used as default for existing installations
-				'default'     => 'product_sku'
+				'default'     => 'product_sku',
 			),
 			'ga_id'                                   => array(
 				'title'       => __( 'Google Analytics Tracking ID', 'woocommerce-google-analytics-integration' ),

--- a/tests/unit-tests/WCGoogleGtagJS.php
+++ b/tests/unit-tests/WCGoogleGtagJS.php
@@ -116,4 +116,39 @@ class WCGoogleGtagJS extends EventsDataTest {
 		$this->assertEquals( true, wp_script_is( $gtag->script_handle . '-ga-integration', 'enqueued' ), 'the script is enqueued' );
 	}
 
+	/**
+	 * Test the get_product_identifier method to verify:
+	 *
+	 * 1. Product SKU is returned if the `ga_product_identifier` option is set to `product_sku`.
+	 * 2. Prefixed (#) product ID is returned if the `ga_product_identifier` option is set to `product_sku` and the product SKU is empty.
+	 * 3. Product ID is returned if the `ga_product_identifier` option is set to `product_id`.
+	 * 4. The filter `woocommerce_ga_product_identifier` can be used to modify the value.
+	 *
+	 * @return void
+	 */
+	public function test_get_product_identifier() {
+		$mock_sku = $this->getMockBuilder( WC_Google_Gtag_JS::class )
+						 ->setMethods( array( '__construct' ) )
+						 ->setConstructorArgs( array( array( 'ga_product_identifier' => 'product_sku' ) ) )
+						 ->getMock();
+
+		$this->assertEquals( $this->get_product()->get_sku(), $mock_sku::get_product_identifier( $this->get_product() ) );
+
+		$this->get_product()->set_sku( '' );
+		$this->assertEquals( '#' . $this->get_product()->get_id(), $mock_sku::get_product_identifier( $this->get_product() ) );
+
+		$mock_id = $this->getMockBuilder( WC_Google_Gtag_JS::class )
+						->setMethods( array( '__construct' ) )
+						->setConstructorArgs( array( array( 'ga_product_identifier' => 'product_id' ) ) )
+						->getMock();
+
+		$this->assertEquals( $this->get_product()->get_id(), $mock_id::get_product_identifier( $this->get_product() ) );
+
+		add_filter( 'woocommerce_ga_product_identifier', function( $product ) {
+			return 'filtered';
+		} );
+
+		$this->assertEquals( 'filtered', $mock_id::get_product_identifier( $this->get_product() ) );
+	}
+
 }

--- a/tests/unit-tests/WCGoogleGtagJS.php
+++ b/tests/unit-tests/WCGoogleGtagJS.php
@@ -144,9 +144,12 @@ class WCGoogleGtagJS extends EventsDataTest {
 
 		$this->assertEquals( $this->get_product()->get_id(), $mock_id::get_product_identifier( $this->get_product() ) );
 
-		add_filter( 'woocommerce_ga_product_identifier', function( $product ) {
-			return 'filtered';
-		} );
+		add_filter(
+			'woocommerce_ga_product_identifier',
+			function( $product ) {
+				return 'filtered';
+			}
+		);
 
 		$this->assertEquals( 'filtered', $mock_id::get_product_identifier( $this->get_product() ) );
 	}

--- a/woocommerce-google-analytics-integration.php
+++ b/woocommerce-google-analytics-integration.php
@@ -30,6 +30,7 @@ if ( ! class_exists( 'WC_Google_Analytics_Integration' ) ) {
 		__FILE__,
 		function () {
 			WC_Google_Analytics_Integration::get_instance()->maybe_show_ga_pro_notices();
+			WC_Google_Analytics_Integration::get_instance()->maybe_set_defaults();
 		}
 	);
 
@@ -206,6 +207,23 @@ if ( ! class_exists( 'WC_Google_Analytics_Integration' ) ) {
 
 			WC_Admin_Notices::add_custom_notice( 'woocommerce_google_analytics_pro_notice', $notice_html );
 			update_option( 'woocommerce_google_analytics_pro_notice_shown', true );
+		}
+
+		/**
+		 * Set default options during activation if no settings exist
+		 * 
+		 * @since x.x.x
+		 *
+		 * @return void
+		 */
+		public function maybe_set_defaults() {
+			$settings_key = 'woocommerce_google_analytics_settings';
+
+			if ( false === get_option( $settings_key, false ) ) {
+				update_option( $settings_key, array(
+					'ga_product_identifier' => 'product_id'
+				) );
+			}
 		}
 
 		/**

--- a/woocommerce-google-analytics-integration.php
+++ b/woocommerce-google-analytics-integration.php
@@ -211,7 +211,7 @@ if ( ! class_exists( 'WC_Google_Analytics_Integration' ) ) {
 
 		/**
 		 * Set default options during activation if no settings exist
-		 * 
+		 *
 		 * @since x.x.x
 		 *
 		 * @return void
@@ -220,9 +220,12 @@ if ( ! class_exists( 'WC_Google_Analytics_Integration' ) ) {
 			$settings_key = 'woocommerce_google_analytics_settings';
 
 			if ( false === get_option( $settings_key, false ) ) {
-				update_option( $settings_key, array(
-					'ga_product_identifier' => 'product_id'
-				) );
+				update_option(
+					$settings_key,
+					array(
+						'ga_product_identifier' => 'product_id',
+					)
+				);
 			}
 		}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #295 

Adds a new setting to `WooCommerce > Settings > Integration > Google Analytics` that allows merchants to specify the structure of the product identifier for Google Analytics.

### Checks:
* [x] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Screenshots:

![Screenshot 2023-10-04 at 10 05 28](https://github.com/woocommerce/woocommerce-google-analytics-integration/assets/40762232/9724581b-51c3-4ffa-88d3-5d1acfa12fee)


### Detailed test instructions:

1. On a test site that already has Google Analytics Integration configured, deactivate the extension, checkout `add/295-product-identifier-setting`, and re-activate the extension
2. Go to `WooCommerce > Settings > Integration > Google Analytics` and confirm that `Product Identification` is set to `Product SKU with prefixed (#) ID as fallback`
3. Install the extension from this branch on a new test site that has never had Google Analytics Integration installed and configured
4. Go to `WooCommerce > Settings > Integration > Google Analytics` and confirm that `Product Identification` is set to `Product ID` (_The default for new installs_)
5. Enter a value for `Google Analytics Tracking ID`, check `Enable Enhanced eCommerce`, and `Save changes`
6. Visit a product incognito that has a SKU set with GA Debug enabled
7. Check the console to confirm that for the `view_item` event, the item `id` is the product ID
8. In `wp-admin`, change the setting to `Product SKU with prefixed (#) ID as fallback`
9. Refresh the product page incognito and confirm that the SKU is now used for the `view_item` event
10. Delete the SKU for this product
11. Refresh the product page incognito and confirm that the product ID prefixed with a # is now used for the `view_item` event
12. Add a snippet to the site:
```php
add_filter(
	'woocommerce_ga_product_identifier',
	function( $id, $product ) {
		return $product->get_price() . '-test';
	},
	10,
	2
);
```
13. Refresh the product page incognito and confirm that the value set using the filter is now used for the `view_item` event

### Additional details:

This change does not yet apply to tracking when using WooCommerce Blocks. That will be addressed in a follow-up PR.

### Changelog entry

> Add - Setting to specify the structure of the product identifier