### PR TITLE
Add a manual workflow run for PHP unit tests

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -20,3 +20,7 @@ trim_trailing_whitespace = false
 insert_final_newline = false
 indent_size = 2
 tab_width = 2
+
+[*.yml]
+indent_size = 2
+indent_style = spaces

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -15,13 +15,25 @@ on:
       - composer.json
       - composer.lock
       - .github/workflows/php-unit-tests.yml
+  workflow_dispatch:
+    inputs:
+      php-version:
+        description: 'PHP Version'
+        default: '8.2'
+      wp-rc-version:
+        description: 'WordPress version for Release Candidate (ex. 6.5-RC3)'
+        default: 'latest'
+      wc-rc-version:
+        description: 'WooCommerce version for Release Candidate (ex. 8.7.0-rc.1)'
+        default: 'latest'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
- GetMatrix:
+  GetMatrix:
+    if: github.event_name != 'workflow_dispatch'
     name: Get WP and WC version Matrix
     runs-on: ubuntu-latest
     outputs:
@@ -39,7 +51,8 @@ jobs:
         with:
             slug: woocommerce
 
- UnitTests:
+  UnitTests:
+    if: github.event_name != 'workflow_dispatch'
     name: PHP unit tests - PHP ${{ matrix.php }}, WP ${{ matrix.wp-version || 'latest' }}, WC ${{ matrix.wc-versions || 'latest' }}
     runs-on: ubuntu-latest
     needs: GetMatrix
@@ -95,3 +108,26 @@ jobs:
           done
 
           git config --global --unset $URL_CONFIG
+
+  ReleaseCandidateUnitTests:
+    if: github.event_name == 'workflow_dispatch'
+    name: PHP unit tests (for Release Candidates)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Prepare PHP
+        uses: woocommerce/grow/prepare-php@actions-v1
+        with:
+          php-version: "${{ inputs.php-version }}"
+
+      - name: Prepare MySQL
+        uses: woocommerce/grow/prepare-mysql@actions-v1
+
+      - name: Install WP tests
+        run: ./bin/install-unit-tests.sh wordpress_test root root localhost ${{ inputs.wp-rc-version }} ${{ inputs.wc-rc-version }}
+
+      - name: Run PHP unit tests
+        run: vendor/bin/phpunit


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR allows us to run the PHP unit tests manually for any version of PHP / WP / WC. This makes it easier to test release candidates / beta versions without needing to setup the environment locally. The intention is for this to be used during compatibility testing, once this PR is approved we can do the same for other extension we manage.

I've also edited the recommended spacing for YAML files to the editor config, to ensure we stick to consistent spacing.

### Detailed test instructions:

A manual workflow can't be triggered until this branch is merged. So testing will need to be done on a fork.

1. Create a fork of this repo
2. Merge the corresponding branch (with a PR or directly)
3. Run the manual workflow using release candidate versions of WP and WC
4. Confirm the single job `PHP unit tests (for Release Candidates)` completed successfully
![image](https://github.com/woocommerce/woocommerce-google-analytics-integration/assets/11388669/334622ec-bf69-4e51-ad3a-fe2232275284)

### Changelog entry
* Dev - Add a manual workflow run for PHP unit tests.
