### PR TITLE
Add require plugins header

### DIFF
--- a/woocommerce-google-analytics-integration.php
+++ b/woocommerce-google-analytics-integration.php
@@ -9,6 +9,7 @@
  * WC requires at least: 8.4
  * WC tested up to: 8.7
  * Requires at least: 6.2
+ * Requires Plugins: woocommerce
  * Tested up to: 6.5
  * License: GPLv2 or later
  * Text Domain: woocommerce-google-analytics-integration


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #401   

This PR enables the new Requires Plugins header available in WP 6.5

See --> https://make.wordpress.org/core/2024/03/05/introducing-plugin-dependencies-in-wordpress-6-5/

### Screenshots:

<img width="1555" alt="Screenshot 2024-03-15 at 10 53 45" src="https://github.com/woocommerce/automatewoo/assets/5908855/40ccd247-1aeb-402f-a07f-4a7029bf174d">

<img width="1507" alt="Screenshot 2024-03-15 at 10 53 35" src="https://github.com/woocommerce/woocommerce-google-analytics-integration/assets/5908855/f1c96ba8-f9fc-47a7-83e0-81647b3c7505">






### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Install WP 6.5 (RC2) --> https://wordpress.org/wordpress-6.5-RC2.zip 
2. Install Woo Commerce and the extension (checkout this PR)
3. If WC is activated, the extension can be activated
4. If WC is not activated, extension button for activate is disabled. A notice "This plugin cannot be activated because required plugins are missing or inactive." is shown.
5. If extension is activated and WC is activated. WC cannot be deactivated. And it shows info like "Required by: Google Analytics for WooCommerce" 


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Tweak - Add WP 6.5 Require plugins header
