### PR TITLE
Avoid running malicious inputs as shell commands in the GitHub Actions

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -50,14 +50,18 @@ jobs:
 
       - name: Install WP release candidate (optional)
         if: github.event.inputs.wp-rc-version != ''
+        env:
+          INPUT_WP_RC_VERSION: ${{ github.event.inputs.wp-rc-version }}
         run: |
-          npm run -- wp-env run tests-cli -- wp core update --version=${{ github.event.inputs.wp-rc-version }}
+          npm run -- wp-env run tests-cli -- wp core update --version="${INPUT_WP_RC_VERSION}"
           npm run -- wp-env run tests-cli -- wp core update-db
 
       - name: Install WC release candidate (optional)
         if: github.event.inputs.wc-rc-version != ''
+        env:
+          INPUT_WC_RC_VERSION: ${{ github.event.inputs.wc-rc-version }}
         run: |
-          npm run -- wp-env run tests-cli -- wp plugin update woocommerce --version=${{ github.event.inputs.wc-rc-version }}
+          npm run -- wp-env run tests-cli -- wp plugin update woocommerce --version="${INPUT_WC_RC_VERSION}"
           npm run -- wp-env run tests-cli -- wp wc update
 
       - name: Download and install Chromium browser.

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -127,7 +127,10 @@ jobs:
         uses: woocommerce/grow/prepare-mysql@actions-v1
 
       - name: Install WP tests
-        run: ./bin/install-unit-tests.sh wordpress_test root root localhost ${{ inputs.wp-rc-version }} ${{ inputs.wc-rc-version }}
+        env:
+          INPUT_WP_RC_VERSION: ${{ inputs.wp-rc-version }}
+          INPUT_WC_RC_VERSION: ${{ inputs.wc-rc-version }}
+        run: ./bin/install-unit-tests.sh wordpress_test root root localhost "${INPUT_WP_RC_VERSION}" "${INPUT_WC_RC_VERSION}"
 
       - name: Run PHP unit tests
         run: vendor/bin/phpunit


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR avoids running malicious inputs as shell commands in the GitHub Actions.

Although these input values are entered by devs who have access to this repo, which means it's almost unlikely to be vulnerable to such attacks, it would be better to fix it.

### Checks:

* [x] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Detailed test instructions:

1. Please refer to the PR https://github.com/woocommerce/google-listings-and-ads/pull/2397 that fixes the same issue.
1. Check if the "Install WP release candidate" and "Install WC release candidate" steps can work as before when entering valid versions
   - https://github.com/woocommerce/woocommerce-google-analytics-integration/actions/runs/9029889610/job/24813107364
1. Check if the "Install WP tests" step can work as before when entering valid versions
   - https://github.com/woocommerce/woocommerce-google-analytics-integration/actions/runs/9029901200/job/24813139876#step:5:2

### Changelog entry
