### PR TITLE
Declare feature compatibility for the product block editor

### DIFF
--- a/woocommerce-google-analytics-integration.php
+++ b/woocommerce-google-analytics-integration.php
@@ -40,6 +40,7 @@ if ( ! class_exists( 'WC_Google_Analytics_Integration' ) ) {
 			if ( class_exists( FeaturesUtil::class ) ) {
 				FeaturesUtil::declare_compatibility( 'custom_order_tables', __FILE__ );
 				FeaturesUtil::declare_compatibility( 'cart_checkout_blocks', __FILE__ );
+				FeaturesUtil::declare_compatibility( 'product_block_editor', __FILE__ );
 			}
 		}
 	);


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Project thread: peeuvX-Ti-p2

As this extension doesn't involve the product editing page, it only needs to declare the feature compatibility for the new product editor (Product Block Editor).

### Checks:

* [x] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Detailed test instructions:

1. Set up WooCommerce >= 8.5
2. Currently, [the `is_legacy` flag of the new product editor is set to true](https://github.com/woocommerce/woocommerce/blob/8.5.2/plugins/woocommerce/src/Internal/Features/FeaturesController.php#L182), so it won't show Incompatible warnings. Adding the following code snippet can turn off the flag:
   ```php
   add_action(
   	'woocommerce_register_feature_definitions',
   	function( $features_controller ) {
   		$slug = 'product_block_editor';
   		$args = $features_controller->get_features( true )[ $slug ];
   
   		$args['is_legacy'] = false;
   		$features_controller->add_feature_definition( $slug, $args['name'], $args );
   	}
   );
   ```
3. Git checkout the `trunk` branch.
4. Go to WooCommerce > Settings > Advanced > Features. Enable the **New product editor**.
5. This extension should be listed as one of the incompatible plugins.
   ![image](https://github.com/woocommerce/woocommerce-google-analytics-integration/assets/17420811/65b0062b-5073-49c2-a2b1-7e16c2d89d84)
6. Git checkout this PR's branch: `tweak/product-block-editor-compatibility`.
7. Refresh the Settings page.
8. Check if the incompatible list doesn't have this extension.
   ![image](https://github.com/woocommerce/woocommerce-google-analytics-integration/assets/17420811/40078661-0f40-47f4-959a-4e2bc710d0c9)

### Changelog entry

> Tweak - Declare feature compatibility for the new product editor (also called product block editor).
