### PR TITLE
Remove options remapping, use settings directly.

### DIFF
--- a/includes/class-wc-abstract-google-analytics-js.php
+++ b/includes/class-wc-abstract-google-analytics-js.php
@@ -17,8 +17,8 @@ abstract class WC_Abstract_Google_Analytics_JS {
 	/** @var WC_Abstract_Google_Analytics_JS $instance Class Instance */
 	protected static $instance;
 
-	/** @var array $options Inherited Analytics options */
-	protected static $options;
+	/** @var array $settings Inherited Analytics settings */
+	protected static $settings;
 
 	/** @var string Developer ID */
 	public const DEVELOPER_ID = 'dOGY3NW';
@@ -110,14 +110,14 @@ abstract class WC_Abstract_Google_Analytics_JS {
 	}
 
 	/**
-	 * Return one of our options
+	 * Return one of our settings
 	 *
-	 * @param string $option Key/name for the option.
+	 * @param string $setting Key/name for the setting.
 	 *
-	 * @return string|null Value of the option or null if not found
+	 * @return string|null Value of the setting or null if not found
 	 */
-	protected static function get( $option ): ?string {
-		return self::$options[ $option ] ?? null;
+	protected static function get( $setting ): ?string {
+		return self::$settings[ $setting ] ?? null;
 	}
 
 	/**
@@ -336,8 +336,8 @@ abstract class WC_Abstract_Google_Analytics_JS {
 	/**
 	 * Get the class instance
 	 *
-	 * @param  array $options Options
+	 * @param  array $settings Settings
 	 * @return WC_Abstract_Google_Analytics_JS
 	 */
-	abstract public static function get_instance( $options = array() ): WC_Abstract_Google_Analytics_JS;
+	abstract public static function get_instance( $settings = array() ): WC_Abstract_Google_Analytics_JS;
 }

--- a/includes/class-wc-google-analytics.php
+++ b/includes/class-wc-google-analytics.php
@@ -69,11 +69,10 @@ class WC_Google_Analytics extends WC_Integration {
 	/**
 	 * Returns the proper class based on Gtag settings.
 	 *
-	 * @param  array $options                  Options
 	 * @return WC_Abstract_Google_Analytics_JS
 	 */
-	protected function get_tracking_instance( $options = array() ) {
-		return WC_Google_Gtag_JS::get_instance( $options );
+	protected function get_tracking_instance() {
+		return WC_Google_Gtag_JS::get_instance( $this->settings );
 	}
 
 	/**
@@ -88,14 +87,13 @@ class WC_Google_Analytics extends WC_Integration {
 		// Load the settings
 		$this->init_form_fields();
 		$this->init_settings();
-		$constructor = $this->init_options();
 
 		add_action( 'admin_notices', array( $this, 'universal_analytics_upgrade_notice' ) );
 
 		// Contains snippets/JS tracking code
 		include_once 'class-wc-abstract-google-analytics-js.php';
 		include_once 'class-wc-google-gtag-js.php';
-		$this->get_tracking_instance( $constructor );
+		$this->get_tracking_instance();
 
 		// Display a task on  "Things to do next section"
 		add_action( 'init', array( $this, 'add_wc_setup_task' ), 20 );
@@ -133,38 +131,6 @@ class WC_Google_Analytics extends WC_Integration {
 				)
 			);
 		}
-	}
-
-	/**
-	 * Loads all of our options for this plugin (stored as properties as well)
-	 *
-	 * @return array An array of options that can be passed to other classes
-	 */
-	public function init_options() {
-		$options = array(
-			'ga_product_identifier'                   => 'product_sku',
-			'ga_id'                                   => null,
-			'ga_standard_tracking_enabled'            => null,
-			'ga_support_display_advertising'          => null,
-			'ga_support_enhanced_link_attribution'    => null,
-			'ga_anonymize_enabled'                    => null,
-			'ga_404_tracking_enabled'                 => null,
-			'ga_enhanced_remove_from_cart_enabled'    => null,
-			'ga_enhanced_product_impression_enabled'  => null,
-			'ga_enhanced_product_click_enabled'       => null,
-			'ga_enhanced_checkout_process_enabled'    => null,
-			'ga_enhanced_product_detail_view_enabled' => null,
-			'ga_event_tracking_enabled'               => null,
-			'ga_linker_cross_domains'                 => null,
-			'ga_linker_allow_incoming_enabled'        => null,
-		);
-
-		$constructor = array();
-		foreach ( $options as $option => $default ) {
-			$constructor[ $option ] = $this->$option = $this->get_option( $option, $default );
-		}
-
-		return $constructor;
 	}
 
 	/**
@@ -316,21 +282,22 @@ class WC_Google_Analytics extends WC_Integration {
 	 * @return array       Updated WC Tracker data.
 	 */
 	public function track_options( $data ) {
+		$options = $this->settings;
 		$data['wc-google-analytics'] = array(
-			'standard_tracking_enabled'         => $this->ga_standard_tracking_enabled,
-			'support_display_advertising'       => $this->ga_support_display_advertising,
-			'support_enhanced_link_attribution' => $this->ga_support_enhanced_link_attribution,
-			'anonymize_enabled'                 => $this->ga_anonymize_enabled,
-			'ga_404_tracking_enabled'           => $this->ga_404_tracking_enabled,
-			'ecommerce_tracking_enabled'        => $this->ga_ecommerce_tracking_enabled,
-			'event_tracking_enabled'            => $this->ga_event_tracking_enabled,
+			'standard_tracking_enabled'         => $options['ga_standard_tracking_enabled'],
+			'support_display_advertising'       => $options['ga_support_display_advertising'],
+			'support_enhanced_link_attribution' => $options['ga_support_enhanced_link_attribution'],
+			'anonymize_enabled'                 => $options['ga_anonymize_enabled'],
+			'ga_404_tracking_enabled'           => $options['ga_404_tracking_enabled'],
+			'ecommerce_tracking_enabled'        => $options['ga_ecommerce_tracking_enabled'],
+			'event_tracking_enabled'            => $options['ga_event_tracking_enabled'],
 			'plugin_version'                    => WC_GOOGLE_ANALYTICS_INTEGRATION_VERSION,
-			'linker_allow_incoming_enabled'     => empty( $this->ga_linker_allow_incoming_enabled ) ? 'no' : 'yes',
-			'linker_cross_domains'              => $this->ga_linker_cross_domains,
+			'linker_allow_incoming_enabled'     => empty( $options['ga_linker_allow_incoming_enabled'] ) ? 'no' : 'yes',
+			'linker_cross_domains'              => $options['ga_linker_cross_domains'],
 		);
 
 		// ID prefix, blank, or X for unknown
-		$prefix = strstr( strtoupper( $this->ga_id ), '-', true );
+		$prefix = strstr( strtoupper( $options['ga_id'] ), '-', true );
 		if ( in_array( $prefix, array( 'UA', 'G', 'GT' ), true ) || empty( $prefix ) ) {
 			$data['wc-google-analytics']['ga_id'] = $prefix;
 		} else {

--- a/includes/class-wc-google-analytics.php
+++ b/includes/class-wc-google-analytics.php
@@ -16,51 +16,6 @@ use Automattic\WooCommerce\Admin\Features\OnboardingTasks\TaskLists;
  */
 class WC_Google_Analytics extends WC_Integration {
 
-	/** @var string $ga_id Google Analytics Tracking ID */
-	public $ga_id;
-
-	/** @var string $ga_standard_tracking_enabled Is standard tracking enabled (yes|no) */
-	public $ga_standard_tracking_enabled;
-
-	/** @var string $ga_support_display_advertising Supports display advertising (yes|no) */
-	public $ga_support_display_advertising;
-
-	/** @var string $ga_support_enhanced_link_attribution Use enhanced link attribution (yes|no) */
-	public $ga_support_enhanced_link_attribution;
-
-	/** @var string $ga_anonymize_enabled Anonymize IP addresses (yes|no) */
-	public $ga_anonymize_enabled;
-
-	/** @var string $ga_404_tracking_enabled Track 404 errors (yes|no) */
-	public $ga_404_tracking_enabled;
-
-	/** @var string $ga_ecommerce_tracking_enabled Purchase transactions (yes|no) */
-	public $ga_ecommerce_tracking_enabled;
-
-	/** @var string $ga_enhanced_remove_from_cart_enabled Track remove from cart events (yes|no) */
-	public $ga_enhanced_remove_from_cart_enabled;
-
-	/** @var string $ga_enhanced_product_impression_enabled Track product impressions (yes|no) */
-	public $ga_enhanced_product_impression_enabled;
-
-	/** @var string $ga_enhanced_product_click_enabled Track product clicks (yes|no) */
-	public $ga_enhanced_product_click_enabled;
-
-	/** @var string $ga_enhanced_checkout_process_enabled Track checkout initiated (yes|no) */
-	public $ga_enhanced_checkout_process_enabled;
-
-	/** @var string $ga_enhanced_product_detail_view_enabled Track product detail views (yes|no) */
-	public $ga_enhanced_product_detail_view_enabled;
-
-	/** @var string $ga_event_tracking_enabled Track add to cart events (yes|no) */
-	public $ga_event_tracking_enabled;
-
-	/** @var string $ga_linker_cross_domains Domains for automatic linking */
-	public $ga_linker_cross_domains;
-
-	/** @var string $ga_linker_allow_incoming_enabled Accept incoming linker (yes|no) */
-	public $ga_linker_allow_incoming_enabled;
-
 	/**
 	 * Defines the script handles that should be async.
 	 */
@@ -386,7 +341,7 @@ class WC_Google_Analytics extends WC_Integration {
 	 * @return bool         True if tracking for a certain setting is disabled
 	 */
 	private function disable_tracking( $type ) {
-		return is_admin() || current_user_can( 'manage_options' ) || ( ! $this->ga_id ) || 'no' === $type || apply_filters( 'woocommerce_ga_disable_tracking', false, $type );
+		return is_admin() || current_user_can( 'manage_options' ) || ( ! $this->settings['ga_id'] ) || 'no' === $type || apply_filters( 'woocommerce_ga_disable_tracking', false, $type );
 	}
 
 	/**

--- a/includes/class-wc-google-analytics.php
+++ b/includes/class-wc-google-analytics.php
@@ -53,7 +53,7 @@ class WC_Google_Analytics extends WC_Integration {
 		// Display a task on  "Things to do next section"
 		add_action( 'init', array( $this, 'add_wc_setup_task' ), 20 );
 		// Admin Options
-		add_filter( 'woocommerce_tracker_data', array( $this, 'track_options' ) );
+		add_filter( 'woocommerce_tracker_data', array( $this, 'track_settings' ) );
 		add_action( 'woocommerce_update_options_integration_google_analytics', array( $this, 'process_admin_options' ) );
 		add_action( 'woocommerce_update_options_integration_google_analytics', array( $this, 'show_options_info' ) );
 		add_action( 'admin_init', array( $this, 'privacy_policy' ) );
@@ -236,23 +236,23 @@ class WC_Google_Analytics extends WC_Integration {
 	 * @param  array $data Current WC tracker data.
 	 * @return array       Updated WC Tracker data.
 	 */
-	public function track_options( $data ) {
-		$options = $this->settings;
+	public function track_settings( $data ) {
+		$settings = $this->settings;
 		$data['wc-google-analytics'] = array(
-			'standard_tracking_enabled'         => $options['ga_standard_tracking_enabled'],
-			'support_display_advertising'       => $options['ga_support_display_advertising'],
-			'support_enhanced_link_attribution' => $options['ga_support_enhanced_link_attribution'],
-			'anonymize_enabled'                 => $options['ga_anonymize_enabled'],
-			'ga_404_tracking_enabled'           => $options['ga_404_tracking_enabled'],
-			'ecommerce_tracking_enabled'        => $options['ga_ecommerce_tracking_enabled'],
-			'event_tracking_enabled'            => $options['ga_event_tracking_enabled'],
+			'standard_tracking_enabled'         => $settings['ga_standard_tracking_enabled'],
+			'support_display_advertising'       => $settings['ga_support_display_advertising'],
+			'support_enhanced_link_attribution' => $settings['ga_support_enhanced_link_attribution'],
+			'anonymize_enabled'                 => $settings['ga_anonymize_enabled'],
+			'ga_404_tracking_enabled'           => $settings['ga_404_tracking_enabled'],
+			'ecommerce_tracking_enabled'        => $settings['ga_ecommerce_tracking_enabled'],
+			'event_tracking_enabled'            => $settings['ga_event_tracking_enabled'],
 			'plugin_version'                    => WC_GOOGLE_ANALYTICS_INTEGRATION_VERSION,
-			'linker_allow_incoming_enabled'     => empty( $options['ga_linker_allow_incoming_enabled'] ) ? 'no' : 'yes',
-			'linker_cross_domains'              => $options['ga_linker_cross_domains'],
+			'linker_allow_incoming_enabled'     => empty( $settings['ga_linker_allow_incoming_enabled'] ) ? 'no' : 'yes',
+			'linker_cross_domains'              => $settings['ga_linker_cross_domains'],
 		);
 
 		// ID prefix, blank, or X for unknown
-		$prefix = strstr( strtoupper( $options['ga_id'] ), '-', true );
+		$prefix = strstr( strtoupper( $settings['ga_id'] ), '-', true );
 		if ( in_array( $prefix, array( 'UA', 'G', 'GT' ), true ) || empty( $prefix ) ) {
 			$data['wc-google-analytics']['ga_id'] = $prefix;
 		} else {

--- a/includes/class-wc-google-gtag-js.php
+++ b/includes/class-wc-google-gtag-js.php
@@ -37,7 +37,7 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 	 */
 	public function __construct( $settings = array() ) {
 		parent::__construct();
-		self::$options = $settings;
+		self::$settings = $settings;
 
 		$this->load_analytics_config();
 		$this->map_actions();
@@ -202,8 +202,8 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 			'begin_checkout'   => 'ga_enhanced_checkout_process_enabled',
 		);
 
-		foreach( $settings as $event => $option_name ) {
-			if ( 'yes' === self::get( $option_name ) ) {
+		foreach( $settings as $event => $setting_name ) {
+			if ( 'yes' === self::get( $setting_name ) ) {
 				$events[] = $event;
 			}
 		}

--- a/includes/class-wc-google-gtag-js.php
+++ b/includes/class-wc-google-gtag-js.php
@@ -31,13 +31,13 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 
 	/**
 	 * Constructor
-	 * Takes our options from the parent class so we can later use them in the JS snippets
+	 * Takes our settings from the parent class so we can later use them in the JS snippets
 	 *
-	 * @param array $options Options
+	 * @param array $settings Settings
 	 */
-	public function __construct( $options = array() ) {
+	public function __construct( $settings = array() ) {
 		parent::__construct();
-		self::$options = $options;
+		self::$options = $settings;
 
 		$this->load_analytics_config();
 		$this->map_actions();
@@ -214,12 +214,12 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 	/**
 	 * Get the class instance
 	 *
-	 * @param array $options Options
+	 * @param array $settings Settings
 	 * @return WC_Abstract_Google_Analytics_JS
 	 */
-	public static function get_instance( $options = array() ): WC_Abstract_Google_Analytics_JS {
+	public static function get_instance( $settings = array() ): WC_Abstract_Google_Analytics_JS {
 		if ( null === self::$instance ) {
-			self::$instance = new self( $options );
+			self::$instance = new self( $settings );
 		}
 
 		return self::$instance;


### PR DESCRIPTION
_:warning: This PR requires https://github.com/woocommerce/woocommerce-google-analytics-integration/pull/328_
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
- [Remove options remapping, use settings directly.](https://github.com/woocommerce/woocommerce-google-analytics-integration/commit/0bc1a5b715cfb1debc264976a14b2a5a03738c22) 
   Fix https://github.com/woocommerce/woocommerce-google-analytics-integration/issues/359

I don't see any value in having another layer that's just a copy of the existing `->settings`. Having three places to store the same thing may lead to more bugs like #359, where the objects get out of sync.
- [Remove redundant WC_Google_Analytics properties](https://github.com/woocommerce/woocommerce-google-analytics-integration/commit/899c0d3d0561487b78b57174b022106ea32f8316) 
   use `$this->settings` directly.
   All the properties, except `ga_id`, were not used at all. `ga_id` was used only once.
   
### Checks:
<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1.  Go to _WooCommerce > Settings > Integration > Google Analytics_ `wp-admin/admin.php?page=wc-settings&tab=integration&section=google_analytics`
2. Make sure _" Purchase Transactions"_ is checked
3. Check the value of all the settings match the tracker data 
   ```
   wp wc tracker snapshot --format=json | jq '.[0]["wc-google-analytics"]' 
   ```
4. Check that `wcgaiData.config` matches the settings
5. Smoke test the plugin


### Additional details:
1. I think we can consider one more tweak: removing the `static get` function and using the settings array directly. A static function that relies on the property set by the instance constructor looks bug-prone. Plus, defining a function to do `$this->get( 'foo' )` instead of `$this->settings['foo']`, makes the code less explicit and does not bring much value IMO

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Dev - Remove options remapping, use settings directly.
