### PR TITLE
Wrap inline `remove_from_cart` script in IIFE

### DIFF
--- a/includes/class-wc-google-gtag-js.php
+++ b/includes/class-wc-google-gtag-js.php
@@ -394,10 +394,12 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 		// we listen for clicks on `.woocommerce` container(s),
 		// as `.woocommerce-cart-form` and its items are re-rendered on each removal.
 		wc_enqueue_js(
-			"const selector = '.woocommerce-cart-form__cart-item .remove';
-			$( '.woocommerce' ).off('click', selector).on( 'click', selector, function() {
-				$event_code
-			});"
+			"(function(){
+				const selector = '.woocommerce-cart-form__cart-item .remove';
+				$( '.woocommerce' ).off('click', selector).on( 'click', selector, function() {
+					$event_code
+				});
+			})();"
 		);
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:
Wrap inline `remove_from_cart` script in IIFE
To avoid syntax errors for const re-declaration.
Quick fix for  https://wordpress.org/support/topic/javascript-output-twice/#post-17098290
 7098382-zd-a8c

This is a regression from https://github.com/woocommerce/woocommerce-google-analytics-integration/pull/283



### Checks:
<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

##### Global

1. Enable cart tracking in `/wp-admin/admin.php?page=wc-settings&tab=integration&section=google_analytics`
2. Open the shop page **not as admin**
3. Add something to the cart
4. Open cart page
5. Open the browser console
6. Check that there is no `selector` global variable.


##### Duplicate exectuion

1. Enable cart tracking in `/wp-admin/admin.php?page=wc-settings&tab=integration&section=google_analytics`
2. Add mini-cart widget to the cart page
3. Open the shop page **not as admin**
4. Add something to the cart
5. Open cart page
6. Open the browser console
7. Check that there is no syntax errors

### Additional details:

1. I think we can actually move that script to the external shared file, but I'd leave it for future improvement and ship a quick fix sooner than later.

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - JS syntax error on pages with cart and mini-cart rendered, which was causing purchases and cart removals not to be tracked.