### PR TITLE
Apply discounts to the ecommerce event if available

### DIFF
--- a/assets/js/src/utils/index.js
+++ b/assets/js/src/utils/index.js
@@ -15,7 +15,7 @@ export const getProductFieldObject = ( product, quantity ) => {
 		variantData.item_variant = product.variation;
 	}
 
-	return {
+	const data = {
 		item_id: getProductId( product ),
 		item_name: product.name,
 		...getProductCategories( product ),
@@ -26,6 +26,23 @@ export const getProductFieldObject = ( product, quantity ) => {
 		),
 		...variantData,
 	};
+
+	// Apply discounts to ecommerce events.
+	// https://developers.google.com/analytics/devguides/collection/ga4/apply-discount?client_type=gtag
+	if (
+		typeof product.price_after_coupon_discount === 'number' &&
+		! isNaN( product.price_after_coupon_discount ) &&
+		product.price_after_coupon_discount !== product.prices.price
+	) {
+		data.discount =
+			product.prices.price - product.price_after_coupon_discount;
+		data.price = formatPrice(
+			product.price_after_coupon_discount,
+			product.prices.currency_minor_unit
+		);
+	}
+
+	return data;
 };
 
 /**

--- a/assets/js/src/utils/index.js
+++ b/assets/js/src/utils/index.js
@@ -32,7 +32,7 @@ export const getProductFieldObject = ( product, quantity ) => {
 	if (
 		typeof product.price_after_coupon_discount === 'number' &&
 		! isNaN( product.price_after_coupon_discount ) &&
-		product.price_after_coupon_discount !== product.prices.price
+		product.price_after_coupon_discount < product.prices.price
 	) {
 		data.discount = formatPrice(
 			product.prices.price - product.price_after_coupon_discount,

--- a/assets/js/src/utils/index.js
+++ b/assets/js/src/utils/index.js
@@ -34,8 +34,10 @@ export const getProductFieldObject = ( product, quantity ) => {
 		! isNaN( product.price_after_coupon_discount ) &&
 		product.price_after_coupon_discount !== product.prices.price
 	) {
-		data.discount =
-			product.prices.price - product.price_after_coupon_discount;
+		data.discount = formatPrice(
+			product.prices.price - product.price_after_coupon_discount,
+			product.prices.currency_minor_unit
+		);
 		data.price = formatPrice(
 			product.price_after_coupon_discount,
 			product.prices.currency_minor_unit

--- a/assets/js/src/utils/index.js
+++ b/assets/js/src/utils/index.js
@@ -29,11 +29,7 @@ export const getProductFieldObject = ( product, quantity ) => {
 
 	// Apply discounts to ecommerce events.
 	// https://developers.google.com/analytics/devguides/collection/ga4/apply-discount?client_type=gtag
-	if (
-		typeof product.price_after_coupon_discount === 'number' &&
-		! isNaN( product.price_after_coupon_discount ) &&
-		product.price_after_coupon_discount < product.prices.price
-	) {
+	if ( product?.price_after_coupon_discount < product.prices.price ) {
 		data.discount = formatPrice(
 			product.prices.price - product.price_after_coupon_discount,
 			product.prices.currency_minor_unit

--- a/includes/class-wc-abstract-google-analytics-js.php
+++ b/includes/class-wc-abstract-google-analytics-js.php
@@ -288,7 +288,10 @@ abstract class WC_Abstract_Google_Analytics_JS {
 					return array_merge(
 						$this->get_formatted_product( $item->get_product() ),
 						array(
-							'quantity' => $item->get_quantity(),
+							'quantity'                    => $item->get_quantity(),
+							// The method get_total() will return the price after coupon discounts.
+							// https://github.com/woocommerce/woocommerce/blob/54eba223b8dec015c91a13423f9eced09e96f399/plugins/woocommerce/includes/class-wc-order-item-product.php#L308-L310
+							'price_after_coupon_discount' => $this->get_formatted_price( $item->get_total() ),
 						)
 					);
 				},


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #417. This PR fixes a bug that the price in purchase events does not take coupon discounts into account by getting the price after discount using [the method `get_total()` in `WC_Order_Item_Product` class](https://github.com/woocommerce/woocommerce/blob/54eba223b8dec015c91a13423f9eced09e96f399/plugins/woocommerce/includes/class-wc-order-item-product.php#L308-L310), and [add the `discount` parameter to the ecommerce event](https://developers.google.com/analytics/devguides/collection/ga4/apply-discount?client_type=gtag).

Only the `purchase` event will include discounts if available, since only the method `get_formatted_order()` will include the "price after coupon discounts" for each order line item.

### Checks:
<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Screenshots:


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Checkout the branch of this PR and run `npm ci` and `npm run build`
2. Open Network tab from browser dev console, add `google-analytics` as the filter
3. Add some products into the cart, for example, two products.
4. Go to checkout page
5. Apply a coupon
6. Complete the purchase, see the order received page
7. From the Network tab, find the request with `dt: Order Confirmation` and `en: purchase`, which is the purchase event
8. From this event you should see there are two product parameters starts with `pr1` and `pr2`, e.g.
    - **pr1**: `id28~nmSingle~caMusic~qt1~pr12~ds12`
    - **pr2**: `id36~nmBeanie with Logo~caAccessories~qt1~pr10~ds8`
9. The `pr` in the value is the price after coupon discounts, and `ds` is the amount of coupon discounts.
10. Add another two products into the carts, complete the order WITHOUT applying any coupons.
11. You should see there is no `ds` in the event parameters, and the price is just the regular price.

### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Apply discounts to the ecommerce event if available
