### PR TITLE
Prevent tracking admins or order multiple times and additional adjustments

### DIFF
--- a/assets/js/src/tracker/data-formatting.js
+++ b/assets/js/src/tracker/data-formatting.js
@@ -173,6 +173,10 @@ export const view_item = ( {
  * @param {Object} params.order The order object
  */
 export const purchase = ( { order } ) => {
+	if ( order === undefined ) {
+		return false;
+	}
+
 	return {
 		currency: order.currency,
 		value: parseInt( order.value ),

--- a/assets/js/src/tracker/index.js
+++ b/assets/js/src/tracker/index.js
@@ -71,11 +71,13 @@ class Tracker {
 		}
 
 		return function trackerEventHandler( data ) {
-			window[ config.tracker_function_name ](
-				'event',
-				name,
-				formatter( data )
-			);
+			if ( config.events.includes( name ) ) {
+				window[ config.tracker_function_name ](
+					'event',
+					name,
+					formatter( data )
+				);
+			}
 		};
 	}
 }

--- a/assets/js/src/tracker/index.js
+++ b/assets/js/src/tracker/index.js
@@ -71,11 +71,12 @@ class Tracker {
 		}
 
 		return function trackerEventHandler( data ) {
-			if ( config.events.includes( name ) ) {
+			const eventData = formatter( data );
+			if ( config.events.includes( name ) && eventData ) {
 				window[ config.tracker_function_name ](
 					'event',
 					name,
-					formatter( data )
+					eventData
 				);
 			}
 		};

--- a/includes/class-wc-google-analytics.php
+++ b/includes/class-wc-google-analytics.php
@@ -217,13 +217,13 @@ class WC_Google_Analytics extends WC_Integration {
 	public function track_settings( $data ) {
 		$settings                    = $this->settings;
 		$data['wc-google-analytics'] = array(
-			'support_display_advertising'       => $settings['ga_support_display_advertising'],
-			'ga_404_tracking_enabled'           => $settings['ga_404_tracking_enabled'],
-			'ecommerce_tracking_enabled'        => $settings['ga_ecommerce_tracking_enabled'],
-			'event_tracking_enabled'            => $settings['ga_event_tracking_enabled'],
-			'plugin_version'                    => WC_GOOGLE_ANALYTICS_INTEGRATION_VERSION,
-			'linker_allow_incoming_enabled'     => empty( $settings['ga_linker_allow_incoming_enabled'] ) ? 'no' : 'yes',
-			'linker_cross_domains'              => $settings['ga_linker_cross_domains'],
+			'support_display_advertising'   => $settings['ga_support_display_advertising'],
+			'ga_404_tracking_enabled'       => $settings['ga_404_tracking_enabled'],
+			'ecommerce_tracking_enabled'    => $settings['ga_ecommerce_tracking_enabled'],
+			'event_tracking_enabled'        => $settings['ga_event_tracking_enabled'],
+			'plugin_version'                => WC_GOOGLE_ANALYTICS_INTEGRATION_VERSION,
+			'linker_allow_incoming_enabled' => empty( $settings['ga_linker_allow_incoming_enabled'] ) ? 'no' : 'yes',
+			'linker_cross_domains'          => $settings['ga_linker_cross_domains'],
 		);
 
 		// ID prefix, blank, or X for unknown

--- a/includes/class-wc-google-analytics.php
+++ b/includes/class-wc-google-analytics.php
@@ -112,13 +112,6 @@ class WC_Google_Analytics extends WC_Integration {
 				'placeholder' => 'GT-XXXXX',
 				'default'     => get_option( 'woocommerce_ga_id' ), // Backwards compat
 			),
-			'ga_standard_tracking_enabled'            => array(
-				'label'         => __( 'Enable Standard Tracking', 'woocommerce-google-analytics-integration' ),
-				'description'   => __( 'This tracks session data such as demographics, system, etc. You don\'t need to enable this if you are using a 3rd party Google analytics plugin.', 'woocommerce-google-analytics-integration' ),
-				'type'          => 'checkbox',
-				'checkboxgroup' => 'start',
-				'default'       => get_option( 'woocommerce_ga_standard_tracking_enabled' ) ? get_option( 'woocommerce_ga_standard_tracking_enabled' ) : 'no',  // Backwards compat
-			),
 			'ga_support_display_advertising'          => array(
 				'label'         => __( '"Display Advertising" Support', 'woocommerce-google-analytics-integration' ),
 				/* translators: Read more link */
@@ -126,22 +119,6 @@ class WC_Google_Analytics extends WC_Integration {
 				'type'          => 'checkbox',
 				'checkboxgroup' => '',
 				'default'       => get_option( 'woocommerce_ga_support_display_advertising' ) ? get_option( 'woocommerce_ga_support_display_advertising' ) : 'yes', // Backwards compat
-			),
-			'ga_support_enhanced_link_attribution'    => array(
-				'label'         => __( 'Use Enhanced Link Attribution', 'woocommerce-google-analytics-integration' ),
-				/* translators: Read more link */
-				'description'   => sprintf( __( 'Set the Google Analytics code to support Enhanced Link Attribution. %1$sRead more about Enhanced Link Attribution%2$s.', 'woocommerce-google-analytics-integration' ), '<a href="https://support.google.com/analytics/answer/7377126?hl=en" target="_blank">', '</a>' ),
-				'type'          => 'checkbox',
-				'checkboxgroup' => '',
-				'default'       => get_option( 'woocommerce_ga_support_enhanced_link_attribution' ) ? get_option( 'woocommerce_ga_support_enhanced_link_attribution' ) : 'no',  // Backwards compat
-			),
-			'ga_anonymize_enabled'                    => array(
-				'label'         => __( 'Anonymize IP addresses', 'woocommerce-google-analytics-integration' ),
-				/* translators: Read more link */
-				'description'   => sprintf( __( 'Enabling this option is mandatory in certain countries due to national privacy laws. %1$sRead more about IP Anonymization%2$s.', 'woocommerce-google-analytics-integration' ), '<a href="https://support.google.com/analytics/answer/2763052" target="_blank">', '</a>' ),
-				'type'          => 'checkbox',
-				'checkboxgroup' => '',
-				'default'       => 'yes',
 			),
 			'ga_404_tracking_enabled'                 => array(
 				'label'         => __( 'Track 404 (Not found) Errors', 'woocommerce-google-analytics-integration' ),
@@ -240,10 +217,7 @@ class WC_Google_Analytics extends WC_Integration {
 	public function track_settings( $data ) {
 		$settings                    = $this->settings;
 		$data['wc-google-analytics'] = array(
-			'standard_tracking_enabled'         => $settings['ga_standard_tracking_enabled'],
 			'support_display_advertising'       => $settings['ga_support_display_advertising'],
-			'support_enhanced_link_attribution' => $settings['ga_support_enhanced_link_attribution'],
-			'anonymize_enabled'                 => $settings['ga_anonymize_enabled'],
 			'ga_404_tracking_enabled'           => $settings['ga_404_tracking_enabled'],
 			'ecommerce_tracking_enabled'        => $settings['ga_ecommerce_tracking_enabled'],
 			'event_tracking_enabled'            => $settings['ga_event_tracking_enabled'],

--- a/includes/class-wc-google-analytics.php
+++ b/includes/class-wc-google-analytics.php
@@ -60,7 +60,6 @@ class WC_Google_Analytics extends WC_Integration {
 		add_action( 'admin_init', array( $this, 'privacy_policy' ) );
 
 		// Tracking code
-		// add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_tracking_code' ), 9 );
 		add_filter( 'script_loader_tag', array( $this, 'async_script_loader_tags' ), 10, 3 );
 
 		// utm_nooverride parameter for Google AdWords
@@ -291,57 +290,6 @@ class WC_Google_Analytics extends WC_Integration {
 			<style>#privacy-settings-accordion-block-woocommerce-google-analytics-integration .privacy-settings-accordion-actions { display: none }</style>';
 
 		wp_add_privacy_policy_content( 'Google Analytics for WooCommerce', wpautop( $content, false ) );
-	}
-
-	/**
-	 * Display the tracking codes
-	 * Acts as a controller to figure out which code to display
-	 */
-	public function enqueue_tracking_code() {
-		global $wp;
-		$display_ecommerce_tracking = false;
-
-		$this->get_tracking_instance()->load_opt_out();
-
-		if ( $this->disable_tracking( 'all' ) ) {
-			return;
-		}
-
-		// Check if is order received page and stop when the products and not tracked
-		if ( is_order_received_page() ) {
-			$order_id = isset( $wp->query_vars['order-received'] ) ? $wp->query_vars['order-received'] : 0;
-			$order    = wc_get_order( $order_id );
-			if ( $order && ! (bool) $order->get_meta( '_ga_tracked' ) ) {
-				$display_ecommerce_tracking = true;
-				$this->enqueue_ecommerce_tracking_code( $order_id );
-			}
-		}
-	}
-
-	/**
-	 * Generate eCommerce tracking code
-	 *
-	 * @param int $order_id The Order ID for adding a transaction.
-	 */
-	protected function enqueue_ecommerce_tracking_code( $order_id ) {
-		// Get the order and output tracking code.
-		$order = wc_get_order( $order_id );
-
-		// Make sure we have a valid order object.
-		if ( ! $order ) {
-			return;
-		}
-
-		// Check order key.
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-		$order_key = empty( $_GET['key'] ) ? '' : wc_clean( wp_unslash( $_GET['key'] ) );
-		if ( ! $order->key_is_valid( $order_key ) ) {
-			return;
-		}
-
-		// Mark the order as tracked.
-		$order->update_meta_data( '_ga_tracked', 1 );
-		$order->save();
 	}
 
 	/**

--- a/includes/class-wc-google-analytics.php
+++ b/includes/class-wc-google-analytics.php
@@ -45,10 +45,11 @@ class WC_Google_Analytics extends WC_Integration {
 
 		add_action( 'admin_notices', array( $this, 'universal_analytics_upgrade_notice' ) );
 
-		// Contains snippets/JS tracking code
-		include_once 'class-wc-abstract-google-analytics-js.php';
-		include_once 'class-wc-google-gtag-js.php';
-		$this->get_tracking_instance();
+		if ( ! $this->disable_tracking( 'all' ) ) {
+			include_once 'class-wc-abstract-google-analytics-js.php';
+			include_once 'class-wc-google-gtag-js.php';
+			$this->get_tracking_instance();
+		}
 
 		// Display a task on  "Things to do next section"
 		add_action( 'init', array( $this, 'add_wc_setup_task' ), 20 );
@@ -59,7 +60,7 @@ class WC_Google_Analytics extends WC_Integration {
 		add_action( 'admin_init', array( $this, 'privacy_policy' ) );
 
 		// Tracking code
-		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_tracking_code' ), 9 );
+		// add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_tracking_code' ), 9 );
 		add_filter( 'script_loader_tag', array( $this, 'async_script_loader_tags' ), 10, 3 );
 
 		// utm_nooverride parameter for Google AdWords

--- a/includes/class-wc-google-analytics.php
+++ b/includes/class-wc-google-analytics.php
@@ -40,9 +40,10 @@ class WC_Google_Analytics extends WC_Integration {
 
 		add_action( 'admin_notices', array( $this, 'universal_analytics_upgrade_notice' ) );
 
+		include_once 'class-wc-abstract-google-analytics-js.php';
+		include_once 'class-wc-google-gtag-js.php';
+
 		if ( ! $this->disable_tracking( 'all' ) ) {
-			include_once 'class-wc-abstract-google-analytics-js.php';
-			include_once 'class-wc-google-gtag-js.php';
 			$this->get_tracking_instance();
 		}
 

--- a/includes/class-wc-google-analytics.php
+++ b/includes/class-wc-google-analytics.php
@@ -17,11 +17,6 @@ use Automattic\WooCommerce\Admin\Features\OnboardingTasks\TaskLists;
 class WC_Google_Analytics extends WC_Integration {
 
 	/**
-	 * Defines the script handles that should be async.
-	 */
-	private const ASYNC_SCRIPT_HANDLES = array( 'google-tag-manager' );
-
-	/**
 	 * Returns the proper class based on Gtag settings.
 	 *
 	 * @return WC_Abstract_Google_Analytics_JS
@@ -58,9 +53,6 @@ class WC_Google_Analytics extends WC_Integration {
 		add_action( 'woocommerce_update_options_integration_google_analytics', array( $this, 'process_admin_options' ) );
 		add_action( 'woocommerce_update_options_integration_google_analytics', array( $this, 'show_options_info' ) );
 		add_action( 'admin_init', array( $this, 'privacy_policy' ) );
-
-		// Tracking code
-		add_filter( 'script_loader_tag', array( $this, 'async_script_loader_tags' ), 10, 3 );
 
 		// utm_nooverride parameter for Google AdWords
 		add_filter( 'woocommerce_get_return_url', array( $this, 'utm_nooverride' ) );
@@ -344,29 +336,5 @@ class WC_Google_Analytics extends WC_Integration {
 				TaskLists::get_list( 'extended' )
 			)
 		);
-	}
-
-	/**
-	 * Add async to script tags with defined handles.
-	 *
-	 * @param string $tag HTML for the script tag.
-	 * @param string $handle Handle of the script.
-	 * @param string $src Src of the script.
-	 *
-	 * @return string
-	 */
-	public function async_script_loader_tags( $tag, $handle, $src ) {
-		if ( ! in_array( $handle, self::ASYNC_SCRIPT_HANDLES, true ) ) {
-			return $tag;
-		}
-
-		// Check if the script has the async attribute already. If so, don't add it again.
-		$has_async_tag = preg_match( '/\basync\b/', $tag );
-		if ( ! empty( $has_async_tag ) ) {
-			return $tag;
-		}
-
-		// Add the async attribute
-		return str_replace( ' src', ' async src', $tag );
 	}
 }

--- a/includes/class-wc-google-gtag-js.php
+++ b/includes/class-wc-google-gtag-js.php
@@ -193,8 +193,6 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 			'tracker_function_name' => self::tracker_function_name(),
 			'track_404'             => 'yes' === self::get( 'ga_404_tracking_enabled' ),
 			'allow_google_signals'  => 'yes' === self::get( 'ga_support_display_advertising' ),
-			'link_attribution'      => 'yes' === self::get( 'ga_support_enhanced_link_attribution' ),
-			'anonymize_ip'          => 'yes' === self::get( 'ga_anonymize_enabled' ),
 			'logged_in'             => is_user_logged_in(),
 			'linker'                => array(
 				'domains'        => ! empty( self::get( 'ga_linker_cross_domains' ) ) ? array_map( 'esc_js', explode( ',', self::get( 'ga_linker_cross_domains' ) ) ) : array(),

--- a/includes/class-wc-google-gtag-js.php
+++ b/includes/class-wc-google-gtag-js.php
@@ -61,7 +61,9 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 			'https://www.googletagmanager.com/gtag/js?id=' . self::get( 'ga_id' ),
 			array(),
 			null,
-			false
+			array(
+				'strategy' => 'async'
+			)
 		);
 		// tracker.js needs to be executed ASAP, the remaining bits for main.js could be deffered,
 		// but to reduce the traffic, we ship it all together.

--- a/includes/class-wc-google-gtag-js.php
+++ b/includes/class-wc-google-gtag-js.php
@@ -186,8 +186,7 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 	 * @return array
 	 */
 	public function get_analytics_config(): array {
-		return array(
-			'developer_id'          => self::DEVELOPER_ID,
+		$defaults = array(
 			'gtag_id'               => self::get( 'ga_id' ),
 			'tracker_function_name' => self::tracker_function_name(),
 			'track_404'             => 'yes' === self::get( 'ga_404_tracking_enabled' ),
@@ -206,6 +205,11 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 			'identifier'            => self::get( 'ga_product_identifier' ),
 			'consent_modes'         => self::get_consent_modes(),
 		);
+
+		$config                 = apply_filters( 'woocommerce_ga_gtag_config', $defaults );
+		$config['developer_id'] = self::DEVELOPER_ID;
+
+		return $config;
 	}
 
 	/**

--- a/includes/class-wc-google-gtag-js.php
+++ b/includes/class-wc-google-gtag-js.php
@@ -62,7 +62,7 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 			array(),
 			null,
 			array(
-				'strategy' => 'async'
+				'strategy' => 'async',
 			)
 		);
 		// tracker.js needs to be executed ASAP, the remaining bits for main.js could be deffered,


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Following on from #322, this PR ensures that no tracking happens if [disable_tracking()](https://github.com/woocommerce/woocommerce-google-analytics-integration/blob/0a546f42430ad9fcda6f9b17a3840a9acb9a3bc2/includes/class-wc-google-analytics.php#L43) returns true. Additionally, the new tracking wasn't considering the `_ga_tracked` meta value for orders meaning if a user was to refresh the thank you page multiple `purchase` events would be triggered which is fixed in 94b4dc7.

**Additional cleanup:**

- Removed `async_script_loader_tags()` and set `strategy` on the enqueued script 4e8e1ac
- Added filter to [adjust gtag config](https://github.com/woocommerce/woocommerce-google-analytics-integration/commit/e5485bf1ddc6a719a8e6c0b7d2730989dbc0356e)
- Added check to confirm specific event is enabled before tracking d7befb1 (_This was added earlier but lost in a previous PR_)
- Removed settings that are no longer relevant with GA4 3b26491
    1. `Enable Standard Tracking`
        - Previously had an impact on how things were loaded but didn't do much beyond that. The option description did not seem to be particularly relevant either so I thought the best option was to remove it entirely
    2. `Use Enhanced Link Attribution`
        - No longer relevant. See https://developers.google.com/analytics/devguides/collection/analyticsjs/enhanced-link-attribution
    4. `Anonymize IP addresses`
       - No longer relevant. See https://support.google.com/analytics/answer/2763052

### Screenshots:

<img width="1583" alt="Screenshot 2024-03-05 at 13 00 08" src="https://github.com/woocommerce/woocommerce-google-analytics-integration/assets/40762232/c2942311-9811-4b1d-8c52-177ff1fb7bd7">

### Detailed test instructions:

1. Build extension from `fix/tracking-for-purchases-and-admins`
2. Go to [Tag Assistant](https://tagassistant.google.com/) and debug site
3. While logged in as an admin, confirm that no tracking is sent
4. Logout
5. Open an incognito window and ensure all options are selected in `WooCommerce > Settings > Integrations > Google Analytics`
6. Confirm events are tracked
7. Place an order and confirm a `purchase` event is sent
8. Refresh the thank you page and confirm a second `purchase` event is not sent
9. In the incognito window, disable some events like `Add to Cart Events` and `Product Detail Views`
10. In the non-incognito window, confirm that those events are no longer sent

### Additional:

I believe we can remove a couple of the other settings but as we're close to release I decided to only remove settings that explicitly state they are not support by GA4. If any other changes are needed that can be addressed post launch.

### Changelog entry

> Fix - Prevent tracking orders multiple times and additional fixes