### PR TITLE
Add E2E tests for denying via WP Consent API

### DIFF
--- a/tests/e2e/specs/js-scripts/wp-consent-api.test.js
+++ b/tests/e2e/specs/js-scripts/wp-consent-api.test.js
@@ -84,6 +84,66 @@ test.describe( 'WP Consent API Integration', () => {
 		} );
 	} );
 
+	test( 'Consent update denying `analytics_storage` is sent when WP Consent API `statistics` category is `denied`', async ( {
+		page,
+	} ) => {
+		await page.goto( 'shop?consent_default=granted' );
+		await page.evaluate( () =>
+			window.wp_set_consent( 'statistics', 'deny' )
+		);
+
+		const dataLayer = await page.evaluate( () => window.dataLayer );
+		const consentState = dataLayer.filter( ( i ) => i[ 0 ] === 'consent' );
+
+		await expect( consentState.length ).toEqual( 2 );
+
+		await expect( consentState[ 0 ] ).toEqual( {
+			0: 'consent',
+			1: 'default',
+			2: expect.objectContaining( { analytics_storage: 'granted' } ),
+		} );
+
+		await expect( consentState[ 1 ] ).toEqual( {
+			0: 'consent',
+			1: 'update',
+			2: { analytics_storage: 'denied' },
+		} );
+	} );
+
+	test( 'Consent update denying `ad_storage`, `ad_user_data`, `ad_personalization` is sent when WP Consent API `marketing` category is `denied`', async ( {
+		page,
+	} ) => {
+		await page.goto( 'shop?consent_default=granted' );
+		await page.evaluate( () =>
+			window.wp_set_consent( 'marketing', 'deny' )
+		);
+
+		const dataLayer = await page.evaluate( () => window.dataLayer );
+		const consentState = dataLayer.filter( ( i ) => i[ 0 ] === 'consent' );
+
+		await expect( consentState.length ).toEqual( 2 );
+
+		await expect( consentState[ 0 ] ).toEqual( {
+			0: 'consent',
+			1: 'default',
+			2: expect.objectContaining( {
+				ad_storage: 'granted',
+				ad_user_data: 'granted',
+				ad_personalization: 'granted',
+			} ),
+		} );
+
+		await expect( consentState[ 1 ] ).toEqual( {
+			0: 'consent',
+			1: 'update',
+			2: {
+				ad_storage: 'denied',
+				ad_user_data: 'denied',
+				ad_personalization: 'denied',
+			},
+		} );
+	} );
+
 	test( 'Consent state is sent as update when page is loaded', async ( {
 		page,
 	} ) => {

--- a/tests/e2e/specs/js-scripts/wp-consent-api.test.js
+++ b/tests/e2e/specs/js-scripts/wp-consent-api.test.js
@@ -87,7 +87,7 @@ test.describe( 'WP Consent API Integration', () => {
 	test( 'Consent update denying `analytics_storage` is sent when WP Consent API `statistics` category is `denied`', async ( {
 		page,
 	} ) => {
-		await page.goto( 'shop?consent_default=granted' );
+		await page.goto( 'shop' );
 		await page.evaluate( () =>
 			window.wp_set_consent( 'statistics', 'deny' )
 		);
@@ -113,7 +113,7 @@ test.describe( 'WP Consent API Integration', () => {
 	test( 'Consent update denying `ad_storage`, `ad_user_data`, `ad_personalization` is sent when WP Consent API `marketing` category is `denied`', async ( {
 		page,
 	} ) => {
-		await page.goto( 'shop?consent_default=granted' );
+		await page.goto( 'shop' );
 		await page.evaluate( () =>
 			window.wp_set_consent( 'marketing', 'deny' )
 		);


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

This is a small add-on to https://github.com/woocommerce/woocommerce-google-analytics-integration/pull/429.
So, we test that a visitor can also deny their consent using the WP Consent API.

### Checks:
<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Screenshots:

<!--- Optional --->
![image](https://github.com/woocommerce/woocommerce-google-analytics-integration/assets/17435/ddf4e286-3368-4a39-899b-24fe9fc6e507)


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Checkout `add/wp-consent-api-integration-tests-2` and build extension
2. Setup [E2E environment and run tests](https://github.com/woocommerce/woocommerce-google-analytics-integration?tab=readme-ov-file#e2e-testing)
3. Confirm all tests pass


