### PR TITLE
Process tracker config separately from feeding data to classic tracking

### DIFF
--- a/assets/js/src/config.js
+++ b/assets/js/src/config.js
@@ -1,11 +1,2 @@
-/* global wcgaiData */
-/* eslint-disable camelcase */
-export const {
-	config,
-	events,
-	cart,
-	products,
-	product,
-	added_to_cart: addedToCart,
-	order,
-} = wcgaiData;
+/* global wcgai */
+export const config = wcgai.config;

--- a/assets/js/src/index.js
+++ b/assets/js/src/index.js
@@ -1,6 +1,6 @@
 // Initialize tracking for classic WooCommerce pages
-import { trackClassicIntegration } from './integrations/classic';
-trackClassicIntegration();
+import { trackClassicPages } from './integrations/classic';
+window.wcgai.trackClassicPages = trackClassicPages;
 
 // Initialize tracking for Block based WooCommerce pages
 import './integrations/blocks';

--- a/assets/js/src/utils/index.js
+++ b/assets/js/src/utils/index.js
@@ -1,5 +1,5 @@
 import { addAction, removeAction } from '@wordpress/hooks';
-import { config, products, cart } from '../config.js';
+import { config } from '../config.js';
 
 /**
  * Formats data into the productFieldObject shape.
@@ -158,9 +158,11 @@ const formatCategoryKey = ( index ) => {
  * Searches through the global wcgaiData.products object to find a single product by its ID
  *
  * @param {number} search The ID of the product to search for
+ * @param {Object[]} products The array of available products
+ * @param {Object} cart The cart object
  * @return {Object|undefined} The product object or undefined if not found
  */
-export const getProductFromID = ( search ) => {
+export const getProductFromID = ( search, products, cart ) => {
 	return (
 		cart?.items?.find( ( { id } ) => id === search ) ??
 		products?.find( ( { id } ) => id === search )

--- a/includes/class-wc-google-analytics.php
+++ b/includes/class-wc-google-analytics.php
@@ -111,6 +111,13 @@ class WC_Google_Analytics extends WC_Integration {
 
 		// utm_nooverride parameter for Google AdWords
 		add_filter( 'woocommerce_get_return_url', array( $this, 'utm_nooverride' ) );
+
+		// Dequeue the WooCommerce Blocks Google Analytics integration,
+		// not to let it register its `gtag` function so that we could provide a more detailed configuration.
+		add_action( 'wp_enqueue_scripts', function() {
+			wp_dequeue_script( 'wc-blocks-google-analytics' );
+		});
+
 	}
 
 	/**

--- a/includes/class-wc-google-gtag-js.php
+++ b/includes/class-wc-google-gtag-js.php
@@ -43,7 +43,7 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 		$this->map_actions();
 
 		// Setup frontend scripts
-		add_action( 'wp_enqueue_scripts', array( $this, 'register_scripts' ) );
+		add_action( 'wp_enqueue_scripts', array( $this, 'register_scripts' ), 5 );
 		add_action( 'wp_footer', array( $this, 'inline_script_data' ) );
 	}
 
@@ -130,7 +130,7 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 	 *
 	 * @return void
 	 */
-	public function append_script_data( string $type, $data ): void {	
+	public function append_script_data( string $type, $data ): void {
 		if ( ! isset( $this->script_data[ $type ] ) ) {
 			$this->script_data[ $type ] = array();
 		}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
- [Set wp_enqueue_scripts priority](https://github.com/woocommerce/woocommerce-google-analytics-integration/commit/352fa295175f2a7c4d563535de0b37942b910a34) 
- [Dequeue the WC Blocks GA integration srcipt](https://github.com/woocommerce/woocommerce-google-analytics-integration/commit/8a7eb7bbc5df8d4e2e6d443e1d68387a83c9bb61) 
   not to let it register its `gtag` function so that we could provide a more detailed configuration.
   
   So we can overwrite WC Core GA even with "Add to Cart Events" on.
- [Process tracker config separately from feeding data to classic tracking](https://github.com/woocommerce/woocommerce-google-analytics-integration/commit/afa53c943d34c2d60212a119e291faddd924e92c) 
   Set up tracker synchronously once the script is loaded (possibly in the `<head>`).
   Track classic WC events only after data is ready and the document is loaded - at leas on `wp_footer`.
   
   Address https://github.com/woocommerce/woocommerce-google-analytics-integration/pull/322#issuecomment-1967508597

### Checks:
<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Build, install, activate the extension.
2. Set up integration, select all "Event tracking" options at `/wp-admin/admin.php?page=wc-settings&tab=integration&section=google_analytics`
3. Add a snippet that adds some script depending on ours:
	```php
	add_action( 'wp_enqueue_scripts', function () {
	    wp_register_script( 'my-code', '', array('woocommerce-google-analytics-integration'), null, false );
	    wp_add_inline_script( 'my-code', "console.log('Hello');" );
	    wp_enqueue_script( 'my-code' );
	} );
	```
4. Open [Tag assistant ](https://tagassistant.google.com/)
5. Open shop page, check that `view_item_list`, is tracked
6. Add item to cart, check that `add_to_cart` is tracked
4. Smoke test the extension.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
No changelog entry as it fixes bugs introduced in with https://github.com/woocommerce/woocommerce-google-analytics-integration/pull/322, which were not present in the previous, released version.