### PR TITLE
Warn about potential scripts order mismatch.

### DIFF
--- a/includes/class-wc-google-gtag-js.php
+++ b/includes/class-wc-google-gtag-js.php
@@ -105,11 +105,23 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 			)
 		);
 
+		$message = sprintf(
+			/* translators: 1 inlined data script, 2 the tracker definition */
+			__( "`wcgai.trackClassicPages` function is not available. Please make sure Google Analytics for WooCommerce's scripts are loaded correctly. `%1\$s` after `%2\$s`. Some other plugins may defer or change the script order.", 'woocommerce-google-analytics-integration' ),
+			$this->data_script_handle,
+			$this->script_handle,
+		);
+
 		wp_add_inline_script(
 			$this->data_script_handle,
 			sprintf(
-				'wcgai.trackClassicPages( %s );',
-				$this->get_script_data()
+				'if( window.wcgai && typeof window.wcgai.trackClassicPages === "function" ){
+					wcgai.trackClassicPages( %s );
+				} else {
+					console.error( "%s" );
+				}',
+				$this->get_script_data(),
+				esc_js( $message ),
 			)
 		);
 


### PR DESCRIPTION

### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
Warn about potential scripts order mismatch.
to make it easier to track issues like https://github.com/woocommerce/woocommerce-google-analytics-integration/issues/368

### Checks:
<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Build, install activate.
2. Install and activate Autoptimize plugin
3. Set it up
   - _Do not aggregate but defer?_ - enabled
   - _Also defer inline JS?_ disabled
   - _Exclude scripts from Autoptimize:_ empty
   ![image](https://github.com/woocommerce/woocommerce-google-analytics-integration/assets/17435/80eca3f6-5727-4da9-bd91-24761a7a413d)



### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Tweak - Warn about potential script order mismatch
