### PR TITLE
Handle AJAX add to cart for simple products

### DIFF
--- a/assets/js/src/integrations/classic.js
+++ b/assets/js/src/integrations/classic.js
@@ -52,13 +52,23 @@ export function trackClassicPages( {
 	 * @param {HTMLElement[]} button    - An array of HTML elements representing the add to cart button.
 	 */
 	document.body.onadded_to_cart = ( e, fragments, cartHash, button ) => {
-		tracker.eventHandler( 'add_to_cart' )( {
-			product: getProductFromID(
-				parseInt( button[ 0 ].dataset.product_id ),
-				products,
-				cart
-			),
-		} );
+		// Get product ID from data attribute (archive pages) or value (single product pages).
+		const productID = parseInt(
+			button[ 0 ].dataset.product_id || button[ 0 ].value
+		);
+
+		// If the current product doesn't match search by ID.
+		const productToHandle =
+			product.id === productID
+				? product
+				: getProductFromID( parseInt( productID ), products, cart );
+
+		// Confirm we found a product to handle.
+		if ( ! productToHandle ) {
+			return;
+		}
+
+		tracker.eventHandler( 'add_to_cart' )( { product: productToHandle } );
 	};
 
 	/**

--- a/assets/js/src/integrations/classic.js
+++ b/assets/js/src/integrations/classic.js
@@ -59,7 +59,7 @@ export function trackClassicPages( {
 
 		// If the current product doesn't match search by ID.
 		const productToHandle =
-			product.id === productID
+			product?.id === productID
 				? product
 				: getProductFromID( parseInt( productID ), products, cart );
 

--- a/assets/js/src/tracker/data-formatting.js
+++ b/assets/js/src/tracker/data-formatting.js
@@ -46,7 +46,7 @@ export const view_item_list = ( {
  */
 export const add_to_cart = ( { product, quantity = 1 } ) => {
 	return {
-		items: [ getProductFieldObject( product, quantity ) ],
+		items: product ? [ getProductFieldObject( product, quantity ) ] : [],
 	};
 };
 
@@ -59,7 +59,7 @@ export const add_to_cart = ( { product, quantity = 1 } ) => {
  */
 export const remove_from_cart = ( { product, quantity = 1 } ) => {
 	return {
-		items: [ getProductFieldObject( product, quantity ) ],
+		items: product ? [ getProductFieldObject( product, quantity ) ] : [],
 	};
 };
 
@@ -128,6 +128,10 @@ export const add_shipping_info = ( { storeCart } ) => {
  * @param {Object} params.product The product to track
  */
 export const select_content = ( { product } ) => {
+	if ( ! product ) {
+		return false;
+	}
+
 	return {
 		content_type: 'product',
 		content_id: getProductId( product ),


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR resolves the issue that an add to cart AJAX request from a single product page was throwing an error.
WC core doesn't handle AJAX from single product pages, however it can be replicated with [a plugin](https://wordpress.org/plugins/woo-ajax-add-to-cart/). It's also quite common for themes to include this kind of behaviour.

Reported in the forum: https://wordpress.org/support/topic/js-error-on-product-page-2/

The PR resolved two issues:
1. If the product data attribute is not available on the add to cart button, then extract it from the value (WC sets it on the value in [this template](https://github.com/woocommerce/woocommerce/blob/8.6.1/plugins/woocommerce/templates/single-product/add-to-cart/simple.php#L49)).
2. The handlers / formatter is given the result of searching for a product. However in some cases a product is not found by the function `getProductFromID`, in such cases we need to prevent from formatting the data.

We also need to be careful with the handler `document.body.onadded_to_cart` as we always hook into this regardless if we disable `add_to_cart` tracking, should we conditionally hook into that event?

Closes #382 


### Detailed test instructions:

1. Setup tracking including `add_to_cart` tracking
2. Install a plugin to do AJAX add to cart: https://wordpress.org/plugins/woo-ajax-add-to-cart/
3. Create a simple product
4. Add simple product on a single product page
5. Confirm that the product is tracked
6. Create a page with the shortcode `[products]` and ensure AJAX add to cart on archives is enabled in WC > Settings
7. Add a simple product from the archive page
8. Confirm that the product is tracked

### Additional details:

This PR points out a separate issue that we search for products in the cart items first and then the list of products, [see here](https://github.com/woocommerce/woocommerce-google-analytics-integration/blob/2.0.1/assets/js/src/utils/index.js#L167-L168).

That's a problem when it comes to the quantity number, which we can see in the following scenario:
1. Add single product 3x to cart
2. Refresh archive page
3. Add same single product to cart
4. View tracking data and the quantity is set to 3

Ideally we should be setting the quantity back to 1. Also is it really relevant to search through cart data, even though the product ID matches, we might have added one with a discount / addon which could make the price different. We'll need to log this in a separate issue.

Another issue is that it still won't work for variable products added to AJAX as we'll need to access the form data to find out which variation was selected.

### Changelog entry
* Fix - Handle AJAX add to cart for simple products
