### PR TITLE
Fix the JS exceptions and incorrect `quantity` value for checkout event tracking

### DIFF
--- a/assets/js/src/tracking.js
+++ b/assets/js/src/tracking.js
@@ -104,6 +104,15 @@ export const trackCheckoutStep =
 			return;
 		}
 
+		// compatibility-code "WC >= 8.1" -- The data structure of `storeCart` was (accidentally) changed.
+		if ( ! storeCart.hasOwnProperty( 'cartTotals' ) ) {
+			storeCart = {
+				cartCoupons: storeCart.coupons,
+				cartItems: storeCart.items,
+				cartTotals: storeCart.totals,
+			};
+		}
+
 		trackEvent( step === 0 ? 'begin_checkout' : 'checkout_progress', {
 			items: storeCart.cartItems.map( getProductFieldObject ),
 			coupon: storeCart.cartCoupons[ 0 ]?.code || '',

--- a/assets/js/src/tracking.js
+++ b/assets/js/src/tracking.js
@@ -114,7 +114,9 @@ export const trackCheckoutStep =
 		}
 
 		trackEvent( step === 0 ? 'begin_checkout' : 'checkout_progress', {
-			items: storeCart.cartItems.map( getProductFieldObject ),
+			items: storeCart.cartItems.map( ( item ) =>
+				getProductFieldObject( item, item.quantity )
+			),
 			coupon: storeCart.cartCoupons[ 0 ]?.code || '',
 			currency: storeCart.cartTotals.currency_code,
 			value: formatPrice(


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #341 
Closes #342 

- Fix the incompatible data structure that causes JS exceptions when sending checkout event tracking for [issue #341](https://github.com/woocommerce/woocommerce-google-analytics-integration/issues/341).
- Fix the incorrect `quantity` value when sending checkout event tracking for [issue #342](https://github.com/woocommerce/woocommerce-google-analytics-integration/issues/342).

### Checks:

* [x] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Screenshots:

![1](https://github.com/woocommerce/woocommerce-google-analytics-integration/assets/17420811/66195b10-1aec-4ca3-942b-358b98f0da78)

### Detailed test instructions:

1. Install and enable [Google Analytics Debugger](https://chromewebstore.google.com/detail/jnkmfdileelhofjcijamephohjechhna).
2. Use Woo with version >= 8.1.0.
3. Edit the checkout page to use the **Checkout** block.
   ![image](https://github.com/woocommerce/woocommerce-google-analytics-integration/assets/17420811/db736008-68a6-4bcb-88ed-590d894d1b27)
4. Open the Console tab in the browser's DevTool.
5. Add items to your cart and go to the Checkout page.
6. Check if there is no longer JS exception in the Console tab.
7. Check if the quantity (`~qt\d+~`) value in the `begin_checkout` or `checkout_progress` event tracking is correct via the Console tab.

### Changelog entry

> Fix - Avoid JavaScript exceptions when sending checkout event tracking due to incompatible data structure.
> Fix - Correct misplaced each product index value as its quantity when sending checkout event tracking.
