### PR TITLE
Add E2E tests for the WP Consent API integration

### DIFF
--- a/tests/e2e/bin/test-env-setup.sh
+++ b/tests/e2e/bin/test-env-setup.sh
@@ -6,6 +6,9 @@ wp-env run tests-cli wp theme activate twentytwentytwo
 echo -e 'Install WooCommerce \n'
 wp-env run tests-cli -- wp plugin install woocommerce --activate
 
+echo -e 'Install WP Consent API \n'
+wp-env run tests-cli -- wp plugin install wp-consent-api --activate
+
 echo -e 'Update URL structure \n'
 wp-env run tests-cli -- wp rewrite structure '/%postname%/' --hard
 

--- a/tests/e2e/specs/js-scripts/wp-consent-api.test.js
+++ b/tests/e2e/specs/js-scripts/wp-consent-api.test.js
@@ -91,7 +91,8 @@ test.describe( 'WP Consent API Integration', () => {
 		await page.evaluate( () =>
 			window.wp_set_consent( 'marketing', 'allow' )
 		);
-		await page.goto( 'shop?consent_default=denied' );
+		// Go to a new page to confirm that the consent state is maintained across page loads
+		await page.goto( '/?consent_default=denied' );
 
 		const dataLayer = await page.evaluate( () => window.dataLayer );
 		const consentState = dataLayer.filter( ( i ) => i[ 0 ] === 'consent' );

--- a/tests/e2e/specs/js-scripts/wp-consent-api.test.js
+++ b/tests/e2e/specs/js-scripts/wp-consent-api.test.js
@@ -1,0 +1,156 @@
+/**
+ * External dependencies
+ */
+const { test, expect } = require( '@playwright/test' );
+
+/**
+ * Internal dependencies
+ */
+import { setSettings, clearSettings } from '../../utils/api';
+
+test.describe( 'WP Consent API Integration', () => {
+	test.beforeAll( async () => {
+		await setSettings();
+	} );
+
+	test.afterAll( async () => {
+		await clearSettings();
+	} );
+
+	test( 'window.wp_consent_type is set to `optin`', async ( { page } ) => {
+		await page.goto( 'shop' );
+
+		const consentType = await page.evaluate( () => window.wp_consent_type );
+		await expect( consentType ).toEqual( 'optin' );
+	} );
+
+	test( 'Consent update granting `analytics_storage` is sent when WP Consent API `statistics` category is `allowed`', async ( {
+		page,
+	} ) => {
+		await page.goto( 'shop?consent_default=denied' );
+		await page.evaluate( () =>
+			window.wp_set_consent( 'statistics', 'allow' )
+		);
+
+		const dataLayer = await page.evaluate( () => window.dataLayer );
+		const consentState = dataLayer.filter( ( i ) => i[ 0 ] === 'consent' );
+
+		await expect( consentState.length ).toEqual( 2 );
+
+		await expect( consentState[ 0 ] ).toEqual( {
+			0: 'consent',
+			1: 'default',
+			2: expect.objectContaining( { analytics_storage: 'denied' } ),
+		} );
+
+		await expect( consentState[ 1 ] ).toEqual( {
+			0: 'consent',
+			1: 'update',
+			2: { analytics_storage: 'granted' },
+		} );
+	} );
+
+	test( 'Consent update granting `ad_storage`, `ad_user_data`, `ad_personalization` is sent when WP Consent API `marketing` category is `allowed`', async ( {
+		page,
+	} ) => {
+		await page.goto( 'shop?consent_default=denied' );
+		await page.evaluate( () =>
+			window.wp_set_consent( 'marketing', 'allow' )
+		);
+
+		const dataLayer = await page.evaluate( () => window.dataLayer );
+		const consentState = dataLayer.filter( ( i ) => i[ 0 ] === 'consent' );
+
+		await expect( consentState.length ).toEqual( 2 );
+
+		await expect( consentState[ 0 ] ).toEqual( {
+			0: 'consent',
+			1: 'default',
+			2: expect.objectContaining( {
+				ad_storage: 'denied',
+				ad_user_data: 'denied',
+				ad_personalization: 'denied',
+			} ),
+		} );
+
+		await expect( consentState[ 1 ] ).toEqual( {
+			0: 'consent',
+			1: 'update',
+			2: {
+				ad_storage: 'granted',
+				ad_user_data: 'granted',
+				ad_personalization: 'granted',
+			},
+		} );
+	} );
+
+	test( 'Consent state is sent as update when page is loaded', async ( {
+		page,
+	} ) => {
+		await page.goto( 'shop?consent_default=denied' );
+		await page.evaluate( () =>
+			window.wp_set_consent( 'marketing', 'allow' )
+		);
+		await page.goto( 'shop?consent_default=denied' );
+
+		const dataLayer = await page.evaluate( () => window.dataLayer );
+		const consentState = dataLayer.filter( ( i ) => i[ 0 ] === 'consent' );
+
+		await expect( consentState.length ).toEqual( 2 );
+
+		await expect( consentState[ 0 ] ).toEqual( {
+			0: 'consent',
+			1: 'default',
+			2: expect.objectContaining( {
+				ad_storage: 'denied',
+				ad_user_data: 'denied',
+				ad_personalization: 'denied',
+				analytics_storage: 'denied',
+			} ),
+		} );
+
+		await expect( consentState[ 1 ] ).toEqual( {
+			0: 'consent',
+			1: 'update',
+			2: {
+				ad_storage: 'granted',
+				ad_user_data: 'granted',
+				ad_personalization: 'granted',
+			},
+		} );
+	} );
+
+	test( 'Consent state is sent as update when page is loaded if the default is set to `granted`', async ( {
+		page,
+	} ) => {
+		await page.goto( 'shop' );
+		await page.evaluate( () =>
+			window.wp_set_consent( 'statistics', 'deny' )
+		);
+		await page.goto( 'shop' );
+
+		const dataLayer = await page.evaluate( () => window.dataLayer );
+		const consentState = dataLayer.filter( ( i ) => i[ 0 ] === 'consent' );
+
+		await expect( consentState.length ).toEqual( 2 );
+
+		await expect( consentState[ 0 ] ).toEqual( {
+			0: 'consent',
+			1: 'default',
+			2: expect.objectContaining( {
+				ad_storage: 'granted',
+				ad_user_data: 'granted',
+				ad_personalization: 'granted',
+				analytics_storage: 'granted',
+			} ),
+		} );
+
+		await expect( consentState[ 1 ] ).toEqual( {
+			0: 'consent',
+			1: 'update',
+			2: {
+				analytics_storage: 'denied',
+			},
+		} );
+	} );
+} );

--- a/tests/e2e/test-snippets/test-snippets.php
+++ b/tests/e2e/test-snippets/test-snippets.php
@@ -19,10 +19,14 @@ use WC_Google_Gtag_JS;
 add_filter(
 	'woocommerce_ga_gtag_consent_modes',
 	function ( $modes ) {
-		$modes[0]['analytics_storage']  = 'granted';
-		$modes[0]['ad_storage']         = 'granted';
-		$modes[0]['ad_user_data']       = 'granted';
-		$modes[0]['ad_personalization'] = 'granted';
+		// Optional: Set the default consent state for tests via the `consent_default` URL parameter.
+		$status = isset( $_GET['consent_default'] ) ? $_GET['consent_default'] : 'granted';
+
+		$modes[0]['analytics_storage']  = $status;
+		$modes[0]['ad_storage']         = $status;
+		$modes[0]['ad_user_data']       = $status;
+		$modes[0]['ad_personalization'] = $status;
+
 		return $modes;
 	}
 );

--- a/tests/e2e/test-snippets/test-snippets.php
+++ b/tests/e2e/test-snippets/test-snippets.php
@@ -19,8 +19,11 @@ use WC_Google_Gtag_JS;
 add_filter(
 	'woocommerce_ga_gtag_consent_modes',
 	function ( $modes ) {
+		$status = 'granted';
 		// Optional: Set the default consent state for tests via the `consent_default` URL parameter.
-		$status = isset( $_GET['consent_default'] ) ? $_GET['consent_default'] : 'granted';
+		if ( isset( $_GET['consent_default'] ) ) {
+			$status = sanitize_text_field( wp_unslash( $_GET['consent_default'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		}
 
 		$modes[0]['analytics_storage']  = $status;
 		$modes[0]['ad_storage']         = $status;

--- a/tests/e2e/test-snippets/test-snippets.php
+++ b/tests/e2e/test-snippets/test-snippets.php
@@ -21,7 +21,7 @@ add_filter(
 	function ( $modes ) {
 		$status = 'granted';
 		// Optional: Set the default consent state for tests via the `consent_default` URL parameter.
-		if ( isset( $_GET['consent_default'] ) ) {
+		if ( isset( $_GET['consent_default'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			$status = sanitize_text_field( wp_unslash( $_GET['consent_default'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Follow-up to #425

Adds E2E tests for the integration with WP Consent API.

**Scenarios covered:**

1. GA4W sets the global `wp_consent_type` variable to `optin` if it's not currently set
2. Consent `granted` update is sent for `analytics_storage` when the WP Consent API category `statistics` is `allowed`
3. Consent `granted` update is sent for `ad_storage`, `ad_user_data`, and `ad_personalization` when the WP Consent API category `marketing` is `allowed`
4. The current consent state is sent when the page loads if the default state is `denied` and the current state is `granted`
5. The current consent state is sent when the page loads if the default state is `granted` and the current state is `denied`

_Note: Scenario 2 & 3 cover on page updates via the `wp_listen_for_consent_change` event listener. Scenario 4 & 5 are immediate updates when the page loads based on the current event state._

### Screenshots:

<img width="1069" alt="Screenshot 2024-05-31 at 18 24 07" src="https://github.com/woocommerce/woocommerce-google-analytics-integration/assets/40762232/5beeb524-ff21-4f1f-a512-173530a3f5d1">

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Checkout `add/wp-consent-api-integration-tests` and build extension
2. Setup [E2E environment and run tests](https://github.com/woocommerce/woocommerce-google-analytics-integration?tab=readme-ov-file#e2e-testing)
3. Confirm all tests pass