### PR TITLE
Update plugin branding to Google Analytics for WooCommerce

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,14 +1,14 @@
 # Contributing
 
-Thanks for your interest in contributing to WooCommerce Google Analytics Integration!
+Thanks for your interest in contributing to Google Analytics for WooCommerce!
 
 ## Guidelines
 
 Like the WooCommerce project, we want to ensure a welcoming environment for everyone. With that in mind, all contributors are expected to follow our [Code of Conduct](./CODE_OF_CONDUCT.md).
 
-If you wish to contribute code, please read the information in the sections below. Then [fork](https://help.github.com/articles/fork-a-repo/) WooCommerce Google Analytics Integration, commit your changes, and [submit a pull request](https://docs.github.com/en/github/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests) 🎉
+If you wish to contribute code, please read the information in the sections below. Then [fork](https://help.github.com/articles/fork-a-repo/) Google Analytics for WooCommerce, commit your changes, and [submit a pull request](https://docs.github.com/en/github/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests) 🎉
 
-WooCommerce Google Analytics Integration is licensed under the GPLv3+, and all contributions to the project will be released under the same license. You maintain copyright over any contribution you make, and by submitting a pull request, you are agreeing to release that contribution under the GPLv3+ license.
+Google Analytics for WooCommerce is licensed under the GPLv3+, and all contributions to the project will be released under the same license. You maintain copyright over any contribution you make, and by submitting a pull request, you are agreeing to release that contribution under the GPLv3+ license.
 
 ## Reporting Security Issues
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# WooCommerce Google Analytics Integration
+# Google Analytics for WooCommerce
 
 WordPress plugin: Provides the integration between WooCommerce and Google Analytics.
 
@@ -10,7 +10,7 @@ Will be required for WooCommerce shops using the integration from WooCommerce 2.
 
 ## NPM Scripts
 
-WooCommerce Google Analytics Integration utilizes npm scripts for task management utilities.
+Google Analytics for WooCommerce utilizes npm scripts for task management utilities.
 
 `npm run build` - Runs the tasks necessary for a release. These may include building JavaScript, SASS, CSS minification, and language files.
 
@@ -34,4 +34,4 @@ Alternatively, run `npm run lint:php:diff` to run coding standards checks agains
 
 ## Docs
 
-- [Hooks defined or used in WooCommerce Google Analytics Integration](./docs/Hooks.md)
+- [Hooks defined or used in Google Analytics for WooCommerce](./docs/Hooks.md)

--- a/includes/class-wc-google-analytics-task.php
+++ b/includes/class-wc-google-analytics-task.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * Set up Google Analytics Integration task.
+ * Set up Google Analytics for WooCommerce task.
  *
- * Adds a set up Google Analytics Integration task to the task list.
+ * Adds a set up Google Analytics for WooCommerce task to the task list.
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/class-wc-google-analytics.php
+++ b/includes/class-wc-google-analytics.php
@@ -7,7 +7,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 use Automattic\WooCommerce\Admin\Features\OnboardingTasks\TaskLists;
 
 /**
- * Google Analytics Integration
+ * Google Analytics for WooCommerce
  *
  * Allows tracking code to be inserted into store pages.
  *
@@ -358,7 +358,7 @@ class WC_Google_Analytics extends WC_Integration {
 			<p class="privacy-policy-tutorial">' . $policy_text . '</p>
 			<style>#privacy-settings-accordion-block-woocommerce-google-analytics-integration .privacy-settings-accordion-actions { display: none }</style>';
 
-		wp_add_privacy_policy_content( 'WooCommerce Google Analytics Integration', wpautop( $content, false ) );
+		wp_add_privacy_policy_content( 'Google Analytics for WooCommerce', wpautop( $content, false ) );
 	}
 
 	/**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "woocommerce-google-analytics-integration",
-  "title": "WooCommerce Google Analytics Integration",
+  "title": "Google Analytics for WooCommerce",
   "version": "1.8.6",
   "license": "GPL-2.0",
   "homepage": "https://wordpress.org/plugins/woocommerce-google-analytics-integration/",

--- a/readme.txt
+++ b/readme.txt
@@ -1,4 +1,4 @@
-=== WooCommerce Google Analytics Integration ===
+=== Google Analytics for WooCommerce ===
 Contributors: woocommerce, automattic, claudiosanches, bor0, royho, laurendavissmith001, c-shultz
 Tags: woocommerce, google analytics
 Requires at least: 3.9

--- a/woocommerce-google-analytics-integration.php
+++ b/woocommerce-google-analytics-integration.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Plugin Name: WooCommerce Google Analytics Integration
+ * Plugin Name: Google Analytics for WooCommerce
  * Plugin URI: https://wordpress.org/plugins/woocommerce-google-analytics-integration/
  * Description: Allows Google Analytics tracking code to be inserted into WooCommerce store pages.
  * Author: WooCommerce
@@ -148,10 +148,10 @@ if ( ! class_exists( 'WC_Google_Analytics_Integration' ) ) {
 		public function woocommerce_missing_notice() {
 			if ( defined( 'WOOCOMMERCE_VERSION' ) ) {
 				/* translators: 1 is the required component, 2 the Woocommerce version */
-				$error = sprintf( __( 'WooCommerce Google Analytics requires WooCommerce version %1$s or higher. You are using version %2$s', 'woocommerce-google-analytics-integration' ), WC_GOOGLE_ANALYTICS_INTEGRATION_MIN_WC_VER, WOOCOMMERCE_VERSION );
+				$error = sprintf( __( 'Google Analytics for WooCommerce requires WooCommerce version %1$s or higher. You are using version %2$s', 'woocommerce-google-analytics-integration' ), WC_GOOGLE_ANALYTICS_INTEGRATION_MIN_WC_VER, WOOCOMMERCE_VERSION );
 			} else {
 				/* translators: 1 is the required component */
-				$error = sprintf( __( 'WooCommerce Google Analytics requires WooCommerce version %1$s or higher.', 'woocommerce-google-analytics-integration' ), WC_GOOGLE_ANALYTICS_INTEGRATION_MIN_WC_VER );
+				$error = sprintf( __( 'Google Analytics for WooCommerce requires WooCommerce version %1$s or higher.', 'woocommerce-google-analytics-integration' ), WC_GOOGLE_ANALYTICS_INTEGRATION_MIN_WC_VER );
 			}
 
 			echo '<div class="error"><p><strong>' . wp_kses_post( $error ) . '</strong></p></div>';

--- a/woocommerce-google-analytics-integration.php
+++ b/woocommerce-google-analytics-integration.php
@@ -45,7 +45,7 @@ if ( ! class_exists( 'WC_Google_Analytics_Integration' ) ) {
 	);
 
 	/**
-	 * WooCommerce Google Analytics Integration main class.
+	 * Google Analytics for WooCommerce main class.
 	 */
 	class WC_Google_Analytics_Integration {
 
@@ -162,7 +162,7 @@ if ( ! class_exists( 'WC_Google_Analytics_Integration' ) ) {
 		 * Add a new integration to WooCommerce.
 		 *
 		 * @param  array $integrations WooCommerce integrations.
-		 * @return array               Google Analytics integration added.
+		 * @return array               Google Analytics for WooCommerce added.
 		 */
 		public function add_integration( $integrations ) {
 			$integrations[] = 'WC_Google_Analytics';


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Renames the extension from `WooCommerce Google Analytics Integration` to `Google Analytics for WooCommerce`.

### Detailed test instructions:

1. Review changes and confirm the extension name has been replaced correctly
2. Search codebase to confirm that there are no remaining instances of `WooCommerce Google Analytics Integration` that need to be replaced

### Additional details:

The plugin name in the main plugin file header comment has not been altered so as to not cause problems on WordPress.org.

### Changelog entry

> Update - Extension branding to Google Analytics for WooCommerce