### PR TITLE
Add integration with WP Consent API

### DIFF
--- a/assets/js/src/index.js
+++ b/assets/js/src/index.js
@@ -3,7 +3,7 @@ import { classicTracking } from './integrations/classic';
 import { blocksTracking } from './integrations/blocks';
 import {
 	setCurrentConsentState,
-	addConsentStateChangeEventListener
+	addConsentStateChangeEventListener,
 } from './integrations/wp-consent-api';
 
 // Wait for 'ga4w:ready' event if `window.ga4w` is not there yet.

--- a/assets/js/src/index.js
+++ b/assets/js/src/index.js
@@ -1,7 +1,10 @@
 import { setupEventHandlers } from './tracker';
 import { classicTracking } from './integrations/classic';
 import { blocksTracking } from './integrations/blocks';
-import { setCurrentConsentState, addConsentStateChangeEventListener } from './integrations/wp-consent-api';
+import {
+	setCurrentConsentState,
+	addConsentStateChangeEventListener
+} from './integrations/wp-consent-api';
 
 // Wait for 'ga4w:ready' event if `window.ga4w` is not there yet.
 if ( window.ga4w ) {
@@ -16,11 +19,6 @@ if ( window.ga4w ) {
 		window.addEventListener( 'load', warnIfDataMissing );
 	}
 }
-
-const consentMap = {
-	statistics: [ 'analytics_storage' ],
-	marketing: [ 'ad_storage', 'ad_user_data', 'ad_personalization' ],
-};
 
 function initializeTracking() {
 	setCurrentConsentState( window.ga4w.settings );

--- a/assets/js/src/index.js
+++ b/assets/js/src/index.js
@@ -15,7 +15,37 @@ if ( window.ga4w ) {
 		window.addEventListener( 'load', warnIfDataMissing );
 	}
 }
+
+const consentMap = {
+	statistics: [
+		'analytics_storage',
+	],
+	marketing: [
+		'ad_storage',
+		'ad_user_data',
+		'ad_personalization',
+	],
+};
+
 function initializeTracking() {
+	if ( typeof wp_has_consent === 'function' ) {
+		window.wp_consent_type = 'optin';
+
+		const consentState = {};
+
+		for ( const [ category, types ] of Object.entries( consentMap ) ) {
+			if ( wp_has_consent( category ) ) {
+				types.forEach( type => {
+					consentState[ type ] = 'granted';
+				} );
+			}
+		}
+
+		if ( Object.keys( consentState ).length > 0 ) {
+			gtag( 'consent', 'update', consentState );
+		}
+	}
+
 	const getEventHandler = setupEventHandlers( window.ga4w.settings );
 
 	classicTracking( getEventHandler, window.ga4w.data );

--- a/assets/js/src/index.js
+++ b/assets/js/src/index.js
@@ -17,32 +17,26 @@ if ( window.ga4w ) {
 }
 
 const consentMap = {
-	statistics: [
-		'analytics_storage',
-	],
-	marketing: [
-		'ad_storage',
-		'ad_user_data',
-		'ad_personalization',
-	],
+	statistics: [ 'analytics_storage' ],
+	marketing: [ 'ad_storage', 'ad_user_data', 'ad_personalization' ],
 };
 
 function initializeTracking() {
-	if ( typeof wp_has_consent === 'function' ) {
+	if ( typeof wp_has_consent === 'function' ) { // eslint-disable-line camelcase
 		window.wp_consent_type = 'optin';
 
 		const consentState = {};
 
 		for ( const [ category, types ] of Object.entries( consentMap ) ) {
-			if ( wp_has_consent( category ) ) {
-				types.forEach( type => {
+			if ( wp_has_consent( category ) ) { // eslint-disable-line camelcase, no-undef
+				types.forEach( ( type ) => {
 					consentState[ type ] = 'granted';
 				} );
 			}
 		}
 
 		if ( Object.keys( consentState ).length > 0 ) {
-			gtag( 'consent', 'update', consentState );
+			gtag( 'consent', 'update', consentState ); // eslint-disable-line no-undef
 		}
 	}
 
@@ -64,16 +58,17 @@ function warnIfDataMissing() {
 document.addEventListener( 'wp_listen_for_consent_change', function ( event ) {
 	const consentUpdate = {};
 
-	const types = consentMap[ Object.keys( event.detail )[0] ];
-	const state = Object.values( event.detail )[0] === 'allow' ? 'granted' : 'deny';
+	const types = consentMap[ Object.keys( event.detail )[ 0 ] ];
+	const state =
+		Object.values( event.detail )[ 0 ] === 'allow' ? 'granted' : 'deny';
 
 	if ( types !== undefined ) {
-		types.forEach( type => {
+		types.forEach( ( type ) => {
 			consentUpdate[ type ] = state;
 		} );
 
 		if ( Object.keys( consentUpdate ).length > 0 ) {
-			gtag( 'consent', 'update', consentUpdate );
+			gtag( 'consent', 'update', consentUpdate ); // eslint-disable-line no-undef
 		}
 	}
-});
+} );

--- a/assets/js/src/index.js
+++ b/assets/js/src/index.js
@@ -22,13 +22,15 @@ const consentMap = {
 };
 
 function initializeTracking() {
-	if ( typeof wp_has_consent === 'function' ) { // eslint-disable-line camelcase
+	// eslint-disable-next-line camelcase
+	if ( typeof wp_has_consent === 'function' ) {
 		window.wp_consent_type = 'optin';
 
 		const consentState = {};
 
 		for ( const [ category, types ] of Object.entries( consentMap ) ) {
-			if ( wp_has_consent( category ) ) { // eslint-disable-line camelcase, no-undef
+			// eslint-disable-next-line camelcase, no-undef
+			if ( wp_has_consent( category ) ) {
 				types.forEach( ( type ) => {
 					consentState[ type ] = 'granted';
 				} );

--- a/assets/js/src/index.js
+++ b/assets/js/src/index.js
@@ -60,3 +60,20 @@ function warnIfDataMissing() {
 		);
 	}
 }
+
+document.addEventListener( 'wp_listen_for_consent_change', function ( event ) {
+	const consentUpdate = {};
+
+	const types = consentMap[ Object.keys( event.detail )[0] ];
+	const state = Object.values( event.detail )[0] === 'allow' ? 'granted' : 'deny';
+
+	if ( types !== undefined ) {
+		types.forEach( type => {
+			consentUpdate[ type ] = state;
+		} );
+
+		if ( Object.keys( consentUpdate ).length > 0 ) {
+			gtag( 'consent', 'update', consentUpdate );
+		}
+	}
+});

--- a/assets/js/src/integrations/wp-consent-api.js
+++ b/assets/js/src/integrations/wp-consent-api.js
@@ -15,7 +15,7 @@ export const setCurrentConsentState = ( {
 		const consentState = {};
 
 		for ( const [ category, types ] of Object.entries( consentMap ) ) {
-			// eslint-disable-next-line camelcase, no-undef
+			// eslint-disable-next-line camelcase, no-undef -- `wp_has_consent` is defined by the WP Consent API plugin.
 			if ( wp_has_consent( category ) ) {
 				types.forEach( ( type ) => {
 					consentState[ type ] = 'granted';

--- a/assets/js/src/integrations/wp-consent-api.js
+++ b/assets/js/src/integrations/wp-consent-api.js
@@ -1,0 +1,56 @@
+const consentMap = {
+	statistics: [ 'analytics_storage' ],
+	marketing: [ 'ad_storage', 'ad_user_data', 'ad_personalization' ],
+};
+
+export const setCurrentConsentState = ( {
+	tracker_function_name: trackerFunctionName,
+} ) => {
+	// eslint-disable-next-line camelcase
+	if ( typeof wp_has_consent === 'function' ) {
+		if ( window.wp_consent_type === undefined ) {
+			window.wp_consent_type = 'optin';
+		}
+
+		const consentState = {};
+
+		for ( const [ category, types ] of Object.entries( consentMap ) ) {
+			// eslint-disable-next-line camelcase, no-undef
+			if ( wp_has_consent( category ) ) {
+				types.forEach( ( type ) => {
+					consentState[ type ] = 'granted';
+				} );
+			}
+		}
+
+		if ( Object.keys( consentState ).length > 0 ) {
+			window[ trackerFunctionName ]( 'consent', 'update', consentState );
+		}
+	}
+};
+
+export const addConsentStateChangeEventListener = ( {
+	tracker_function_name: trackerFunctionName,
+} ) => {
+	document.addEventListener( 'wp_listen_for_consent_change', ( event ) => {
+		const consentUpdate = {};
+
+		const types = consentMap[ Object.keys( event.detail )[ 0 ] ];
+		const state =
+			Object.values( event.detail )[ 0 ] === 'allow' ? 'granted' : 'deny';
+
+		if ( types !== undefined ) {
+			types.forEach( ( type ) => {
+				consentUpdate[ type ] = state;
+			} );
+
+			if ( Object.keys( consentUpdate ).length > 0 ) {
+				window[ trackerFunctionName ](
+					'consent',
+					'update',
+					consentUpdate
+				);
+			}
+		}
+	} );
+};

--- a/assets/js/src/integrations/wp-consent-api.js
+++ b/assets/js/src/integrations/wp-consent-api.js
@@ -15,10 +15,19 @@ export const setCurrentConsentState = ( {
 		const consentState = {};
 
 		for ( const [ category, types ] of Object.entries( consentMap ) ) {
-			// eslint-disable-next-line camelcase, no-undef -- `wp_has_consent` is defined by the WP Consent API plugin.
-			if ( wp_has_consent( category ) ) {
+			if (
+				// eslint-disable-next-line camelcase, no-undef -- `consent_api_get_cookie` is defined by the WP Consent API plugin.
+				consent_api_get_cookie(
+					window.consent_api.cookie_prefix + '_' + category
+				) !== ''
+			) {
+				// eslint-disable-next-line camelcase, no-undef -- `wp_has_consent` is defined by the WP Consent API plugin.
+				const hasConsent = wp_has_consent( category )
+					? 'granted'
+					: 'denied';
+
 				types.forEach( ( type ) => {
-					consentState[ type ] = 'granted';
+					consentState[ type ] = hasConsent;
 				} );
 			}
 		}
@@ -37,7 +46,9 @@ export const addConsentStateChangeEventListener = ( {
 
 		const types = consentMap[ Object.keys( event.detail )[ 0 ] ];
 		const state =
-			Object.values( event.detail )[ 0 ] === 'allow' ? 'granted' : 'denied';
+			Object.values( event.detail )[ 0 ] === 'allow'
+				? 'granted'
+				: 'denied';
 
 		if ( types !== undefined ) {
 			types.forEach( ( type ) => {

--- a/assets/js/src/integrations/wp-consent-api.js
+++ b/assets/js/src/integrations/wp-consent-api.js
@@ -37,7 +37,7 @@ export const addConsentStateChangeEventListener = ( {
 
 		const types = consentMap[ Object.keys( event.detail )[ 0 ] ];
 		const state =
-			Object.values( event.detail )[ 0 ] === 'allow' ? 'granted' : 'deny';
+			Object.values( event.detail )[ 0 ] === 'allow' ? 'granted' : 'denied';
 
 		if ( types !== undefined ) {
 			types.forEach( ( type ) => {

--- a/assets/js/src/integrations/wp-consent-api.js
+++ b/assets/js/src/integrations/wp-consent-api.js
@@ -6,7 +6,7 @@ const consentMap = {
 export const setCurrentConsentState = ( {
 	tracker_function_name: trackerFunctionName,
 } ) => {
-	// eslint-disable-next-line camelcase
+	// eslint-disable-next-line camelcase -- `wp_has_consent` is defined by the WP Consent API plugin.
 	if ( typeof wp_has_consent === 'function' ) {
 		if ( window.wp_consent_type === undefined ) {
 			window.wp_consent_type = 'optin';

--- a/includes/class-wc-google-analytics.php
+++ b/includes/class-wc-google-analytics.php
@@ -58,6 +58,9 @@ class WC_Google_Analytics extends WC_Integration {
 		// utm_nooverride parameter for Google AdWords
 		add_filter( 'woocommerce_get_return_url', array( $this, 'utm_nooverride' ) );
 
+		// Mark extension as compatible with WP Consent API
+		add_filter( 'wp_consent_api_registered_' . plugin_basename( __FILE__ ), '__return_true' );
+
 		// Dequeue the WooCommerce Blocks Google Analytics integration,
 		// not to let it register its `gtag` function so that we could provide a more detailed configuration.
 		add_action(

--- a/includes/class-wc-google-gtag-js.php
+++ b/includes/class-wc-google-gtag-js.php
@@ -94,7 +94,7 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 					function %2$s(){dataLayer.push(arguments);}
 					// Set up default consent state.
 					for ( const mode of %4$s || [] ) {
-						%2$s( "consent", "default", mode );
+						%2$s( "consent", "default", { ...mode, "wait_for_update": 500 } );
 					}
 					%2$s("js", new Date());
 					%2$s("set", "developer_id.%3$s", true);

--- a/includes/class-wc-google-gtag-js.php
+++ b/includes/class-wc-google-gtag-js.php
@@ -94,7 +94,7 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 					function %2$s(){dataLayer.push(arguments);}
 					// Set up default consent state.
 					for ( const mode of %4$s || [] ) {
-						%2$s( "consent", "default", { ...mode, "wait_for_update": 500 } );
+						%2$s( "consent", "default", { "wait_for_update": 500, ...mode } );
 					}
 					%2$s("js", new Date());
 					%2$s("set", "developer_id.%3$s", true);


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #424

Adds integration with the [WP Consent API](https://wordpress.org/plugins/wp-consent-api/) plugin to better support different consent banner configurations.

If the plugin is installed on a website then the existing consent state will be sent as an update when [tracking is initialised](https://github.com/woocommerce/woocommerce-google-analytics-integration/blob/4c3a0362f33b32f755884b0c03c338f7a1f71b1a/assets/js/src/index.js#L26). For on-page updates, we're [adding an event listener](https://github.com/woocommerce/woocommerce-google-analytics-integration/blob/4c3a0362f33b32f755884b0c03c338f7a1f71b1a/assets/js/src/index.js#L60) for `wp_listen_for_consent_change` which is dispatched by WP Consent API when any changes are made.

### Detailed test instructions:

#### General test instruction

1. Build extension from `add/424-integration-with-wp-consent-api`
2. Install [Complianz](https://wordpress.org/plugins/complianz-gdpr/) and setup a basic consent banner
3. Debug the site using [Tag Assistant](https://tagassistant.google.com/) while logged out
4. Grant consent via consent banner
5. Confirm a `Consent` event is sent with the updated state
6. Trigger events on page i.e visit the shop archive, visit a single product, add a product to cart
7. Confirm the events are all recorded in Tag Assistant and that the consent `On-page Update` is `Granted` (_Under the Consent tab_)
    <img width="1680" alt="Screenshot 2024-05-20 at 17 50 37" src="https://github.com/woocommerce/woocommerce-google-analytics-integration/assets/40762232/5f1bcd1d-b283-49df-a2e5-a3c97168c531">
8. Revoke consent via the consent banner
9. Confirm that the consent state is no longer `Granted` in Tag Assistant


#### Event order testing

By default, the WP Consent API plugin JavaScript loads in the footer meaning we are unable to send the consent update event with the current state until after the page loads.

We need to support calls to `gtag` from on the page for Google Listings & Ads and other third-party extensions. To do that we're including the `wait_for_update` parameter as [recommended by Google](https://developers.google.com/tag-platform/security/guides/consent?consentmode=advanced#async) so that events sent before the consent update will still be recorded. 57ec41e

1. Trigger an event on the page
```php
add_action(
	'wp_head',
	function() {
		echo '<script>gtag( "event", "example_event" );</script>';
	}
);
```
2. Visit the site while debugging via Tag Assistant with consent `Granted`
    1. Confirm the event is sent before the consent update
    2. View the `Consent` tab and confirm that the `On-page Update` is listed as `Granted`

**Without `wait_for_update`:**

<img width="1440" alt="Screenshot 2024-05-20 at 15 23 56" src="https://github.com/woocommerce/woocommerce-google-analytics-integration/assets/40762232/ccdf253c-d53b-4e44-8244-d4b318218553">

**With `wait_for_update`:**

<img width="1475" alt="Screenshot 2024-05-20 at 15 26 37" src="https://github.com/woocommerce/woocommerce-google-analytics-integration/assets/40762232/20ec0e47-00e7-47f4-9191-b190d798d25b">

### Additional details:

- Another option was to add the existing consent state to the `ga4w` data object so that immediately after we set the consent defaults the update can be sent. While this would be preferable, caching and minification plugins would cause problems with it which is why we're relying on a purely JS implementation instead
- **Tests will be added in a follow-up PR**

### Changelog entry

> Add - Integration with the WP Consent API plugin
