### PR TITLE
Fix warning after plugin install using wp-cli

### DIFF
--- a/includes/class-wc-google-analytics.php
+++ b/includes/class-wc-google-analytics.php
@@ -266,7 +266,7 @@ class WC_Google_Analytics extends WC_Integration {
 	 * @return bool         True if tracking for a certain setting is disabled
 	 */
 	private function disable_tracking( $type ) {
-		return is_admin() || current_user_can( 'manage_options' ) || ( ! $this->settings['ga_id'] ) || 'no' === $type || apply_filters( 'woocommerce_ga_disable_tracking', false, $type );
+		return is_admin() || current_user_can( 'manage_options' ) || empty( $this->settings['ga_id'] ) || 'no' === $type || apply_filters( 'woocommerce_ga_disable_tracking', false, $type );
 	}
 
 	/**


### PR DESCRIPTION
Fixes PHP Warning after plugin install using wp-cli.

`Undefined array key "ga_id" in /wp-content/plugins/woocommerce-google-analytics-integration/includes/class-wc-google-analytics.php on line 269`


### Changelog entry

> Fix - Warning after plugin install using wp-cli.
