### PR TITLE
Fix add to cart event for WC 8.5 blocks

### DIFF
--- a/assets/js/src/tracking.js
+++ b/assets/js/src/tracking.js
@@ -4,7 +4,6 @@ import {
 	getProductImpressionObject,
 	formatPrice,
 } from './utils';
-import { trackAddToCartEvent } from '../../../../google-listings-and-ads/js/src/gtag-events/utils';
 
 /**
  * Variable holding the current checkout step. It will be modified by trackCheckoutOption and trackCheckoutStep methods.
@@ -53,7 +52,6 @@ export const trackAddToCart = ( data ) => {
 		// WC < 8.5
 		product = data.product;
 		quantity = data.quantity;
-		trackAddToCartEvent( data.product, data.quantity );
 	} else {
 		product = data;
 		quantity = 1;

--- a/assets/js/src/utils.js
+++ b/assets/js/src/utils.js
@@ -4,7 +4,7 @@ import { addAction, removeAction } from '@wordpress/hooks';
  * Formats data into the productFieldObject shape.
  *
  * @see https://developers.google.com/analytics/devguides/collection/gtagjs/enhanced-ecommerce#product-data
- * @param {Object} product - The product data
+ * @param {Object} product  - The product data
  * @param {number} quantity - The product quantity
  *
  * @return {Object} The product data
@@ -26,7 +26,7 @@ export const getProductFieldObject = ( product, quantity ) => {
  * Formats data into the impressionFieldObject shape.
  *
  * @see https://developers.google.com/analytics/devguides/collection/gtagjs/enhanced-ecommerce#impression-data
- * @param {Object} product - The product data
+ * @param {Object} product  - The product data
  * @param {string} listName - The list for this product
  *
  * @return {Object} - The product impression data
@@ -47,7 +47,7 @@ export const getProductImpressionObject = ( product, listName ) => {
 /**
  * Returns the price of a product formatted as a string.
  *
- * @param {string} price - The price to parse
+ * @param {string} price                 - The price to parse
  * @param {number} [currencyMinorUnit=2] - The number decimals to show in the currency
  *
  * @return {string} - The price of the product formatted
@@ -59,9 +59,9 @@ export const formatPrice = ( price, currencyMinorUnit = 2 ) => {
 /**
  * Removes previous actions with the same hookName and namespace and then adds the new action.
  *
- * @param {string} hookName The hook name for the action
- * @param {string} namespace The unique namespace for the action
- * @param {Function} callback The function to run when the action happens.
+ * @param {string}   hookName  The hook name for the action
+ * @param {string}   namespace The unique namespace for the action
+ * @param {Function} callback  The function to run when the action happens.
  */
 export const addUniqueAction = ( hookName, namespace, callback ) => {
 	removeAction( hookName, namespace );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #346 . 

This PR closes a bug in GA when using WC8.5 and Product Blocks. In WC 8.5 we receive a Proxy Product as a parameter. Before we got 2, product and quantity


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Install WC < 8.5
2. Setup a block shop page
3. Use GA Debugger extension to check the GA events.
4. Add an item to the cart and verify the add to cart event is triggered without errors
5. Install WC >= 8.5 
6. Add an item to the cart and verify the add to cart event is triggered without errors


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Add to cart produces an error in WC 8.5 and Blocks
