### PR TITLE
Update WordPressCS to version 3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     },
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "^v0.7",
-        "wp-coding-standards/wpcs": "^2.3",
+        "wp-coding-standards/wpcs": "^3.0",
         "exussum12/coverage-checker": "^1.0",
         "phpunit/phpunit": "^9.5",
         "yoast/phpunit-polyfills": "^1.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ace93dcb2663aefb52cf3f91ebc4e52c",
+    "content-hash": "52728946198bb47f6340f1feb6558e1f",
     "packages": [],
     "packages-dev": [
         {
@@ -399,6 +399,142 @@
             ],
             "description": "Library for handling version information and constraints",
             "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
+            "name": "phpcsstandards/phpcsextra",
+            "version": "1.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/PHPCSExtra.git",
+                "reference": "746c3190ba8eb2f212087c947ba75f4f5b9a58d5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSExtra/zipball/746c3190ba8eb2f212087c947ba75f4f5b9a58d5",
+                "reference": "746c3190ba8eb2f212087c947ba75f4f5b9a58d5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4",
+                "phpcsstandards/phpcsutils": "^1.0.8",
+                "squizlabs/php_codesniffer": "^3.7.1"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-console-highlighter": "^1.0",
+                "php-parallel-lint/php-parallel-lint": "^1.3.2",
+                "phpcsstandards/phpcsdevcs": "^1.1.6",
+                "phpcsstandards/phpcsdevtools": "^1.2.1",
+                "phpunit/phpunit": "^4.5 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-stable": "1.x-dev",
+                    "dev-develop": "1.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHPCSExtra/graphs/contributors"
+                }
+            ],
+            "description": "A collection of sniffs and standards for use with PHP_CodeSniffer.",
+            "keywords": [
+                "PHP_CodeSniffer",
+                "phpcbf",
+                "phpcodesniffer-standard",
+                "phpcs",
+                "standards",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCSStandards/PHPCSExtra/issues",
+                "source": "https://github.com/PHPCSStandards/PHPCSExtra"
+            },
+            "time": "2023-09-20T22:06:18+00:00"
+        },
+        {
+            "name": "phpcsstandards/phpcsutils",
+            "version": "1.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/PHPCSUtils.git",
+                "reference": "69465cab9d12454e5e7767b9041af0cd8cd13be7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/69465cab9d12454e5e7767b9041af0cd8cd13be7",
+                "reference": "69465cab9d12454e5e7767b9041af0cd8cd13be7",
+                "shasum": ""
+            },
+            "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7 || ^1.0",
+                "php": ">=5.4",
+                "squizlabs/php_codesniffer": "^3.7.1 || 4.0.x-dev@dev"
+            },
+            "require-dev": {
+                "ext-filter": "*",
+                "php-parallel-lint/php-console-highlighter": "^1.0",
+                "php-parallel-lint/php-parallel-lint": "^1.3.2",
+                "phpcsstandards/phpcsdevcs": "^1.1.6",
+                "yoast/phpunit-polyfills": "^1.0.5 || ^2.0.0"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-stable": "1.x-dev",
+                    "dev-develop": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "PHPCSUtils/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHPCSUtils/graphs/contributors"
+                }
+            ],
+            "description": "A suite of utility functions for use with PHP_CodeSniffer",
+            "homepage": "https://phpcsutils.com/",
+            "keywords": [
+                "PHP_CodeSniffer",
+                "phpcbf",
+                "phpcodesniffer-standard",
+                "phpcs",
+                "phpcs3",
+                "standards",
+                "static analysis",
+                "tokens",
+                "utility"
+            ],
+            "support": {
+                "docs": "https://phpcsutils.com/",
+                "issues": "https://github.com/PHPCSStandards/PHPCSUtils/issues",
+                "source": "https://github.com/PHPCSStandards/PHPCSUtils"
+            },
+            "time": "2023-07-16T21:39:41+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -1698,16 +1834,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.7.1",
+            "version": "3.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "1359e176e9307e906dc3d890bcc9603ff6d90619"
+                "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/1359e176e9307e906dc3d890bcc9603ff6d90619",
-                "reference": "1359e176e9307e906dc3d890bcc9603ff6d90619",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/ed8e00df0a83aa96acf703f8c2979ff33341f879",
+                "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879",
                 "shasum": ""
             },
             "require": {
@@ -1743,9 +1879,15 @@
             "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
             "keywords": [
                 "phpcs",
-                "standards"
+                "standards",
+                "static analysis"
             ],
-            "time": "2022-06-18T07:21:10+00:00"
+            "support": {
+                "issues": "https://github.com/squizlabs/PHP_CodeSniffer/issues",
+                "source": "https://github.com/squizlabs/PHP_CodeSniffer",
+                "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
+            },
+            "time": "2023-02-22T23:07:41+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -1795,30 +1937,38 @@
         },
         {
             "name": "wp-coding-standards/wpcs",
-            "version": "2.3.0",
+            "version": "3.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
-                "reference": "7da1894633f168fe244afc6de00d141f27517b62"
+                "reference": "b4caf9689f1a0e4a4c632679a44e638c1c67aff1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/7da1894633f168fe244afc6de00d141f27517b62",
-                "reference": "7da1894633f168fe244afc6de00d141f27517b62",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/b4caf9689f1a0e4a4c632679a44e638c1c67aff1",
+                "reference": "b4caf9689f1a0e4a4c632679a44e638c1c67aff1",
                 "shasum": ""
             },
             "require": {
+                "ext-filter": "*",
+                "ext-libxml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlreader": "*",
                 "php": ">=5.4",
-                "squizlabs/php_codesniffer": "^3.3.1"
+                "phpcsstandards/phpcsextra": "^1.1.0",
+                "phpcsstandards/phpcsutils": "^1.0.8",
+                "squizlabs/php_codesniffer": "^3.7.2"
             },
             "require-dev": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || ^0.6",
+                "php-parallel-lint/php-console-highlighter": "^1.0.0",
+                "php-parallel-lint/php-parallel-lint": "^1.3.2",
                 "phpcompatibility/php-compatibility": "^9.0",
-                "phpcsstandards/phpcsdevtools": "^1.0",
+                "phpcsstandards/phpcsdevtools": "^1.2.0",
                 "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
             },
             "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.6 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
+                "ext-iconv": "For improved results",
+                "ext-mbstring": "For improved results"
             },
             "type": "phpcodesniffer-standard",
             "notification-url": "https://packagist.org/downloads/",
@@ -1835,9 +1985,21 @@
             "keywords": [
                 "phpcs",
                 "standards",
+                "static analysis",
                 "wordpress"
             ],
-            "time": "2020-05-13T23:57:56+00:00"
+            "support": {
+                "issues": "https://github.com/WordPress/WordPress-Coding-Standards/issues",
+                "source": "https://github.com/WordPress/WordPress-Coding-Standards",
+                "wiki": "https://github.com/WordPress/WordPress-Coding-Standards/wiki"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/thewpcc/contribute/wp-php-63406",
+                    "type": "custom"
+                }
+            ],
+            "time": "2023-09-14T07:06:09+00:00"
         },
         {
             "name": "yoast/phpunit-polyfills",
@@ -1904,5 +2066,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "1.1.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/includes/class-wc-google-analytics-js.php
+++ b/includes/class-wc-google-analytics-js.php
@@ -539,5 +539,4 @@ class WC_Google_Analytics_JS extends WC_Abstract_Google_Analytics_JS {
 		wp_add_inline_script( 'google-analytics', $code );
 		wp_enqueue_script( 'google-analytics' );
 	}
-
 }

--- a/includes/class-wc-google-analytics-task.php
+++ b/includes/class-wc-google-analytics-task.php
@@ -67,7 +67,4 @@ class WC_Google_Analytics_Task extends Task {
 	public function is_complete() {
 		return WC_Google_Analytics_Integration::get_integration()->is_setup_complete();
 	}
-
 }
-
-

--- a/includes/class-wc-google-analytics.php
+++ b/includes/class-wc-google-analytics.php
@@ -753,7 +753,6 @@ class WC_Google_Analytics extends WC_Integration {
 				TaskLists::get_list( 'extended' )
 			)
 		);
-
 	}
 
 	/**

--- a/includes/class-wc-google-gtag-js.php
+++ b/includes/class-wc-google-gtag-js.php
@@ -128,7 +128,7 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 		// Recursively walk through $data array and escape all values that will be used in JS.
 		array_walk_recursive(
 			$data,
-			function( &$value, $key ) {
+			function ( &$value, $key ) {
 				$value = esc_js( $value );
 			}
 		);
@@ -508,5 +508,4 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 		'
 		);
 	}
-
 }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -18,14 +18,14 @@
 		<exclude name="Squiz.Commenting.LongConditionClosingComment"/>
 
 		<!-- No thanks -->
-		<exclude name="WordPress.PHP.DisallowShortTernary"/>
+		<exclude name="Universal.Operators.DisallowShortTernary"/>
 		<exclude name="WordPress.PHP.YodaConditions.NotYoda"/>
 
 		<!-- These overrides are useful for code hinting -->
 		<exclude name="Generic.CodeAnalysis.UselessOverridingMethod.Found"/>
 
 		<!-- We like short array syntax -->
-		<exclude name="Generic.Arrays.DisallowShortArraySyntax"/>
+		<exclude name="Universal.Arrays.DisallowShortArraySyntax"/>
 
 		<!-- Multiple throws tags are fine -->
 		<exclude name="Squiz.Commenting.FunctionCommentThrowTag.WrongNumber"/>
@@ -62,8 +62,8 @@
 	</rule>
 
 	<!-- This rule flags space indents in HTML tags, which are generally OK. -->
-	<rule ref="WordPress.WhiteSpace.PrecisionAlignment">
-		<exclude name="WordPress.WhiteSpace.PrecisionAlignment.Found"/>
+	<rule ref="Universal.WhiteSpace.PrecisionAlignment">
+		<exclude name="Universal.WhiteSpace.PrecisionAlignment.Found"/>
 	</rule>
 
 	<!-- We allow the use of / in hooks -->

--- a/tests/EventsDataTest.php
+++ b/tests/EventsDataTest.php
@@ -106,5 +106,4 @@ abstract class EventsDataTest extends WP_UnitTestCase {
 		$args = $this->get_filter()->get_args();
 		return $args[0][0];
 	}
-
 }

--- a/tests/class-unittestsbootstrap.php
+++ b/tests/class-unittestsbootstrap.php
@@ -149,5 +149,4 @@ class UnitTestsBootstrap {
 		require_once $wc_tests_dir . '/framework/helpers/class-wc-helper-shipping.php';
 		require_once $wc_tests_dir . '/framework/helpers/class-wc-helper-customer.php';
 	}
-
 }

--- a/tests/unit-tests/AddTransactionEnhanced.php
+++ b/tests/unit-tests/AddTransactionEnhanced.php
@@ -50,5 +50,4 @@ class AddTransactionEnhanced extends EventsDataTest {
 		// Confirm data structure matches what's expected.
 		$this->assertEquals( $expected_data, $this->get_event_data(), 'Event data does not match expected data structure for purchase (add_transaction_enhanced()) event' );
 	}
-
 }

--- a/tests/unit-tests/CheckoutProcess.php
+++ b/tests/unit-tests/CheckoutProcess.php
@@ -56,5 +56,4 @@ class CheckoutProcess extends EventsDataTest {
 		// Confirm data structure matches what's expected.
 		$this->assertEquals( $expected_data, $this->get_event_data(), 'Event data does not match expected data structure for begin_checkout (checkout_process()) event' );
 	}
-
 }

--- a/tests/unit-tests/ListingClick.php
+++ b/tests/unit-tests/ListingClick.php
@@ -41,5 +41,4 @@ class ListingClick extends EventsDataTest {
 		// Confirm data structure matches what's expected.
 		$this->assertEquals( $expected_data, $this->get_event_data(), 'Event data does not match expected data structure for select_content and add_to_cart (listing_click()) events' );
 	}
-
 }

--- a/tests/unit-tests/ListingImpression.php
+++ b/tests/unit-tests/ListingImpression.php
@@ -41,5 +41,4 @@ class ListingImpression extends EventsDataTest {
 		// Confirm data structure matches what's expected.
 		$this->assertEquals( $expected_data, $this->get_event_data(), 'Event data does not match expected data structure for view_item_list (listing_impression()) event' );
 	}
-
 }

--- a/tests/unit-tests/WCGoogleGtagJS.php
+++ b/tests/unit-tests/WCGoogleGtagJS.php
@@ -115,5 +115,4 @@ class WCGoogleGtagJS extends EventsDataTest {
 		// Assert the handle is enqueued.
 		$this->assertEquals( true, wp_script_is( $gtag->script_handle . '-ga-integration', 'enqueued' ), 'the script is enqueued' );
 	}
-
 }

--- a/woocommerce-google-analytics-integration.php
+++ b/woocommerce-google-analytics-integration.php
@@ -154,7 +154,6 @@ if ( ! class_exists( 'WC_Google_Analytics_Integration' ) ) {
 			}
 
 			echo '<div class="error"><p><strong>' . wp_kses_post( $error ) . '</strong></p></div>';
-
 		}
 
 		/**
@@ -215,7 +214,7 @@ if ( ! class_exists( 'WC_Google_Analytics_Integration' ) ) {
 		 * @return string
 		 */
 		public function path( $end = '' ) {
-			return untrailingslashit( dirname( __FILE__ ) ) . $end;
+			return untrailingslashit( __DIR__ ) . $end;
 		}
 
 		/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #296 

Updates WordPressCS to version `3.0` and fixes CS issues across extension files.

### Screenshot

<img width="920" alt="Screenshot 2023-10-30 at 11 28 15" src="https://github.com/woocommerce/woocommerce-google-analytics-integration/assets/40762232/96fe11e4-3307-43a6-a67d-6271f12c282b">

### Detailed test instructions:

1. Checkout `update/296-update-wordpresscs`
2. Run `composer install && npm run lint:php`
3. Confirm no errors are flagged
4. Review changes

### Changelog entry

> Update - WordPressCS to version 3.0