### PR TITLE
Update docs domain name to Woo.com

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -34,7 +34,7 @@ This Code of Conduct applies both within project spaces and in public spaces whe
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at support@woocommerce.com. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at support@woo.com. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -16,7 +16,7 @@ Please see [SECURITY.md](./SECURITY.md).
 
 ## Feature Requests
 
-Feature requests can be submitted to our [ideas board](https://ideas.woocommerce.com/forums/133476-woocommerce?category_id=337630). Be sure to include a good description of the expected behavior and use case, and before submitting a request, please search for similar ones.
+Feature requests can be submitted to our [feature requests page](https://woo.com/feature-requests/woocommerce-google-analytics/). Be sure to include a good description of the expected behavior and use case, and before submitting a request, please search for similar ones.
 
 ## Getting started
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Will be required for WooCommerce shops using the integration from WooCommerce 2.
 
 - [WordPress.org plugin page](https://wordpress.org/plugins/woocommerce-google-analytics-integration/)
 - [WooCommerce.com product page (free)](https://woocommerce.com/products/woocommerce-google-analytics/)
-- [User documentation](https://docs.woocommerce.com/document/google-analytics-integration/)
+- [User documentation](https://woo.com/document/google-analytics-integration/)
 
 ## NPM Scripts
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ WordPress plugin: Provides the integration between WooCommerce and Google Analyt
 Will be required for WooCommerce shops using the integration from WooCommerce 2.1 and up.
 
 - [WordPress.org plugin page](https://wordpress.org/plugins/woocommerce-google-analytics-integration/)
-- [WooCommerce.com product page (free)](https://woocommerce.com/products/woocommerce-google-analytics/)
+- [Woo.com product page (free)](https://woo.com/products/woocommerce-google-analytics/)
 - [User documentation](https://woo.com/document/google-analytics-integration/)
 
 ## NPM Scripts

--- a/includes/class-wc-google-analytics.php
+++ b/includes/class-wc-google-analytics.php
@@ -361,7 +361,7 @@ class WC_Google_Analytics extends WC_Integration {
 	/**
 	 * Hooks into woocommerce_tracker_data and tracks some of the analytic settings (just enabled|disabled status)
 	 * only if you have opted into WooCommerce tracking
-	 * https://woocommerce.com/usage-tracking/
+	 * https://woo.com/usage-tracking/
 	 *
 	 * @param  array $data Current WC tracker data.
 	 * @return array       Updated WC Tracker data.

--- a/woocommerce-google-analytics-integration.php
+++ b/woocommerce-google-analytics-integration.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://wordpress.org/plugins/woocommerce-google-analytics-integration/
  * Description: Allows Google Analytics tracking code to be inserted into WooCommerce store pages.
  * Author: WooCommerce
- * Author URI: https://woocommerce.com
+ * Author URI: https://woo.com
  * Version: 1.8.8
  * WC requires at least: 6.8
  * WC tested up to: 8.2
@@ -107,7 +107,7 @@ if ( ! class_exists( 'WC_Google_Analytics_Integration' ) ) {
 		public function plugin_links( $links ) {
 			$settings_url = $this->get_settings_url();
 			$support_url  = 'https://wordpress.org/support/plugin/woocommerce-google-analytics-integration';
-			$docs_url     = 'https://woocommerce.com/document/google-analytics-integration/?utm_source=wordpress&utm_medium=all-plugins-page&utm_campaign=doc-link&utm_content=woocommerce-google-analytics-integration';
+			$docs_url     = 'https://woo.com/document/google-analytics-integration/?utm_source=wordpress&utm_medium=all-plugins-page&utm_campaign=doc-link&utm_content=woocommerce-google-analytics-integration';
 
 			$plugin_links = array(
 				'<a href="' . esc_url( $settings_url ) . '">' . esc_html__( 'Settings', 'woocommerce-google-analytics-integration' ) . '</a>',
@@ -202,7 +202,7 @@ if ( ! class_exists( 'WC_Google_Analytics_Integration' ) ) {
 			$notice_html = '<strong>' . esc_html__( 'Get detailed insights into your sales with Google Analytics Pro', 'woocommerce-google-analytics-integration' ) . '</strong><br><br>';
 
 			/* translators: 1: href link to GA pro */
-			$notice_html .= sprintf( __( 'Add advanced tracking for your sales funnel, coupons and more. [<a href="%s" target="_blank">Learn more</a> &gt;]', 'woocommerce-google-analytics-integration' ), 'https://woocommerce.com/products/woocommerce-google-analytics-pro/?utm_source=woocommerce-google-analytics-integration&utm_medium=product&utm_campaign=google%20analytics%20free%20to%20pro%20extension%20upsell' );
+			$notice_html .= sprintf( __( 'Add advanced tracking for your sales funnel, coupons and more. [<a href="%s" target="_blank">Learn more</a> &gt;]', 'woocommerce-google-analytics-integration' ), 'https://woo.com/products/woocommerce-google-analytics-pro/?utm_source=woocommerce-google-analytics-integration&utm_medium=product&utm_campaign=google%20analytics%20free%20to%20pro%20extension%20upsell' );
 
 			WC_Admin_Notices::add_custom_notice( 'woocommerce_google_analytics_pro_notice', $notice_html );
 			update_option( 'woocommerce_google_analytics_pro_notice_shown', true );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Update the old WooCommerce.com → the new Woo.com in several places, especially for documentation links.

Project: peeuvX-13n-p2

### Checks:
<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Confirm all new URLs actually go to a page.

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Doc - Use new Woo.com domain.