### PR TITLE
Add a new workflow of GitHub Actions to publish the latest extension build for the `trunk` branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - trunk
-      # For temporary testing
-      - dev/gh-actions-build
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - trunk
+      # For temporary testing
+      - dev/gh-actions-build
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,42 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - trunk
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  BuildExtensionBundle:
+    name: Build extension bundle
+    runs-on: ubuntu-latest
+    env:
+      FORCE_COLOR: 2
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Prepare PHP
+        uses: woocommerce/grow/prepare-php@actions-v1
+        with:
+          install-deps: "no"
+
+      - name: Prepare node
+        uses: woocommerce/grow/prepare-node@actions-v1
+        with:
+          node-version-file: ".nvmrc"
+          ignore-scripts: "no"
+
+      - name: Build production bundle
+        run: |
+          echo "::group::Build log"
+          npm run build
+          echo "::endgroup::"
+
+      - name: Publish dev build to GitHub
+        uses: woocommerce/grow/publish-extension-dev-build@actions-v1
+        with:
+          extension-asset-path: woocommerce-google-analytics-integration.zip

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # WooCommerce Google Analytics Integration
 
+[![PHP Unit Tests](https://github.com/woocommerce/woocommerce-google-analytics-integration/actions/workflows/php-unit-tests.yml/badge.svg)](https://github.com/woocommerce/woocommerce-google-analytics-integration/actions/workflows/php-unit-tests.yml)
+[![JavaScript Linting](https://github.com/woocommerce/woocommerce-google-analytics-integration/actions/workflows/js-linting.yml/badge.svg)](https://github.com/woocommerce/woocommerce-google-analytics-integration/actions/workflows/js-linting.yml)
+[![Build](https://github.com/woocommerce/woocommerce-google-analytics-integration/actions/workflows/build.yml/badge.svg)](https://github.com/woocommerce/woocommerce-google-analytics-integration/actions/workflows/build.yml)
+
 WordPress plugin: Provides the integration between WooCommerce and Google Analytics.
 
 Will be required for WooCommerce shops using the integration from WooCommerce 2.1 and up.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The idea is to keep collaborators informed of what contents are coming but not yet released at any time, and to be the latest test build for download, without waiting for developers to build one.

In particular, it might help with the mentioned question of collaboration with our Product Ambassador: “What process can we put in place to help remind us to get the Product Ambassador involved at an early stage?”

Ref: peeuvX-AL-p2

### 📌 Checklist before merging (@eason9487)

To verify the new GH action, this PR temporarily added af6e267842a2dad4079b3a11eb9f8225c63832fd and it will be reverted before merging.

- [x] Revert af6e267842a2dad4079b3a11eb9f8225c63832fd

### Checks:
<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Detailed test instructions:

1. View [the published release](https://github.com/woocommerce/woocommerce-google-analytics-integration/releases/tag/gha-dev-build) for the `trunk` branch.
   - The content of **Unreleased changes** is empty because there are actually no unreleased PRs other than the dependabot PRs.
2. View [the workflow job logs](https://github.com/woocommerce/woocommerce-google-analytics-integration/actions/runs/6956023270).
3. Rerun the above workflow job to see if it can update the **woocommerce-google-analytics-integration.zip** asset file.
   - The file content and changelog may not be changed if there are no new merged PRs afterward.

### Changelog entry
