### PR TITLE
Format price for purchase event

### DIFF
--- a/assets/js/src/tracker/data-formatting.js
+++ b/assets/js/src/tracker/data-formatting.js
@@ -178,8 +178,11 @@ export const purchase = ( { order } ) => {
 	}
 
 	return {
-		currency: order.currency,
-		value: parseInt( order.value ),
+		currency: order.totals.currency_code,
+		value: formatPrice(
+			order.totals.total_price,
+			order.totals.currency_minor_unit
+		),
 		items: order.items.map( getProductFieldObject ),
 	};
 };

--- a/includes/class-wc-abstract-google-analytics-js.php
+++ b/includes/class-wc-abstract-google-analytics-js.php
@@ -264,8 +264,11 @@ abstract class WC_Abstract_Google_Analytics_JS {
 		}
 
 		return array(
-			'currency' => $order->get_currency(),
-			'value'    => $this->get_formatted_price( $order->get_total() ),
+			'totals'  => array(
+				'currency_code'       => $order->get_currency(),
+				'total_price'         => $this->get_formatted_price( $order->get_total() ),
+				'currency_minor_unit' => wc_get_price_decimals(),
+			),
 			'items'    => array_map(
 				function ( $item ) {
 					return array_merge(

--- a/includes/class-wc-abstract-google-analytics-js.php
+++ b/includes/class-wc-abstract-google-analytics-js.php
@@ -264,12 +264,12 @@ abstract class WC_Abstract_Google_Analytics_JS {
 		}
 
 		return array(
-			'totals'  => array(
+			'totals' => array(
 				'currency_code'       => $order->get_currency(),
 				'total_price'         => $this->get_formatted_price( $order->get_total() ),
 				'currency_minor_unit' => wc_get_price_decimals(),
 			),
-			'items'    => array_map(
+			'items'  => array_map(
 				function ( $item ) {
 					return array_merge(
 						$this->get_formatted_product( $item->get_product() ),


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
Format prices for `purchase` events the same way we do for other events.
Fix https://wordpress.org/support/topic/conversion-value-wrong/

### Checks:
<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1.  Build, install & activate
2. Use [Tag Assistant](https://tagassistant.google.com/)
3. (setup your store to use decimal part in prices)
4. Open shop page, add item to the cart
5. Place an order
6. Inspect `purchase` event in Tag Assistant
7. Check that prices of individual items and the entire cart ar in the same format

#### Before
![image](https://github.com/woocommerce/woocommerce-google-analytics-integration/assets/17435/53c09788-9260-49e8-aac2-ac0ebd5e35c2)
#### After 
![image](https://github.com/woocommerce/woocommerce-google-analytics-integration/assets/17435/99a0533c-b6fb-4417-997c-6a6d7808370a)



### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Purchase price format.
