### PR TITLE
Prevent DB warnings in unit tests

### DIFF
--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -45,7 +45,7 @@ jobs:
     needs: GetMatrix
     strategy:
       matrix:
-        php: [8.1]
+        php: [8.2]
         wp-version: [latest]
         # Please note that wc-versions is a string containing versions separated by commas.
         # It will be split and loop within the run unit test step below to reduce the time spent.
@@ -54,7 +54,7 @@ jobs:
           - php: 7.4
             wp-version: ${{ fromJson(needs.GetMatrix.outputs.wp-versions)[2] }} # L-2 WP Version support
             wc-versions: ${{ fromJson(needs.GetMatrix.outputs.wc-versions)[2] }} # L-2 WC Version support
-          - php: 8.2
+          - php: 8.3
             wp-version: latest
             wc-versions: latest
 

--- a/tests/class-unittestsbootstrap.php
+++ b/tests/class-unittestsbootstrap.php
@@ -102,33 +102,15 @@ class UnitTestsBootstrap {
 		echo 'Installing WooCommerce...' . PHP_EOL;
 
 		define( 'WP_UNINSTALL_PLUGIN', true );
+		define( 'WC_REMOVE_ALL_DATA', true );
 
 		include $this->plugins_dir . '/woocommerce/uninstall.php';
 
-		global $wpdb;
-		$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}woocommerce_attribute_taxonomies" );
-		$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}woocommerce_order_items" );
-		$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}woocommerce_order_itemmeta" );
-
 		\WC_Install::install();
-
-		// Ensure wc_category_lookup table exists (WC 6.5+)
-		add_action(
-			'init',
-			function() {
-				if ( class_exists( \Automattic\WooCommerce\Internal\Admin\CategoryLookup::class ) ) {
-					\Automattic\WooCommerce\Internal\Admin\CategoryLookup::instance()->regenerate();
-				}
-			},
-			11
-		);
-
 		new \WP_Roles();
-
 		WC()->init();
 
 		echo 'WooCommerce Finished Installing...' . PHP_EOL;
-
 	}
 
 	/**

--- a/tests/class-unittestsbootstrap.php
+++ b/tests/class-unittestsbootstrap.php
@@ -59,7 +59,7 @@ class UnitTestsBootstrap {
 	 * Set directory paths.
 	 */
 	public function set_path_props() {
-		$this->tests_dir    = dirname( __FILE__ );
+		$this->tests_dir    = __DIR__;
 		$this->plugin_dir   = dirname( $this->tests_dir );
 		$this->plugins_dir  = sys_get_temp_dir() . '/wordpress/wp-content/plugins';
 		$this->wp_tests_dir = sys_get_temp_dir() . '/wordpress-tests-lib';
@@ -140,7 +140,7 @@ class UnitTestsBootstrap {
 	 *
 	 * @since x.x.x
 	 *
-	 * @param bool $trigger Trigger error.
+	 * @param bool   $trigger Trigger error.
 	 * @param string $function_name Calling function name.
 	 * @return bool
 	 */

--- a/tests/class-unittestsbootstrap.php
+++ b/tests/class-unittestsbootstrap.php
@@ -36,7 +36,7 @@ class UnitTestsBootstrap {
 
 		// load WC
 		tests_add_filter( 'muplugins_loaded', array( $this, 'load_plugins' ) );
-		tests_add_filter( 'init', array( $this, 'install_wc' ) );
+		tests_add_filter( 'setup_theme', array( $this, 'install_wc' ) );
 		tests_add_filter( 'option_active_plugins', [ $this, 'filter_active_plugins' ] );
 
 		// load the WP testing environment


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR reverts the change in #335 since it still produces warnings when starting tests with an empty database. So here we revert to an earlier hook and add a filter to prevent the notice from showing. We also use `WC_REMOVE_ALL_DATA` so all database tables can be removed and recreated when `WC_Install` is called.

The PR also adds PHP version 8.3 to the workflow, so it now runs the default tests on PHP 8.2 and includes the oldest supported version (7.4) and the latest supported version (8.3).

Closes #338

### Detailed test instructions:
1. Install unit tests with a version of WC > 8.3 `bin/install-unit-tests.sh <db_name> <db_user> <db_pass>` (select `Y` to clear database during install)
2. Run unit tests `vendor/bin/phpunit`
3. Confirm there are no longer any warnings when the tests are run
4. Check the Workflow tests and confirm we have successful runs for PHP 7.4, 8.2, 8.3

### Changelog entry
* Dev - Prevent DB warnings in unit tests.
