### PR TITLE
Do not replace another `added_to_cart` vanilla handler if there is one

### DIFF
--- a/assets/js/src/integrations/classic.js
+++ b/assets/js/src/integrations/classic.js
@@ -48,17 +48,15 @@ export function classicTracking(
 	 * @param {Object}        fragments - An object containing fragments of the updated cart.
 	 * @param {string}        cartHash  - A string representing the hash of the cart after the update.
 	 * @param {HTMLElement[]} button    - An array of HTML elements representing the add to cart button.
-	 * @param {Array}         rest      - An array of additional arguments passed to the event handler.
 	 */
-	document.body.onadded_to_cart = (
+	document.body.onadded_to_cart = function (
 		e,
 		fragments,
 		cartHash,
-		button,
-		...rest
-	) => {
+		button
+	) {
 		if ( typeof oldAddedToCart === 'function' ) {
-			oldAddedToCart( e, fragments, cartHash, button, ...rest );
+			oldAddedToCart.apply( this, arguments );
 		}
 		// Get product ID from data attribute (archive pages) or value (single product pages).
 		const productID = parseInt(
@@ -110,20 +108,20 @@ export function classicTracking(
 	// Attach event listeners on initial page load and when the cart div is updated
 	removeFromCartListener();
 	const oldOnupdatedWcDiv = document.body.onupdated_wc_div;
-	document.body.onupdated_wc_div = ( ...args ) => {
+	document.body.onupdated_wc_div = function () {
 		if ( typeof oldOnupdatedWcDiv === 'function' ) {
-			oldOnupdatedWcDiv( ...args );
+			oldOnupdatedWcDiv.apply( this, arguments );
 		}
 		removeFromCartListener();
 	};
 
 	// Trigger the handler when an item is removed from the mini-cart and WooCommerce dispatches the `removed_from_cart` event.
 	const oldOnRemovedFromCart = document.body.onremoved_from_cart;
-	document.body.onremoved_from_cart = ( ...args ) => {
+	document.body.onremoved_from_cart = function () {
 		if ( typeof oldOnRemovedFromCart === 'function' ) {
-			oldOnRemovedFromCart( ...args );
+			oldOnRemovedFromCart.apply( this, arguments );
 		}
-		removeFromCartHandler( { target: args[ 3 ][ 0 ] } );
+		removeFromCartHandler( { target: arguments[ 3 ][ 0 ] } );
 	};
 
 	// Handle product selection events.

--- a/assets/js/src/integrations/classic.js
+++ b/assets/js/src/integrations/classic.js
@@ -40,6 +40,7 @@ export function classicTracking(
 	} );
 
 	// Handle runtime cart events.
+	const oldAddedToCart = document.body.onadded_to_cart;
 	/**
 	 * Track the custom add to cart event dispatched by WooCommerce Core
 	 *
@@ -47,8 +48,18 @@ export function classicTracking(
 	 * @param {Object}        fragments - An object containing fragments of the updated cart.
 	 * @param {string}        cartHash  - A string representing the hash of the cart after the update.
 	 * @param {HTMLElement[]} button    - An array of HTML elements representing the add to cart button.
+	 * @param {Array}         rest      - An array of additional arguments passed to the event handler.
 	 */
-	document.body.onadded_to_cart = ( e, fragments, cartHash, button ) => {
+	document.body.onadded_to_cart = (
+		e,
+		fragments,
+		cartHash,
+		button,
+		...rest
+	) => {
+		if ( typeof oldAddedToCart === 'function' ) {
+			oldAddedToCart( e, fragments, cartHash, button, ...rest );
+		}
 		// Get product ID from data attribute (archive pages) or value (single product pages).
 		const productID = parseInt(
 			button[ 0 ].dataset.product_id || button[ 0 ].value


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Do not replace another `added_to_cart` vanilla handler if there is one.

Or jQuery event to Vanilla listener hack for `added_to_cart` may remove any previous listeners if there are any.

For other events: `onupdated_wc_div` and `onremoved_from_cart` we prevent that.

### Checks:
<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Simulate another extension listening to the event
```php
add_action(
	'wp_head',
	function () {
		wp_add_inline_script(
			'woocommerce-google-analytics-integration',
			'document.body.onadded_to_cart = () => { console.log("Other extension listens to added to cart"); };',
			'before',
		);
	},
);
```
3. Go to shop page
4. Click add to cart
5. You should see the console log, and event should be tracked in https://tagassistant.google.com/


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Tweak - Do not replace other extensions' `add_to_cart` listeners.
