### PR TITLE
Track purchase transaction ID

### DIFF
--- a/assets/js/src/tracker/data-formatting.js
+++ b/assets/js/src/tracker/data-formatting.js
@@ -178,10 +178,14 @@ export const purchase = ( { order } ) => {
 	}
 
 	return {
-		currency: order.totals.currency_code,
-		value: formatPrice(
-			order.totals.total_price,
-			order.totals.currency_minor_unit
+		transaction_id: order.id,
+		affiliation: order.affiliation,
+		currency: order.currency_code,
+		value: formatPrice( order.total_price, order.currency_minor_unit ),
+		tax: formatPrice( order.total_tax, order.currency_minor_unit ),
+		shipping: formatPrice(
+			order.total_shipping,
+			order.currency_minor_unit
 		),
 		items: order.items.map( getProductFieldObject ),
 	};

--- a/assets/js/src/tracker/data-formatting.js
+++ b/assets/js/src/tracker/data-formatting.js
@@ -180,12 +180,18 @@ export const purchase = ( { order } ) => {
 	return {
 		transaction_id: order.id,
 		affiliation: order.affiliation,
-		currency: order.currency_code,
-		value: formatPrice( order.total_price, order.currency_minor_unit ),
-		tax: formatPrice( order.tax_total, order.currency_minor_unit ),
+		currency: order.totals.currency_code,
+		value: formatPrice(
+			order.totals.total_price,
+			order.totals.currency_minor_unit
+		),
+		tax: formatPrice(
+			order.totals.tax_total,
+			order.totals.currency_minor_unit
+		),
 		shipping: formatPrice(
-			order.shipping_total,
-			order.currency_minor_unit
+			order.totals.shipping_total,
+			order.totals.currency_minor_unit
 		),
 		items: order.items.map( getProductFieldObject ),
 	};

--- a/assets/js/src/tracker/data-formatting.js
+++ b/assets/js/src/tracker/data-formatting.js
@@ -182,9 +182,9 @@ export const purchase = ( { order } ) => {
 		affiliation: order.affiliation,
 		currency: order.currency_code,
 		value: formatPrice( order.total_price, order.currency_minor_unit ),
-		tax: formatPrice( order.total_tax, order.currency_minor_unit ),
+		tax: formatPrice( order.tax_total, order.currency_minor_unit ),
 		shipping: formatPrice(
-			order.total_shipping,
+			order.shipping_total,
 			order.currency_minor_unit
 		),
 		items: order.items.map( getProductFieldObject ),

--- a/includes/class-wc-abstract-google-analytics-js.php
+++ b/includes/class-wc-abstract-google-analytics-js.php
@@ -264,12 +264,14 @@ abstract class WC_Abstract_Google_Analytics_JS {
 		}
 
 		return array(
-			'totals' => array(
-				'currency_code'       => $order->get_currency(),
-				'total_price'         => $this->get_formatted_price( $order->get_total() ),
-				'currency_minor_unit' => wc_get_price_decimals(),
-			),
-			'items'  => array_map(
+			'id'                  => $order->get_id(),
+			'affiliation'         => get_bloginfo( 'name' ),
+			'currency_code'       => $order->get_currency(),
+			'currency_minor_unit' => wc_get_price_decimals(),
+			'tax_total'           => $this->get_formatted_price( $order->get_total_tax() ),
+			'shipping_total'      => $this->get_formatted_price( $order->get_total_shipping() ),
+			'total_price'         => $this->get_formatted_price( $order->get_total() ),
+			'items'               => array_map(
 				function ( $item ) {
 					return array_merge(
 						$this->get_formatted_product( $item->get_product() ),

--- a/includes/class-wc-abstract-google-analytics-js.php
+++ b/includes/class-wc-abstract-google-analytics-js.php
@@ -285,7 +285,7 @@ abstract class WC_Abstract_Google_Analytics_JS {
 				'shipping_total'      => $this->get_formatted_price( $order->get_total_shipping() ),
 				'total_price'         => $this->get_formatted_price( $order->get_total() ),
 			),
-			'items'        => array_map(
+			'items'       => array_map(
 				function ( $item ) {
 					return array_merge(
 						$this->get_formatted_product( $item->get_product() ),

--- a/includes/class-wc-abstract-google-analytics-js.php
+++ b/includes/class-wc-abstract-google-analytics-js.php
@@ -276,14 +276,16 @@ abstract class WC_Abstract_Google_Analytics_JS {
 		}
 
 		return array(
-			'id'                  => $order->get_id(),
-			'affiliation'         => get_bloginfo( 'name' ),
-			'currency_code'       => $order->get_currency(),
-			'currency_minor_unit' => wc_get_price_decimals(),
-			'tax_total'           => $this->get_formatted_price( $order->get_total_tax() ),
-			'shipping_total'      => $this->get_formatted_price( $order->get_total_shipping() ),
-			'total_price'         => $this->get_formatted_price( $order->get_total() ),
-			'items'               => array_map(
+			'id'          => $order->get_id(),
+			'affiliation' => get_bloginfo( 'name' ),
+			'totals'      => array(
+				'currency_code'       => $order->get_currency(),
+				'currency_minor_unit' => wc_get_price_decimals(),
+				'tax_total'           => $this->get_formatted_price( $order->get_total_tax() ),
+				'shipping_total'      => $this->get_formatted_price( $order->get_total_shipping() ),
+				'total_price'         => $this->get_formatted_price( $order->get_total() ),
+			),
+			'items'        => array_map(
 				function ( $item ) {
 					return array_merge(
 						$this->get_formatted_product( $item->get_product() ),

--- a/tests/e2e/specs/gtag-events/classic-pages.test.js
+++ b/tests/e2e/specs/gtag-events/classic-pages.test.js
@@ -281,7 +281,7 @@ test.describe( 'GTag events on classic pages', () => {
 		await variableProductAddToCart( page, variableProductID );
 
 		const event = trackGtagEvent( page, 'purchase', 'checkout' );
-		await checkout( page );
+		const orderID = await checkout( page );
 
 		await event.then( ( request ) => {
 			const data = getEventData( request, 'purchase' );
@@ -300,6 +300,11 @@ test.describe( 'GTag events on classic pages', () => {
 				pr: '18.99',
 				va: 'colour: Green, size: Medium',
 			} );
+
+			expect( data[ 'epn.transaction_id' ] ).toEqual( orderID );
+			expect( data[ 'ep.affiliation' ] ).toEqual(
+				'WooCommerce E2E Test Suite'
+			);
 
 			const total = simpleProductPrice + simpleProductPrice + 18.99;
 			expect( data.cu ).toEqual( 'USD' );

--- a/tests/e2e/utils/customer.js
+++ b/tests/e2e/utils/customer.js
@@ -95,6 +95,8 @@ export async function blockProductAddToCart( page, productID ) {
  * Perform checkout steps to purchase a product.
  *
  * @param {Page} page
+ *
+ * @return {number} Order number.
  */
 export async function checkout( page ) {
 	const user = config.addresses.customer.billing;
@@ -135,4 +137,10 @@ export async function checkout( page ) {
 	await expect(
 		page.locator( '.wc-block-order-confirmation-status' )
 	).toContainText( 'order has been received' );
+
+	// Return order number from page.
+	return await page.$eval(
+		'.wc-block-order-confirmation-summary-list-item__value',
+		( el ) => el.textContent
+	);
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds the transaction ID (order ID) which is missing from the purchase event. Previously we sent the following details that [can be seen here](https://github.com/woocommerce/woocommerce-google-analytics-integration/blob/1.8.14/includes/class-wc-google-gtag-js.php#L342-L353):
```php
'transaction_id' => $order->get_order_number(),
'affiliation'    => get_bloginfo( 'name' ),
'value'          => $order->get_total(),
'tax'            => $order->get_total_tax(),
'shipping'       => $order->get_total_shipping(),
'currency'       => $order->get_currency(),
'items'          => $event_items,
``` 

Here we add them back to the details we send with the purchase event.

Closes #387

### Detailed test instructions:

1. Setup the extension for tracking 
2. Create some products to add to the cart
3. Complete a purchase in an incognito window
4. Check the purchase event and confirm it contains both the correct transaction ID set to order ID and affiliation set to the site name (if shipping / taxes is enabled those totals can be confirmed as well)

Note: The changed E2E test still relies on a fix in #384 so it's a little harder to test.

### Additional details:
In the tests I didn't add a check for confirming the shipping totals and tax totals are tracked correctly. In order to do so we would need to set up a default shipping method. I think we can leave this for a follow up issue.

### Changelog entry
* Fix - Track purchase transaction ID.
