### PR TITLE
Fix incorrect quantity when product is already in cart

### DIFF
--- a/assets/js/src/utils/index.js
+++ b/assets/js/src/utils/index.js
@@ -178,7 +178,7 @@ const formatCategoryKey = ( index ) => {
  */
 export const getProductFromID = ( search, products, cart ) => {
 	return (
-		cart?.items?.find( ( { id } ) => id === search ) ??
-		products?.find( ( { id } ) => id === search )
+		products?.find( ( { id } ) => id === search ) ??
+		cart?.items?.find( ( { id } ) => id === search )
 	);
 };

--- a/includes/class-wc-abstract-google-analytics-js.php
+++ b/includes/class-wc-abstract-google-analytics-js.php
@@ -208,6 +208,7 @@ abstract class WC_Abstract_Google_Analytics_JS {
 	 * @param int        $variation_id Variation product ID.
 	 * @param array|bool $variation An array containing product variation attributes to include in the product data.
 	 *                              For the "variation" type products, we'll use product->get_attributes.
+	 * @param bool|int   $quantity  Quantity to include in the formatted product object
 	 *
 	 * @return array
 	 */

--- a/includes/class-wc-abstract-google-analytics-js.php
+++ b/includes/class-wc-abstract-google-analytics-js.php
@@ -80,7 +80,7 @@ abstract class WC_Abstract_Google_Analytics_JS {
 		add_action(
 			'woocommerce_add_to_cart',
 			function ( $cart_item_key, $product_id, $quantity, $variation_id, $variation ) {
-				$this->set_script_data( 'added_to_cart', $this->get_formatted_product( wc_get_product( $product_id ), $variation_id, $variation ) );
+				$this->set_script_data( 'added_to_cart', $this->get_formatted_product( wc_get_product( $product_id ), $variation_id, $variation, $quantity ) );
 			},
 			10,
 			5
@@ -211,7 +211,7 @@ abstract class WC_Abstract_Google_Analytics_JS {
 	 *
 	 * @return array
 	 */
-	public function get_formatted_product( WC_Product $product, $variation_id = 0, $variation = false ): array {
+	public function get_formatted_product( WC_Product $product, $variation_id = 0, $variation = false, $quantity = false ): array {
 		$product_id = $product->is_type( 'variation' ) ? $product->get_parent_id() : $product->get_id();
 		$price      = $product->get_price();
 
@@ -240,6 +240,10 @@ abstract class WC_Abstract_Google_Analytics_JS {
 				),
 			),
 		);
+
+		if ( $quantity ) {
+			$formatted['quantity'] = (int) $quantity;
+		}
 
 		if ( $product->is_type( 'variation' ) ) {
 			$variation = $product->get_attributes();

--- a/tests/e2e/specs/gtag-events/blocks-pages.test.js
+++ b/tests/e2e/specs/gtag-events/blocks-pages.test.js
@@ -232,7 +232,7 @@ test.describe( 'GTag events on block pages', () => {
 
 		await createProductsBlockShopPage();
 		await page.goto( `products-block-shop` );
-		
+
 		const addToCartButton = await page.locator( addToCart ).first();
 
 		await addToCartButton.click();

--- a/tests/e2e/specs/gtag-events/blocks-pages.test.js
+++ b/tests/e2e/specs/gtag-events/blocks-pages.test.js
@@ -225,6 +225,41 @@ test.describe( 'GTag events on block pages', () => {
 		} );
 	} );
 
+	test( 'Add to cart has correct quantity when product is already in cart', async ( {
+		page,
+	} ) => {
+		const addToCart = `[data-product_id="${ simpleProductID }"]`;
+
+		await createProductsBlockShopPage();
+		await page.goto( `products-block-shop` );
+		
+		const addToCartButton = await page.locator( addToCart ).first();
+
+		await addToCartButton.click();
+		await expect( addToCartButton.getByText( '1 in cart' ) ).toBeVisible();
+		await addToCartButton.click();
+		await expect( addToCartButton.getByText( '2 in cart' ) ).toBeVisible();
+
+		await page.reload();
+
+		const event = trackGtagEvent( page, 'add_to_cart' );
+
+		const addToCartButton2 = await page.locator( addToCart ).first();
+		await addToCartButton2.click();
+		await expect( addToCartButton.getByText( '3 in cart' ) ).toBeVisible();
+
+		await event.then( ( request ) => {
+			const data = getEventData( request, 'add_to_cart' );
+			expect( data.product1 ).toEqual( {
+				id: simpleProductID.toString(),
+				nm: 'Simple product',
+				ca: 'Uncategorized',
+				qt: '1',
+				pr: simpleProductPrice.toString(),
+			} );
+		} );
+	} );
+
 	test( 'View item list event is sent from the products block shop page', async ( {
 		page,
 	} ) => {

--- a/tests/e2e/specs/gtag-events/classic-pages.test.js
+++ b/tests/e2e/specs/gtag-events/classic-pages.test.js
@@ -81,7 +81,7 @@ test.describe( 'GTag events on classic pages', () => {
 
 		await page.goto( `?p=${ simpleProductID }` );
 
-		await page.locator( '.quantity input.qty' ).first().fill('3');
+		await page.locator( '.quantity input.qty' ).first().fill( '3' );
 
 		const addToCart = `.single_add_to_cart_button[value="${ simpleProductID }"]`;
 		const addToCartButton = await page.locator( addToCart ).first();

--- a/tests/e2e/specs/gtag-events/classic-pages.test.js
+++ b/tests/e2e/specs/gtag-events/classic-pages.test.js
@@ -74,6 +74,32 @@ test.describe( 'GTag events on classic pages', () => {
 		} );
 	} );
 
+	test( 'Add to cart quantity is sent on a single product page', async ( {
+		page,
+	} ) => {
+		const event = trackGtagEvent( page, 'add_to_cart' );
+
+		await page.goto( `?p=${ simpleProductID }` );
+
+		await page.locator( '.quantity input.qty' ).first().fill('3');
+
+		const addToCart = `.single_add_to_cart_button[value="${ simpleProductID }"]`;
+		const addToCartButton = await page.locator( addToCart ).first();
+
+		await addToCartButton.click();
+
+		await event.then( ( request ) => {
+			const data = getEventData( request, 'add_to_cart' );
+			expect( data.product1 ).toEqual( {
+				id: simpleProductID.toString(),
+				nm: 'Simple product',
+				ca: 'Uncategorized',
+				qt: '3',
+				pr: simpleProductPrice.toString(),
+			} );
+		} );
+	} );
+
 	test( 'Add to cart event is sent on the home page when adding product through URL', async ( {
 		page,
 	} ) => {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #391 

Adjusts the utility to retrieve a [product by its ID](https://github.com/woocommerce/woocommerce-google-analytics-integration/pull/421/commits/aac5606b817b8c1c46f7d80ed65ac59a12d0e33f) to prioritise the product data object over the cart object. This is to prevent the existing cart quantity from being sent with an `add_to_cart` event.

Additionally, the function to [format product data](https://github.com/woocommerce/woocommerce-google-analytics-integration/pull/421/commits/523932fb711428ae4bd56830ca59ba91b70ee3a4) is updated to pass along the quantity on the `added_to_cart` event.

### Detailed test instructions:

1. Checkout `fix/391-incorrect-product-quantity` and build the extension
2. Go to the shop archive
3. Add a simple product to the cart multiple times
4. Refresh the page
5. Add the same product to the cart and confirm that the event sent has the correct quantity of `1`
6. Go to the single product page
7. Set the quantity `4` and add it to cart
8. Confirm the quantity sent in the event is `4`

### Changelog entry

> Fix - Incorrect quantity value when adding product to the cart that exists in the cart