### PR TITLE
Resolve Google Analytics not loading if gtag already exists on the window object.

### DIFF
--- a/assets/js/src/tracker/index.js
+++ b/assets/js/src/tracker/index.js
@@ -26,11 +26,6 @@ class Tracker {
 	 * Initializes the tracker and dataLayer if not already done.
 	 */
 	init() {
-		if ( window[ config.tracker_function_name ] ) {
-			// Tracker already initialized. Do nothing.
-			return;
-		}
-
 		window.dataLayer = window.dataLayer || [];
 
 		function gtag() {

--- a/assets/js/src/tracker/index.js
+++ b/assets/js/src/tracker/index.js
@@ -19,13 +19,7 @@ class Tracker {
 			throw new Error( 'Cannot instantiate more than one Tracker' );
 		}
 		instance = this;
-		instance.init();
-	}
 
-	/**
-	 * Initializes the tracker and dataLayer if not already done.
-	 */
-	init() {
 		window.dataLayer = window.dataLayer || [];
 
 		function gtag() {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://github.com/woocommerce/woocommerce-google-analytics-integration/issues/367.

Resolves the tracker not loading if gtag already exists on the window object.

It's valid for gtag to already exist on the object, as a cookie banner may have created it to send a consent update, or it may exist from another tag such as Google Ads.

Here's an example from Google where it's valid for it to be created multiple times: 

https://developers.google.com/tag-platform/security/guides/consent?consentmode=advanced#gtag.js_3

### Checks:
<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Initialise a gtag object on the window before the plugin loads its JS.

Barebones example for testing purposes:
```
<script>
window.dataLayer = window.dataLayer || [];
function gtag(){dataLayer.push(arguments);}
</script>
```
3. Confirm that the plugin has successfully loaded the Google Analytics tag.



