### PR TITLE
Add dedicated integration with Product Bundles

### DIFF
--- a/assets/js/src/utils/index.js
+++ b/assets/js/src/utils/index.js
@@ -21,7 +21,8 @@ export const getProductFieldObject = ( product, quantity ) => {
 		...getProductCategories( product ),
 		quantity: product.quantity ?? quantity,
 		price: formatPrice(
-			product.prices.price,
+			// Use line total for bundled products, if available.
+			product.totals?.line_total || product.prices.price,
 			product.prices.currency_minor_unit
 		),
 		...variantData,

--- a/includes/class-wc-abstract-google-analytics-js.php
+++ b/includes/class-wc-abstract-google-analytics-js.php
@@ -230,6 +230,13 @@ abstract class WC_Abstract_Google_Analytics_JS {
 			}
 		}
 
+		// Integration with Product Bundles.
+		// Get the minimum price, as `get_price` may return 0 if the product is a bundle and the price is potentially a range.
+		// Even a range containing a single value.
+		if ( class_exists( '\WC_Product_Bundle' ) && $product instanceof WC_Product_Bundle && is_callable( [ $product, 'get_bundle_price' ] ) ) {
+			$price = $product->get_bundle_price( 'min' );
+		}
+
 		$formatted = array(
 			'id'         => $product_id,
 			'name'       => $product->get_title(),

--- a/includes/class-wc-abstract-google-analytics-js.php
+++ b/includes/class-wc-abstract-google-analytics-js.php
@@ -233,7 +233,7 @@ abstract class WC_Abstract_Google_Analytics_JS {
 		// Integration with Product Bundles.
 		// Get the minimum price, as `get_price` may return 0 if the product is a bundle and the price is potentially a range.
 		// Even a range containing a single value.
-		if ( class_exists( '\WC_Product_Bundle' ) && $product instanceof WC_Product_Bundle && is_callable( [ $product, 'get_bundle_price' ] ) ) {
+		if ( $product->is_type( 'bundle' ) && is_callable( [ $product, 'get_bundle_price' ] ) ) {
 			$price = $product->get_bundle_price( 'min' );
 		}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Add dedicated integration with Product Bundles,
Use `->get_bundle_price( 'min' );` instead of `->get_price()` for bundles.

Fixes https://github.com/woocommerce/woocommerce-google-analytics-integration/issues/219 the simple way.

### Checks:
<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Screenshots:

![image](https://github.com/woocommerce/woocommerce-google-analytics-integration/assets/17435/0f16bc58-89cc-4464-983a-e06eeacd174f)


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Install and activate [the Product Bundles (PB) extension](https://woocommerce.com/products/product-bundles/)
2. Add a new bundle product
   ![image](https://github.com/woocommerce/woocommerce-google-analytics-integration/assets/17435/3331d43f-4a9f-421d-8277-a13ae5128339)
3. Add bundled products that are priced individually 
   ![image](https://github.com/woocommerce/woocommerce-google-analytics-integration/assets/17435/afa6a5dd-5311-46a6-85ff-e6d9185568c9)
4. Publish the product bundle
5. Open the site through https://tagassistant.google.com/
6. Go to the product bundle page
7. Check that `view_item` event is tracked with the correct bundle price
8. Add the bundle to cart
9. Check that `add_to_cart` event is tracked with the correct bundle price
10. Uninstall the PB extension and smoke test for regression.



### Additional details:

1. I didn't add E2E tests, as PB is a paid extension, and public contributors to this repo would not be able to use it to run E2Es locally. We can try mocking PB interface, but then it's not really E2E. I'm open to better ideas :) 

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Add - WooCommerce Product Bundles integration.
