### PR TITLE
Add upgrade notice if property ID starts with "UA"

### DIFF
--- a/includes/class-wc-google-analytics.php
+++ b/includes/class-wc-google-analytics.php
@@ -90,6 +90,8 @@ class WC_Google_Analytics extends WC_Integration {
 		$this->init_settings();
 		$constructor = $this->init_options();
 
+		add_action( 'admin_notices', array( $this, 'universal_analytics_upgrade_notice' ) );
+
 		// Contains snippets/JS tracking code
 		include_once 'class-wc-abstract-google-analytics-js.php';
 		include_once 'class-wc-google-gtag-js.php';
@@ -109,6 +111,26 @@ class WC_Google_Analytics extends WC_Integration {
 
 		// utm_nooverride parameter for Google AdWords
 		add_filter( 'woocommerce_get_return_url', array( $this, 'utm_nooverride' ) );
+	}
+
+	/**
+	 * Conditionally display an error notice to the merchant if the stored property ID starts with "UA"
+	 *
+	 * @return void
+	 */
+	public function universal_analytics_upgrade_notice () {
+		if ( 'ua' === substr( strtolower( $this->get_option( 'ga_id' ) ), 0, 2 ) ) {
+			printf(
+				'<div class="%1$s"><p>%2$s</p></div>',
+				'notice notice-error',
+				sprintf(
+					/* translators: 1) URL for Google documentation on upgrading from UA to GA4 2) URL to WooCommerce Google Analytics settings page */
+					__( 'Your website is configured to use Universal Analytics which Google retired in July of 2023. Update your account using the <a href="%s" target="_blank">setup assistant</a> and then update your <a href="%s">WooCommerce settings</a>.', 'woocommerce-google-analytics-integration' ),
+					'https://support.google.com/analytics/answer/9744165?sjid=9632005471070882766-EU#zippy=%2Cin-this-article',
+					'/wp-admin/admin.php?page=wc-settings&tab=integration&section=google_analytics'
+				)
+			);
+		}
 	}
 
 	/**

--- a/includes/class-wc-google-analytics.php
+++ b/includes/class-wc-google-analytics.php
@@ -125,9 +125,11 @@ class WC_Google_Analytics extends WC_Integration {
 				'notice notice-error',
 				sprintf(
 					/* translators: 1) URL for Google documentation on upgrading from UA to GA4 2) URL to WooCommerce Google Analytics settings page */
-					__( 'Your website is configured to use Universal Analytics which Google retired in July of 2023. Update your account using the <a href="%1$s" target="_blank">setup assistant</a> and then update your <a href="%2$s">WooCommerce settings</a>.', 'woocommerce-google-analytics-integration' ), // phpcs:ignore WordPress.Security.EscapeOutput
-					'https://support.google.com/analytics/answer/9744165?sjid=9632005471070882766-EU#zippy=%2Cin-this-article',
-					'/wp-admin/admin.php?page=wc-settings&tab=integration&section=google_analytics'
+					esc_html__( 'Your website is configured to use Universal Analytics which Google retired in July of 2023. Update your account using the %1$ssetup assistant%2$s and then update your %3$sWooCommerce settings%4$s.', 'woocommerce-google-analytics-integration' ),
+					'<a href="https://support.google.com/analytics/answer/9744165" target="_blank">',
+					'</a>',
+					'<a href="/wp-admin/admin.php?page=wc-settings&tab=integration&section=google_analytics">',
+					'</a>'
 				)
 			);
 		}

--- a/includes/class-wc-google-analytics.php
+++ b/includes/class-wc-google-analytics.php
@@ -118,14 +118,14 @@ class WC_Google_Analytics extends WC_Integration {
 	 *
 	 * @return void
 	 */
-	public function universal_analytics_upgrade_notice () {
+	public function universal_analytics_upgrade_notice() {
 		if ( 'ua' === substr( strtolower( $this->get_option( 'ga_id' ) ), 0, 2 ) ) {
-			printf(
+			echo sprintf(
 				'<div class="%1$s"><p>%2$s</p></div>',
 				'notice notice-error',
 				sprintf(
 					/* translators: 1) URL for Google documentation on upgrading from UA to GA4 2) URL to WooCommerce Google Analytics settings page */
-					__( 'Your website is configured to use Universal Analytics which Google retired in July of 2023. Update your account using the <a href="%s" target="_blank">setup assistant</a> and then update your <a href="%s">WooCommerce settings</a>.', 'woocommerce-google-analytics-integration' ),
+					__( 'Your website is configured to use Universal Analytics which Google retired in July of 2023. Update your account using the <a href="%1$s" target="_blank">setup assistant</a> and then update your <a href="%2$s">WooCommerce settings</a>.', 'woocommerce-google-analytics-integration' ), // phpcs:ignore WordPress.Security.EscapeOutput
 					'https://support.google.com/analytics/answer/9744165?sjid=9632005471070882766-EU#zippy=%2Cin-this-article',
 					'/wp-admin/admin.php?page=wc-settings&tab=integration&section=google_analytics'
 				)


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Adds an admin notice if the stored property ID begins with "UA" prompting merchants to use Google's setup assistant and then update their WooCommerce settings.

### Screenshots:

![Screenshot 2023-10-27 at 17 04 01](https://github.com/woocommerce/woocommerce-google-analytics-integration/assets/40762232/83088fc0-6bce-4638-9261-7b25107c31b7)

### Detailed test instructions:

1. Checkout `add/ua-update-notice` on a site with the `Google Analytics Tracking ID` set to `UA-.....`
2. Visit other admin areas to confirm the notice is displayed
3. Confirm notice is clear and links work
4. Update property ID to start with `G-`
5. Confirm notice is no longer displayed

### Changelog entry

> Add - Update notice for merchants using a Universal Analytics Property ID