### PR TITLE
Prevent firing up the add_to_cart event when clicking in product image

### DIFF
--- a/includes/class-wc-google-analytics-js.php
+++ b/includes/class-wc-google-analytics-js.php
@@ -142,7 +142,7 @@ class WC_Google_Analytics_JS extends WC_Abstract_Google_Analytics_JS {
 
 		wc_enqueue_js(
 			"
-			$( '.product.post-" . esc_js( $product->get_id() ) . ' a , .product.post-' . esc_js( $product->get_id() ) . " button' ).on('click', function() {
+			$( '.product.post-" . esc_js( $product->get_id() ) . ' a.button , .product.post-' . esc_js( $product->get_id() ) . " button' ).on('click', function() {
 				if ( false === $(this).hasClass( 'product_type_variable' ) && false === $(this).hasClass( 'product_type_grouped' ) ) {
 					" . self::tracker_var() . "( 'ec:addProduct', {
 						'id': '" . esc_js( $product->get_id() ) . "',

--- a/includes/class-wc-google-gtag-js.php
+++ b/includes/class-wc-google-gtag-js.php
@@ -222,7 +222,7 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 
 		wc_enqueue_js(
 			"
-			$( '.product.post-" . esc_js( $product->get_id() ) . ' a , .product.post-' . esc_js( $product->get_id() ) . " button' ).on('click', function() {
+			$( '.product.post-" . esc_js( $product->get_id() ) . ' a.button , .product.post-' . esc_js( $product->get_id() ) . " button' ).on('click', function() {
 				if ( false === $(this).hasClass( 'product_type_variable' ) && false === $(this).hasClass( 'product_type_grouped' ) ) {
 					$add_to_cart_event_code
 				} else {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #330

With non-blockified themes, the `add_to_cart` event's selector is quite broad, leading it to trigger even when a user clicks on the product image.

https://github.com/woocommerce/woocommerce-google-analytics-integration/blob/487625e0c5bcf61a9c568c0a24ec95c5d63afdd5/includes/class-wc-google-gtag-js.php#L225

This PR makes the selector more specific, checking that the link needs to have the class button.

### Checks:
<!-- Mark completed items with an [x] -->
* [X] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [X] Have you successfully run tests with your changes locally?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Screenshots:

<!--- Optional --->


### Detailed test instructions:

1. Use a non-blockified theme, for example store front.
2. [Setup](https://github.com/woocommerce/woocommerce-google-analytics-integration/wiki/General-Testing) the extension with your Google Analytics Tracking ID.
3. Enable all the options of "Enable Enhanced eCommerce" in `/wp-admin/admin.php?page=wc-settings&tab=integration&section=google_analytics`
4. Install the [Google Analytics Chrome](https://chrome.google.com/webstore/detail/google-analytics-debugger/jnkmfdileelhofjcijamephohjechhna) extension or use the https://tagassistant.google.com/ to see the events.
5. Open an incognito mode, go to the shop and click the product image. See that the event `add_to_cart` is not sent.


### Additional details:
 - PHP unit tests failed but they are fixed here: https://github.com/woocommerce/woocommerce-google-analytics-integration/pull/333. Local tests passes if you run `composer require --dev yoast/phpunit-polyfills:"^1.1.0" && composer install`
<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Prevent firing up the add_to_cart event when clicking in product image
