### PR TITLE
Avoid running untrusted input as shell commands in the GitHub Actions

### DIFF
--- a/.github/workflows/php-hook-documentation.yml
+++ b/.github/workflows/php-hook-documentation.yml
@@ -31,6 +31,8 @@ jobs:
           source-directories: includes/,woocommerce-google-analytics-integration.php
 
       - name: Commit hook documentation
+        env:
+          HEAD_REF: ${{ github.head_ref }}
         shell: bash
         # Use the github-actions bot account to commit.
         # https://api.github.com/users/github-actions%5Bbot%5D
@@ -43,6 +45,6 @@ jobs:
             echo "*No documentation changes to commit.*" >> $GITHUB_STEP_SUMMARY
           else
             echo "*Committing documentation changes.*" >> $GITHUB_STEP_SUMMARY
-            git commit -q -m "Update hooks documentation from ${{ github.head_ref }} branch."
+            git commit -q -m "Update hooks documentation from ${HEAD_REF} branch."
             git push
           fi


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR avoids running untrusted input as shell commands in the GitHub Actions.

Ref: https://securitylab.github.com/research/github-actions-untrusted-input/

### Checks:

* [x] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Detailed test instructions:

Please refer to the PR https://github.com/woocommerce/google-listings-and-ads/pull/2394 that fixes the same issue.

### Changelog entry
