### PR TITLE
Add QIT workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,7 @@
 name: Build
 
 on:
+  workflow_call:
   push:
     branches:
       - trunk
@@ -37,6 +38,16 @@ jobs:
           echo "::endgroup::"
 
       - name: Publish dev build to GitHub
+        if: ${{ github.event_name == 'push' && github.ref_name == 'trunk' }}
         uses: woocommerce/grow/publish-extension-dev-build@actions-v1
         with:
           extension-asset-path: woocommerce-google-analytics-integration.zip
+
+      - name: Publish build artifact
+        if: ${{ ! ( github.event_name == 'push' && github.ref_name == 'trunk' ) }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: woocommerce-google-analytics-integration.zip
+          path: ${{ github.workspace }}/woocommerce-google-analytics-integration.zip
+          # Do not bloat the storage. Keep in only long enough for a caller workflow to pick it up and follow up with some manual debugging.
+          retention-days: 2

--- a/.github/workflows/run-qit.yml
+++ b/.github/workflows/run-qit.yml
@@ -1,0 +1,79 @@
+name: Run QIT
+
+# **What it does**: Runs a suite of QIT tests for the extension.
+# **Why we have it**: To be able to check QIT compatibility at once. For example, to test a specific branch, or upcoming release.
+
+on:
+  workflow_dispatch:
+    inputs:
+      wait:
+        description: 'Should wait for results'
+        default: false
+        type: boolean
+      # Configure which tests to run.
+      test-activation:
+        description: 'Should activation be tested?'
+        required: true
+        default: true
+        type: boolean
+      test-security:
+        description: 'Should security be tested?'
+        required: true
+        default: true
+        type: boolean
+      test-phpstan:
+        description: 'Should phpstan be tested?'
+        required: true
+        default: true
+        type: boolean
+      test-api:
+        description: 'Should API be tested?'
+        required: true
+        default: true
+        type: boolean
+      test-e2e:
+        description: 'Should E2E be tested? (takes a lot of time)'
+        required: true
+        default: false
+        type: boolean
+
+      # Advanced customization.
+      ignore-fail:
+        description: Should pass even if any awaited test fails.
+        required: false
+        default: false
+        type: boolean
+      options:
+        description: 'Additional options for `qit` command, like `--optional_features=hpos`.'
+        required: false
+
+jobs:
+  build:
+    name: Build extension
+    uses: ./.github/workflows/build.yml
+    secrets: inherit
+  qit-tests:
+    name: Run QIT Tests
+    runs-on: ubuntu-20.04
+    needs: build
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: woocommerce-google-analytics-integration.zip
+      - name: Run QIT Tests
+        # Update it with more stable path once merged.
+        uses: woocommerce/grow/run-qit-extension@actions-v1
+        with:
+          qit-partner-user: ${{ secrets.QIT_PARTNER_USER }}
+          qit-partner-secret: ${{ secrets.QIT_PARTNER_SECRET }}
+          version: local
+          wait: ${{ inputs.wait }}
+          extension: 'woocommerce-google-analytics-integration'
+          test-activation: ${{ inputs.test-activation }}
+          test-security: ${{ inputs.test-security }}
+          test-phpstan: ${{ inputs.test-phpstan }}
+          test-api: ${{ inputs.test-api }}
+          test-e2e: ${{ inputs.test-e2e }}
+          ignore-fail: ${{ inputs.ignore-fail }}
+          options: ${{ inputs.options }}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Add a manual QIT workflow so we can run the tests before the release w/o leaving the GitHub context.

### Checks:
<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Screenshots:

![image](https://github.com/woocommerce/woocommerce-google-analytics-integration/assets/17435/02183f7d-b64f-413f-91fa-163cc70d9439)


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

Manual workflows require to be merged to trunk to work, so you can either 
1. Fork the repo
2. Merge to `trunk`
3. Run the workflow
or
1. Merge this PR and try :goberserk: 

This is a clone of GLA version https://github.com/woocommerce/google-listings-and-ads/pull/2114


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Dev - Add QIT workflow
