### PR TITLE
Update tracking for blocks

### DIFF
--- a/assets/js/src/actions.js
+++ b/assets/js/src/actions.js
@@ -8,7 +8,6 @@ import {
 	trackAddToCart,
 	trackChangeCartItemQuantity,
 	trackRemoveCartItem,
-	trackCheckoutStep,
 	trackCheckoutOption,
 	trackEvent,
 	trackSelectContent,

--- a/assets/js/src/actions.js
+++ b/assets/js/src/actions.js
@@ -3,6 +3,7 @@ import { removeAction } from '@wordpress/hooks';
 import { NAMESPACE, ACTION_PREFIX } from './constants';
 import {
 	trackBeginCheckout,
+	trackShippingInfo,
 	trackListProducts,
 	trackAddToCart,
 	trackChangeCartItemQuantity,
@@ -37,7 +38,7 @@ addUniqueAction(
 addUniqueAction(
 	`${ ACTION_PREFIX }-checkout-set-shipping-address`,
 	NAMESPACE,
-	( { ...storeCart } ) => trackCheckoutStep( 2 )( storeCart )
+	trackShippingInfo
 );
 
 removeAction( `${ ACTION_PREFIX }-checkout-set-email-address`, NAMESPACE );

--- a/assets/js/src/actions.js
+++ b/assets/js/src/actions.js
@@ -1,4 +1,3 @@
-import { __ } from '@wordpress/i18n';
 import { removeAction } from '@wordpress/hooks';
 import { NAMESPACE, ACTION_PREFIX } from './constants';
 import {

--- a/assets/js/src/actions.js
+++ b/assets/js/src/actions.js
@@ -2,6 +2,7 @@ import { __ } from '@wordpress/i18n';
 
 import { NAMESPACE, ACTION_PREFIX } from './constants';
 import {
+	trackBeginCheckout,
 	trackListProducts,
 	trackAddToCart,
 	trackChangeCartItemQuantity,
@@ -30,8 +31,9 @@ import { addUniqueAction } from './utils';
 addUniqueAction(
 	`${ ACTION_PREFIX }-checkout-render-checkout-form`,
 	NAMESPACE,
-	( { ...storeCart } ) => trackCheckoutStep( 0 )( storeCart )
+	trackBeginCheckout
 );
+
 addUniqueAction(
 	`${ ACTION_PREFIX }-checkout-set-email-address`,
 	NAMESPACE,

--- a/assets/js/src/actions.js
+++ b/assets/js/src/actions.js
@@ -97,20 +97,6 @@ addUniqueAction(
 );
 
 /**
- * Add Payment Information
- *
- * This event signifies a user has submitted their payment information. Note, this is used to indicate checkout
- * submission, not `purchase` which is triggered on the thanks page.
- *
- * @summary Track the add_payment_info event
- * @see https://developers.google.com/gtagjs/reference/ga4-events#add_payment_info
- */
-// addUniqueAction( `${ ACTION_PREFIX }-checkout-submit`, NAMESPACE, ( c ) => {
-// 	console.log( c );
-// 	trackEvent( 'add_payment_info' );
-// } );
-
-/**
  * Product View Link Clicked
  *
  * @summary Track the select_content event

--- a/assets/js/src/actions.js
+++ b/assets/js/src/actions.js
@@ -4,13 +4,10 @@ import { NAMESPACE, ACTION_PREFIX } from './constants';
 import {
 	trackBeginCheckout,
 	trackShippingTier,
-	trackPaymentMethod,
 	trackListProducts,
 	trackAddToCart,
 	trackChangeCartItemQuantity,
 	trackRemoveCartItem,
-	trackCheckoutOption,
-	trackEvent,
 	trackSelectContent,
 	trackSearch,
 	trackViewItem,
@@ -49,24 +46,6 @@ addUniqueAction(
 removeAction( `${ ACTION_PREFIX }-checkout-set-email-address`, NAMESPACE );
 removeAction( `${ ACTION_PREFIX }-checkout-set-phone-number`, NAMESPACE );
 removeAction( `${ ACTION_PREFIX }-checkout-set-billing-address`, NAMESPACE );
-
-/**
- * Choose a payment method
- *
- * @summary Track the payment method being set using set_checkout_option
- * @see https://developers.google.com/analytics/devguides/collection/gtagjs/enhanced-ecommerce#2_measure_checkout_options
- */
-addUniqueAction(
-	`${ ACTION_PREFIX }-checkout-set-active-payment-method`,
-	NAMESPACE,
-	( { paymentMethodSlug } ) => {
-		trackCheckoutOption( {
-			step: 5,
-			option: __( 'Payment Method', 'woo-gutenberg-products-block' ),
-			value: paymentMethodSlug,
-		} )();
-	}
-);
 
 /**
  * Product List View

--- a/assets/js/src/actions.js
+++ b/assets/js/src/actions.js
@@ -1,5 +1,5 @@
 import { __ } from '@wordpress/i18n';
-
+import { removeAction } from '@wordpress/hooks';
 import { NAMESPACE, ACTION_PREFIX } from './constants';
 import {
 	trackBeginCheckout,
@@ -35,27 +35,14 @@ addUniqueAction(
 );
 
 addUniqueAction(
-	`${ ACTION_PREFIX }-checkout-set-email-address`,
-	NAMESPACE,
-	( { ...storeCart } ) => trackCheckoutStep( 1 )( storeCart )
-);
-addUniqueAction(
 	`${ ACTION_PREFIX }-checkout-set-shipping-address`,
 	NAMESPACE,
 	( { ...storeCart } ) => trackCheckoutStep( 2 )( storeCart )
 );
-addUniqueAction(
-	`${ ACTION_PREFIX }-checkout-set-billing-address`,
-	NAMESPACE,
-	( { ...storeCart } ) => trackCheckoutStep( 3 )( storeCart )
-);
-addUniqueAction(
-	`${ ACTION_PREFIX }-checkout-set-phone-number`,
-	NAMESPACE,
-	( { step, ...storeCart } ) => {
-		trackCheckoutStep( step === 'shipping' ? 2 : 3 )( storeCart );
-	}
-);
+
+removeAction( `${ ACTION_PREFIX }-checkout-set-email-address`, NAMESPACE );
+removeAction( `${ ACTION_PREFIX }-checkout-set-phone-number`, NAMESPACE );
+removeAction( `${ ACTION_PREFIX }-checkout-set-billing-address`, NAMESPACE );
 
 /**
  * Choose a shipping rate

--- a/assets/js/src/actions.js
+++ b/assets/js/src/actions.js
@@ -3,7 +3,8 @@ import { removeAction } from '@wordpress/hooks';
 import { NAMESPACE, ACTION_PREFIX } from './constants';
 import {
 	trackBeginCheckout,
-	trackShippingInfo,
+	trackShippingTier,
+	trackPaymentMethod,
 	trackListProducts,
 	trackAddToCart,
 	trackChangeCartItemQuantity,
@@ -18,15 +19,10 @@ import {
 import { addUniqueAction } from './utils';
 
 /**
- * Track customer progress through steps of the checkout. Triggers the event when the step changes:
- * 	1 - Contact information
- * 	2 - Shipping address
- * 	3 - Billing address
- * 	4 - Shipping options
- * 	5 - Payment options
+ * Track begin_checkout
  *
- * @summary Track checkout progress with begin_checkout and checkout_progress
- * @see https://developers.google.com/analytics/devguides/collection/gtagjs/enhanced-ecommerce#1_measure_checkout_steps
+ * @summary Track the customer has started the checkout process
+ * @see https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtag#begin_checkout
  */
 addUniqueAction(
 	`${ ACTION_PREFIX }-checkout-render-checkout-form`,
@@ -34,33 +30,25 @@ addUniqueAction(
 	trackBeginCheckout
 );
 
+/**
+ * Track add_shipping_info
+ *
+ * @summary Track the selected shipping tier when the checkout form is submitted
+ * @see https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtag#add_shipping_info
+ */
 addUniqueAction(
-	`${ ACTION_PREFIX }-checkout-set-shipping-address`,
+	`${ ACTION_PREFIX }-checkout-submit`,
 	NAMESPACE,
-	trackShippingInfo
+	trackShippingTier
 );
 
+/**
+ * The following actions were previously tracked using]checkout_progress
+ * in UA but there is no comparable event in GA4.
+ */
 removeAction( `${ ACTION_PREFIX }-checkout-set-email-address`, NAMESPACE );
 removeAction( `${ ACTION_PREFIX }-checkout-set-phone-number`, NAMESPACE );
 removeAction( `${ ACTION_PREFIX }-checkout-set-billing-address`, NAMESPACE );
-
-/**
- * Choose a shipping rate
- *
- * @summary Track the shipping rate being set using set_checkout_option
- * @see https://developers.google.com/analytics/devguides/collection/gtagjs/enhanced-ecommerce#2_measure_checkout_options
- */
-addUniqueAction(
-	`${ ACTION_PREFIX }-checkout-set-selected-shipping-rate`,
-	NAMESPACE,
-	( { shippingRateId } ) => {
-		trackCheckoutOption( {
-			step: 4,
-			option: __( 'Shipping Method', 'woo-gutenberg-products-block' ),
-			value: shippingRateId,
-		} )();
-	}
-);
 
 /**
  * Choose a payment method
@@ -138,9 +126,10 @@ addUniqueAction(
  * @summary Track the add_payment_info event
  * @see https://developers.google.com/gtagjs/reference/ga4-events#add_payment_info
  */
-addUniqueAction( `${ ACTION_PREFIX }-checkout-submit`, NAMESPACE, () => {
-	trackEvent( 'add_payment_info' );
-} );
+// addUniqueAction( `${ ACTION_PREFIX }-checkout-submit`, NAMESPACE, ( c ) => {
+// 	console.log( c );
+// 	trackEvent( 'add_payment_info' );
+// } );
 
 /**
  * Product View Link Clicked

--- a/assets/js/src/tracking.js
+++ b/assets/js/src/tracking.js
@@ -89,8 +89,8 @@ export const trackBeginCheckout = ( { storeCart } ) => {
 			storeCart.totals.total_price,
 			storeCart.totals.currency_minor_unit
 		),
-		coupon: storeCart.coupons[ 0 ]?.code || '',
 		items: storeCart.items.map( getProductFieldObject ),
+		...( storeCart.coupons[ 0 ]?.code ? { coupon: storeCart.coupons[ 0 ]?.code } : {} ),
 	} );
 };
 
@@ -107,12 +107,12 @@ export const trackShippingTier = ( { storeCart } ) => {
 			storeCart.totals.total_price,
 			storeCart.totals.currency_minor_unit
 		),
-		coupon: storeCart.coupons[ 0 ]?.code || '',
 		shipping_tier:
 			storeCart.shippingRates[ 0 ]?.shipping_rates?.find(
 				( rate ) => rate.selected
 			)?.name || '',
 		items: storeCart.items.map( getProductFieldObject ),
+		...( storeCart.coupons[ 0 ]?.code ? { coupon: storeCart.coupons[ 0 ]?.code } : {} ),
 	} );
 };
 

--- a/assets/js/src/tracking.js
+++ b/assets/js/src/tracking.js
@@ -45,11 +45,6 @@ export const trackListProducts = ( {
  */
 export const trackAddToCart = ( { product, quantity = 1 } ) => {
 	trackEvent( 'add_to_cart', {
-		event_category: 'ecommerce',
-		event_label: __(
-			'Add to Cart',
-			'woocommerce-google-analytics-integration'
-		),
 		items: [ getProductFieldObject( product, quantity ) ],
 	} );
 };

--- a/assets/js/src/tracking.js
+++ b/assets/js/src/tracking.js
@@ -4,6 +4,7 @@ import {
 	getProductImpressionObject,
 	getProductId,
 	formatPrice,
+	getCartCoupon,
 } from './utils';
 
 /**
@@ -89,8 +90,8 @@ export const trackBeginCheckout = ( { storeCart } ) => {
 			storeCart.totals.total_price,
 			storeCart.totals.currency_minor_unit
 		),
+		...getCartCoupon( storeCart ),
 		items: storeCart.items.map( getProductFieldObject ),
-		...( storeCart.coupons[ 0 ]?.code ? { coupon: storeCart.coupons[ 0 ]?.code } : {} ),
 	} );
 };
 
@@ -111,8 +112,8 @@ export const trackShippingTier = ( { storeCart } ) => {
 			storeCart.shippingRates[ 0 ]?.shipping_rates?.find(
 				( rate ) => rate.selected
 			)?.name || '',
+		...getCartCoupon( storeCart ),
 		items: storeCart.items.map( getProductFieldObject ),
-		...( storeCart.coupons[ 0 ]?.code ? { coupon: storeCart.coupons[ 0 ]?.code } : {} ),
 	} );
 };
 

--- a/assets/js/src/tracking.js
+++ b/assets/js/src/tracking.js
@@ -24,14 +24,14 @@ export const trackListProducts = ( {
 	listName = __( 'Product List', 'woocommerce-google-analytics-integration' ),
 } ) => {
 	trackEvent( 'view_item_list', {
-		event_category: 'engagement',
-		event_label: __(
+		item_list_id: 'engagement',
+		item_list_name: __(
 			'Viewing products',
 			'woocommerce-google-analytics-integration'
 		),
 		items: products.map( ( product, index ) => ( {
 			...getProductImpressionObject( product, listName ),
-			list_position: index + 1,
+			index: index + 1,
 		} ) ),
 	} );
 };

--- a/assets/js/src/tracking.js
+++ b/assets/js/src/tracking.js
@@ -17,17 +17,19 @@ export const trackListProducts = ( {
 	products,
 	listName = __( 'Product List', 'woocommerce-google-analytics-integration' ),
 } ) => {
-	trackEvent( 'view_item_list', {
-		item_list_id: 'engagement',
-		item_list_name: __(
-			'Viewing products',
-			'woocommerce-google-analytics-integration'
-		),
-		items: products.map( ( product, index ) => ( {
-			...getProductImpressionObject( product, listName ),
-			index: index + 1,
-		} ) ),
-	} );
+	if ( products.length > 0 ) {
+		trackEvent( 'view_item_list', {
+			item_list_id: 'engagement',
+			item_list_name: __(
+				'Viewing products',
+				'woocommerce-google-analytics-integration'
+			),
+			items: products.map( ( product, index ) => ( {
+				...getProductImpressionObject( product, listName ),
+				index: index + 1,
+			} ) ),
+		} );
+	}
 };
 
 /**

--- a/assets/js/src/tracking.js
+++ b/assets/js/src/tracking.js
@@ -6,13 +6,6 @@ import {
 } from './utils';
 
 /**
- * Variable holding the current checkout step. It will be modified by trackCheckoutOption and trackCheckoutStep methods.
- *
- * @type {number}
- */
-let currentStep = -1;
-
-/**
  * Tracks view_item_list event
  *
  * @param {Object} params The function params

--- a/assets/js/src/tracking.js
+++ b/assets/js/src/tracking.js
@@ -120,15 +120,11 @@ export const trackShippingTier = ( storeCart ) => {
  *
  * @param {Object} params The function params
  * @param {Object} params.product The product to track
- * @param {string} params.listName The name of the list in which the item was presented to the user.
  */
-export const trackSelectContent = ( {
-	product,
-	listName = __( 'Product List', 'woocommerce-google-analytics-integration' ),
-} ) => {
+export const trackSelectContent = ( { product } ) => {
 	trackEvent( 'select_content', {
 		content_type: 'product',
-		items: [ getProductImpressionObject( product, listName ) ],
+		content_id: getProductId( product ),
 	} );
 };
 

--- a/assets/js/src/tracking.js
+++ b/assets/js/src/tracking.js
@@ -116,29 +116,6 @@ export const trackShippingTier = ( storeCart ) => {
 };
 
 /**
- * Track a set_checkout_option event
- * Notice calling this will set the current checkout step as the step provided in the parameter.
- *
- * @param {Object} params The params from the option.
- * @param {number} params.step The step to track
- * @param {string} params.option The option to set in checkout
- * @param {string} params.value The value for the option
- *
- * @return {(function() : void)} A callable to track the checkout event.
- */
-export const trackCheckoutOption =
-	( { step, option, value } ) =>
-	() => {
-		trackEvent( 'set_checkout_option', {
-			checkout_step: step,
-			checkout_option: option,
-			value,
-		} );
-
-		currentStep = step;
-	};
-
-/**
  * Tracks select_content event.
  *
  * @param {Object} params The function params

--- a/assets/js/src/tracking.js
+++ b/assets/js/src/tracking.js
@@ -81,6 +81,23 @@ export const trackChangeCartItemQuantity = ( { product, quantity = 1 } ) => {
 };
 
 /**
+ * Track begin_checkout event
+ * 
+ * @param { storeCart: Object } param The cart object received from the store.
+ */
+export const trackBeginCheckout = ( { storeCart } ) => {
+	trackEvent( 'begin_checkout', {
+		currency: storeCart.totals.currency_code,
+		value: formatPrice(
+			storeCart.totals.total_price,
+			storeCart.totals.currency_minor_unit
+		),
+		coupon: storeCart.coupons[ 0 ]?.code || '',
+		items: storeCart.items.map( getProductFieldObject ),
+	});
+};
+
+/**
  * Track a begin_checkout and checkout_progress event
  * Notice calling this will set the current checkout step as the step provided in the parameter.
  *

--- a/assets/js/src/tracking.js
+++ b/assets/js/src/tracking.js
@@ -115,34 +115,6 @@ export const trackShippingInfo = ( { storeCart } ) => {
 };
 
 /**
- * Track a begin_checkout and checkout_progress event
- * Notice calling this will set the current checkout step as the step provided in the parameter.
- *
- * @param {number} step The checkout step for to track
- * @return {(function( { storeCart: Object } ): void)} A callable receiving the cart to track the checkout event.
- */
-export const trackCheckoutStep =
-	( step ) =>
-	( { storeCart } ) => {
-		if ( currentStep === step ) {
-			return;
-		}
-
-		trackEvent( step === 0 ? 'begin_checkout' : 'checkout_progress', {
-			items: storeCart.cartItems.map( getProductFieldObject ),
-			coupon: storeCart.cartCoupons[ 0 ]?.code || '',
-			currency: storeCart.cartTotals.currency_code,
-			value: formatPrice(
-				storeCart.cartTotals.total_price,
-				storeCart.cartTotals.currency_minor_unit
-			),
-			checkout_step: step,
-		} );
-
-		currentStep = step;
-	};
-
-/**
  * Track a set_checkout_option event
  * Notice calling this will set the current checkout step as the step provided in the parameter.
  *

--- a/assets/js/src/tracking.js
+++ b/assets/js/src/tracking.js
@@ -2,6 +2,7 @@ import { __ } from '@wordpress/i18n';
 import {
 	getProductFieldObject,
 	getProductImpressionObject,
+	getProductId,
 	formatPrice,
 } from './utils';
 
@@ -75,8 +76,9 @@ export const trackChangeCartItemQuantity = ( { product, quantity = 1 } ) => {
 
 /**
  * Track begin_checkout event
- * 
- * @param { storeCart: Object } param The cart object
+ *
+ * @param {Object} params The function params
+ * @param {Object} params.storeCart The cart object
  */
 export const trackBeginCheckout = ( { storeCart } ) => {
 	trackEvent( 'begin_checkout', {
@@ -87,15 +89,16 @@ export const trackBeginCheckout = ( { storeCart } ) => {
 		),
 		coupon: storeCart.coupons[ 0 ]?.code || '',
 		items: storeCart.items.map( getProductFieldObject ),
-	});
+	} );
 };
 
 /**
  * Track add_shipping_info event
- * 
- * @param { storeCart: Object } param The cart object
+ *
+ * @param {Object} params The function params
+ * @param {Object} params.storeCart The cart object
  */
-export const trackShippingTier = ( storeCart ) => {
+export const trackShippingTier = ( { storeCart } ) => {
 	trackEvent( 'add_shipping_info', {
 		currency: storeCart.totals.currency_code,
 		value: formatPrice(
@@ -103,9 +106,12 @@ export const trackShippingTier = ( storeCart ) => {
 			storeCart.totals.currency_minor_unit
 		),
 		coupon: storeCart.coupons[ 0 ]?.code || '',
-		shipping_tier: storeCart.shippingRates[ 0 ]?.shipping_rates?.find( rate => rate.selected )?.name || '',
+		shipping_tier:
+			storeCart.shippingRates[ 0 ]?.shipping_rates?.find(
+				( rate ) => rate.selected
+			)?.name || '',
 		items: storeCart.items.map( getProductFieldObject ),
-	});
+	} );
 };
 
 /**

--- a/assets/js/src/tracking.js
+++ b/assets/js/src/tracking.js
@@ -83,10 +83,27 @@ export const trackChangeCartItemQuantity = ( { product, quantity = 1 } ) => {
 /**
  * Track begin_checkout event
  * 
- * @param { storeCart: Object } param The cart object received from the store.
+ * @param { storeCart: Object } param The cart object
  */
 export const trackBeginCheckout = ( { storeCart } ) => {
 	trackEvent( 'begin_checkout', {
+		currency: storeCart.totals.currency_code,
+		value: formatPrice(
+			storeCart.totals.total_price,
+			storeCart.totals.currency_minor_unit
+		),
+		coupon: storeCart.coupons[ 0 ]?.code || '',
+		items: storeCart.items.map( getProductFieldObject ),
+	});
+};
+
+/**
+ * Track add_shipping_info event
+ * 
+ * @param { storeCart: Object } param The cart object
+ */
+export const trackShippingInfo = ( { storeCart } ) => {
+	trackEvent( 'add_shipping_info', {
 		currency: storeCart.totals.currency_code,
 		value: formatPrice(
 			storeCart.totals.total_price,

--- a/assets/js/src/tracking.js
+++ b/assets/js/src/tracking.js
@@ -102,7 +102,7 @@ export const trackBeginCheckout = ( { storeCart } ) => {
  * 
  * @param { storeCart: Object } param The cart object
  */
-export const trackShippingInfo = ( { storeCart } ) => {
+export const trackShippingTier = ( storeCart ) => {
 	trackEvent( 'add_shipping_info', {
 		currency: storeCart.totals.currency_code,
 		value: formatPrice(
@@ -110,6 +110,7 @@ export const trackShippingInfo = ( { storeCart } ) => {
 			storeCart.totals.currency_minor_unit
 		),
 		coupon: storeCart.coupons[ 0 ]?.code || '',
+		shipping_tier: storeCart.shippingRates[ 0 ]?.shipping_rates?.find( rate => rate.selected )?.name || '',
 		items: storeCart.items.map( getProductFieldObject ),
 	});
 };

--- a/assets/js/src/tracking.js
+++ b/assets/js/src/tracking.js
@@ -58,11 +58,6 @@ export const trackAddToCart = ( { product, quantity = 1 } ) => {
  */
 export const trackRemoveCartItem = ( { product, quantity = 1 } ) => {
 	trackEvent( 'remove_from_cart', {
-		event_category: 'ecommerce',
-		event_label: __(
-			'Remove Cart Item',
-			'woocommerce-google-analytics-integration'
-		),
 		items: [ getProductFieldObject( product, quantity ) ],
 	} );
 };

--- a/assets/js/src/utils.js
+++ b/assets/js/src/utils.js
@@ -80,6 +80,21 @@ export const getProductId = ( product ) => {
 };
 
 /**
+ * Returns an Object containing the cart coupon if one has been applied
+ *
+ * @param {Object} storeCart - The cart to check for coupons
+ *
+ * @return {Object} - Either an empty Object or one containing the coupon
+ */
+export const getCartCoupon = ( storeCart ) => {
+	return storeCart.coupons[ 0 ]?.code
+		? {
+				coupon: storeCart.coupons[ 0 ]?.code,
+		  }
+		: {};
+};
+
+/**
  * Returns the name of the first category of a product, or an empty string if the product has no categories.
  *
  * @param {Object} product - The product object

--- a/assets/js/src/utils.js
+++ b/assets/js/src/utils.js
@@ -50,10 +50,10 @@ export const getProductImpressionObject = ( product, listName ) => {
  * @param {string} price - The price to parse
  * @param {number} [currencyMinorUnit=2] - The number decimals to show in the currency
  *
- * @return {string} - The price of the product formatted
+ * @return {number} - The price of the product formatted
  */
 export const formatPrice = ( price, currencyMinorUnit = 2 ) => {
-	return ( parseInt( price, 10 ) / 10 ** currencyMinorUnit ).toString();
+	return parseInt( price, 10 ) / 10 ** currencyMinorUnit;
 };
 
 /**

--- a/assets/js/src/utils.js
+++ b/assets/js/src/utils.js
@@ -11,10 +11,10 @@ import { addAction, removeAction } from '@wordpress/hooks';
  */
 export const getProductFieldObject = ( product, quantity ) => {
 	return {
-		id: getProductId( product ),
-		name: product.name,
+		item_id: getProductId( product ),
+		item_name: product.name,
 		quantity,
-		category: getProductCategory( product ),
+		...getProductCategories( product ),
 		price: formatPrice(
 			product.prices.price,
 			product.prices.currency_minor_unit
@@ -33,10 +33,10 @@ export const getProductFieldObject = ( product, quantity ) => {
  */
 export const getProductImpressionObject = ( product, listName ) => {
 	return {
-		id: getProductId( product ),
-		name: product.name,
-		list_name: listName,
-		category: getProductCategory( product ),
+		item_id: getProductId( product ),
+		item_name: product.name,
+		item_list_name: listName,
+		...getProductCategories( product ),
 		price: formatPrice(
 			product.prices.price,
 			product.prices.currency_minor_unit
@@ -86,8 +86,34 @@ const getProductId = ( product ) => {
  *
  * @return {string} - The name of the first category of the product or an empty string if the product has no categories.
  */
-const getProductCategory = ( product ) => {
+const getProductCategories = ( product ) => {
 	return 'categories' in product && product.categories.length
-		? product.categories[ 0 ].name
-		: '';
+		? getCategoryObject( product.categories )
+		: {};
+};
+
+/**
+ * Returns an object containing up to 5 categories for the product.
+ *
+ * @param {Object} categories - An array of product categories
+ *
+ * @return {Object} - An categories object
+ */
+const getCategoryObject = ( categories ) => {
+	return Object.fromEntries(
+		categories.slice( 0, 5 ).map( ( category, index ) => {
+			return [ formatCategoryKey( index ), category.name ];
+		} )
+	);
+};
+
+/**
+ * Returns the correctly formatted key for the category object.
+ *
+ * @param {number} index Index of the current category
+ *
+ * @return {string} - A formatted key for the category object
+ */
+const formatCategoryKey = ( index ) => {
+	return 'item_category' + ( index > 0 ? index + 1 : '' );
 };

--- a/assets/js/src/utils.js
+++ b/assets/js/src/utils.js
@@ -13,7 +13,7 @@ export const getProductFieldObject = ( product, quantity ) => {
 	return {
 		item_id: getProductId( product ),
 		item_name: product.name,
-		quantity,
+		quantity: product.quantity ?? quantity,
 		...getProductCategories( product ),
 		price: formatPrice(
 			product.prices.price,

--- a/assets/js/src/utils.js
+++ b/assets/js/src/utils.js
@@ -75,7 +75,7 @@ export const addUniqueAction = ( hookName, namespace, callback ) => {
  *
  * @return {string} - The product ID
  */
-const getProductId = ( product ) => {
+export const getProductId = ( product ) => {
 	return product.sku ? product.sku : '#' + product.id;
 };
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #268

Tracking for blocks only supports Universal Analytics as it currently stands. This PR updates the tracking for GA4 and removes references to UA documentation.

### Screenshots:

![Screenshot 2023-10-25 at 19 35 45](https://github.com/woocommerce/woocommerce-google-analytics-integration/assets/40762232/98ddd7fa-f8f1-4dda-b70c-98e2a08ea8af)


### Detailed test instructions:

### `view_item_list`

1. Create a page using the `All Products` block and view page in incognito with GA Debug enabled (_Alternatively use Tag Assistant to monitor events_)
2. Confirm that on the initial page load a `view_item_list` event is triggered with the [correct parameters](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtag#view_item_list)
3. Click on the second page of the product listings and confirm that only one new `view_item_list` is triggered and that it matches the above data structure.

### `add_to_cart`

1. On the `All Products` page, click `Add to cart` for a product
2. Confirm that an `add_to_cart` event is triggered with the [correct parameters](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtag#add_to_cart)

### `remove_from_cart` and `change_cart_quantity`

- These events can be ignored with this PR. The experimental hooks in blocks don't work well for how GA4 expects the `remove_from_cart` event to work. #312 has been opened so that this can be addressed in a follow-up PR.

### `begin_checkout`

**Note:** The `experimental__woocommerce_blocks-checkout-render-checkout-form` hook which the `begin_checkout` event relies on doesn't currently work. Reported in https://github.com/woocommerce/woocommerce-blocks/issues/11472.

1. To test this event, go to the block-powered checkout page, apply a coupon, and run the following in console:
```js
wp.hooks.doAction('experimental__woocommerce_blocks-checkout-render-checkout-form', { storeCart: wp.data.select('wc/store/cart').getCartData() } );
```
2. Confirm that the `begin_checkout` event is triggered with the [correct parameters](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtag#begin_checkout) and that item quantities and coupon name are correct in the event data

### `add_shipping_info`

1. Add more than one shipping option to the test site
2. Select an option during checkout and click `Place Order`
2. Confirm that the `add_shipping_info` event is triggered with the [correct parameters](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtag#add_shipping_info)

### `select_content`

1. Go to a page with the `All Products` block
2. Click on a product
2. Confirm that the `select_content ` event is triggered with the [correct parameters](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtag#select_content)

### `search`

- Doesn't work at the moment. Also reported in https://github.com/woocommerce/woocommerce-blocks/issues/11472.

### Changelog entry

> Update - Tracking for GA4 when using Blocks