### PR TITLE
Update test environment setup to resolve notice

### DIFF
--- a/tests/class-unittestsbootstrap.php
+++ b/tests/class-unittestsbootstrap.php
@@ -33,7 +33,7 @@ class UnitTestsBootstrap {
 
 		// load WC
 		tests_add_filter( 'muplugins_loaded', array( $this, 'load_plugins' ) );
-		tests_add_filter( 'setup_theme', array( $this, 'install_wc' ) );
+		tests_add_filter( 'init', array( $this, 'install_wc' ) );
 		tests_add_filter( 'option_active_plugins', [ $this, 'filter_active_plugins' ] );
 
 		// load the WP testing environment


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #334 

Updates `UnitTestsBootstrap` to run `install_wc` on the `init` hook to resolve the notice.

### Screenshots:
<img width="989" alt="Screenshot 2023-11-24 at 15 00 07" src="https://github.com/woocommerce/woocommerce-google-analytics-integration/assets/40762232/8cb7a764-57b5-40d1-831b-0704991e35d1">

### Detailed test instructions:
1. Confirm tests pass without triggering a notice using the latest version of WooCommerce

### Additional

- PHP unit tests failed but they are fixed here: https://github.com/woocommerce/woocommerce-google-analytics-integration/pull/333. Local tests passes if you run `composer require --dev yoast/phpunit-polyfills:"^1.1.0" && composer install`

### Changelog entry

> Tweak - Test environment setup to resolve notice