### PR TITLE
Avoid tracking data when user is not opted-in

### DIFF
--- a/includes/class-wc-google-analytics.php
+++ b/includes/class-wc-google-analytics.php
@@ -220,7 +220,7 @@ class WC_Google_Analytics extends WC_Integration {
 	 */
 	public function track_settings( $data ) {
 		if ( 'no' === get_option( 'woocommerce_allow_tracking', 'no' ) ) {
-			return [];
+			return $data;
 		}
 
 		$settings                    = $this->settings;

--- a/includes/class-wc-google-analytics.php
+++ b/includes/class-wc-google-analytics.php
@@ -219,6 +219,10 @@ class WC_Google_Analytics extends WC_Integration {
 	 * @return array       Updated WC Tracker data.
 	 */
 	public function track_settings( $data ) {
+		if ( 'no' === get_option( 'woocommerce_allow_tracking', 'no' ) ) {
+			return [];
+		}
+
 		$settings                    = $this->settings;
 		$data['wc-google-analytics'] = array(
 			'support_display_advertising'   => $settings['ga_support_display_advertising'],


### PR DESCRIPTION
### Changes proposed in this Pull Request:

When the user is not opted into WooCommerce tracking we should avoid tracking the data for the extension. However, right now we are not doing that and we track the data without checking if the user is opted-in. This PR fixes that.


### Checks:
<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Screenshots:

<img width="938" alt="Screenshot 2024-05-30 at 12 24 59" src="https://github.com/woocommerce/woocommerce-google-analytics-integration/assets/5908855/3c887366-7274-4e73-83e6-d1aa25657071">

<img width="1017" alt="Screenshot 2024-05-30 at 12 23 45" src="https://github.com/woocommerce/woocommerce-google-analytics-integration/assets/5908855/53bab528-cac2-4bd3-aefb-0b8899de3cff">



### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Checkout this PR 
2. Run `wp option update woocommerce_allow_tracking "no"` in WP CLI or set `woocommerce_allow_tracking` option as "no" 
3. Run `wp wc tracker snapshot --format=yaml` in WPCLI 
4. See the `wc-google-analytics` not appearing in the tracking
5. Run `wp option update woocommerce_allow_tracking "yes"` in WP CLI or set `woocommerce_allow_tracking` option as "yes" 
6.  Run `wp wc tracker snapshot --format=yaml` in WPCLI
7. . See the `wc-google-analytics` appearing in the tracking


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Avoid tracking data when user is not opted-in
