### PR TITLE
Return empty array if WC_Cart is not yet instantiated

### DIFF
--- a/includes/class-wc-abstract-google-analytics-js.php
+++ b/includes/class-wc-abstract-google-analytics-js.php
@@ -179,7 +179,7 @@ abstract class WC_Abstract_Google_Analytics_JS {
 		$cart = WC()->cart;
 
 		if ( is_null( $cart ) ) {
-			return array();			
+			return array();
 		}
 
 		return array(

--- a/includes/class-wc-abstract-google-analytics-js.php
+++ b/includes/class-wc-abstract-google-analytics-js.php
@@ -176,6 +176,12 @@ abstract class WC_Abstract_Google_Analytics_JS {
 	 * @return array
 	 */
 	public function get_formatted_cart(): array {
+		$cart = WC()->cart;
+
+		if ( is_null( $cart ) ) {
+			return array();			
+		}
+
 		return array(
 			'items'   => array_map(
 				function ( $item ) {
@@ -190,12 +196,12 @@ abstract class WC_Abstract_Google_Analytics_JS {
 						)
 					);
 				},
-				array_values( WC()->cart->get_cart() )
+				array_values( $cart->get_cart() )
 			),
-			'coupons' => WC()->cart->get_coupons(),
+			'coupons' => $cart->get_coupons(),
 			'totals'  => array(
 				'currency_code'       => get_woocommerce_currency(),
-				'total_price'         => $this->get_formatted_price( WC()->cart->get_total( 'edit' ) ),
+				'total_price'         => $this->get_formatted_price( $cart->get_total( 'edit' ) ),
 				'currency_minor_unit' => wc_get_price_decimals(),
 			),
 		);


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #432

When the formatted cart data is added to the `window.ga4w` object, the main WC (core) class should have instantiated WC_Cart. As reported in #432, an error is sometimes being recorded if the cart is unavailable.

WooCommerce won't instantiate the cart if the request is not a frontend request. So this is likely caused by a cron configuration loading the frontend of the website or triggering the `wp_head` action at the very least. I've not been able to reproduce the error but this PR adds a simple check to confirm if the cart is available before accessing class methods.

### Detailed test instructions:

1. Checkout `fix/432-error-if-cart-unavailable`
2. Debug test site using https://tagassistant.google.com
3. Add products to cart
4. Visit a classic cart page
5. Remove a product from the cart
     ⚠️  Make sure the product you remove from cart isn't also displayed in the `You may be interested in…` section
6. Confirm the `remove_from_cart` event is tracked in TagAssistant with the correct product information

### Changelog entry

> Tweak - Confirm WC_Cart is available before formatting cart data