### PR TITLE
Slightly simplify JS construction in WC_Google_Gtag_JS

### DIFF
--- a/includes/class-wc-google-gtag-js.php
+++ b/includes/class-wc-google-gtag-js.php
@@ -199,12 +199,14 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 	 * @param WC_Product $product
 	 */
 	public static function listing_click( $product ) {
-		$items = [
+		$event_data = [
 			'items' => [
-				'id'       => self::get_product_identifier( $product ),
-				'name'     => $product->get_title(),
-				'category' => self::product_get_category_line( $product ),
-				'quantity' => 1,
+				[
+					'id'       => self::get_product_identifier( $product ),
+					'name'     => $product->get_title(),
+					'category' => self::product_get_category_line( $product ),
+					'quantity' => 1,
+				],
 			],
 		];
 
@@ -218,8 +220,8 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 					}
 				});",
 				esc_js( $product->get_id() ),
-				self::get_event_code( 'add_to_cart', $items ),
-				self::get_event_code( 'select_content', $items ),
+				self::get_event_code( 'add_to_cart', $event_data ),
+				self::get_event_code( 'select_content', $event_data ),
 			)
 		);
 	}

--- a/includes/class-wc-google-gtag-js.php
+++ b/includes/class-wc-google-gtag-js.php
@@ -481,29 +481,25 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 
 		$parameters = apply_filters( 'woocommerce_gtag_event_tracking_parameters', $parameters );
 
+		$items = '';
 		if ( 'yes' === self::get( 'ga_enhanced_ecommerce_tracking_enabled' ) ) {
-			$track_event = sprintf(
-				self::tracker_var() . "( 'event', %s, { 'event_category': %s, 'event_label': %s, 'items': [ %s ] } );",
+			$items = sprintf(
+				", 'items': [ %s ]",
+				$parameters['item']
+			);
+		}
+		wc_enqueue_js(
+			sprintf(
+				"$( %s ).on( 'click', function() {
+					%s( 'event', %s, { 'event_category': %s, 'event_label': %s%s } );
+				});",
+				$selector,
+				self::tracker_var(),
 				$parameters['action'],
 				$parameters['category'],
 				$parameters['label'],
-				$parameters['item']
-			);
-		} else {
-			$track_event = sprintf(
-				self::tracker_var() . "( 'event', %s, { 'event_category': %s, 'event_label': %s } );",
-				$parameters['action'],
-				$parameters['category'],
-				$parameters['label']
-			);
-		}
-
-		wc_enqueue_js(
-			"
-			$( '" . $selector . "' ).on( 'click', function() {
-				" . $track_event . '
-			});
-		'
+				$items,
+			)
 		);
 	}
 

--- a/includes/class-wc-google-gtag-js.php
+++ b/includes/class-wc-google-gtag-js.php
@@ -199,36 +199,28 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 	 * @param WC_Product $product
 	 */
 	public static function listing_click( $product ) {
-		$item = array(
-			'id'       => self::get_product_identifier( $product ),
-			'name'     => $product->get_title(),
-			'category' => self::product_get_category_line( $product ),
-			'quantity' => 1,
-		);
-
-		$select_content_event_code = self::get_event_code(
-			'select_content',
-			array(
-				'items' => array( $item ),
-			)
-		);
-
-		$add_to_cart_event_code = self::get_event_code(
-			'add_to_cart',
-			array(
-				'items' => array( $item ),
-			)
-		);
+		$items = [
+			'items' => [
+				'id'       => self::get_product_identifier( $product ),
+				'name'     => $product->get_title(),
+				'category' => self::product_get_category_line( $product ),
+				'quantity' => 1,
+			]
+		];
 
 		wc_enqueue_js(
-			"
-			$( '.product.post-" . esc_js( $product->get_id() ) . ' a , .product.post-' . esc_js( $product->get_id() ) . " button' ).on('click', function() {
-				if ( false === $(this).hasClass( 'product_type_variable' ) && false === $(this).hasClass( 'product_type_grouped' ) ) {
-					$add_to_cart_event_code
-				} else {
-					$select_content_event_code
-				}
-			});"
+			sprintf(
+				"$( '.product.post-%s a , .product.post-%1\$s button' ).on('click', function() {
+					if ( false === $(this).hasClass( 'product_type_variable' ) && false === $(this).hasClass( 'product_type_grouped' ) ) {
+						%s
+					} else {
+						%s
+					}
+				});",
+				esc_js( $product->get_id() ),
+				self::get_event_code( 'add_to_cart', $items ),
+				self::get_event_code( 'select_content', $items ),
+			)
 		);
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

These are a few cosmetic changes I made trying to understand what code is being constructed by PHP. That should be fully backward compatible, but makes the code slightly more readable at least to me.
- [Simplify JS construction in WC_Google_Gtag_JS::event_tracking_code](https://github.com/woocommerce/woocommerce-google-analytics-integration/commit/c77cbf124359401abb1abca630e95fc3b88111a1)
- [DRY JS construction in WC_Google_Gtag_JS::listing_click](https://github.com/woocommerce/woocommerce-google-analytics-integration/commit/1c5010de01cf421326a4403d62fa870da0c8dcb7)
- [Simplify gtag installatio script.](https://github.com/woocommerce/woocommerce-google-analytics-integration/commit/3dcc5246289c2b2cfa51dff78d815b0c40ab853d) 
   Use `gtag` locally.
   

### Checks:
<!-- Mark completed items with an [x] -->
* [ ] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->
1. Review the code generated from `listing_click` and `event_tracking_code` - it should be the same (ignoring whitespace)
2. Review the code generated from `load_analytics`. It should be effectively equivalent


### Additional details:
<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

