### PR TITLE
[Revert] Update docs domain name to Woo.com

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -34,7 +34,7 @@ This Code of Conduct applies both within project spaces and in public spaces whe
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at support@woo.com. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at support@woocommerce.com. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -16,7 +16,7 @@ Please see [SECURITY.md](./SECURITY.md).
 
 ## Feature Requests
 
-Feature requests can be submitted to our [feature requests page](https://woo.com/feature-requests/woocommerce-google-analytics/). Be sure to include a good description of the expected behavior and use case, and before submitting a request, please search for similar ones.
+Feature requests can be submitted to our [feature requests page](https://woocommerce.com/feature-requests/woocommerce-google-analytics/). Be sure to include a good description of the expected behavior and use case, and before submitting a request, please search for similar ones.
 
 ## Getting started
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ WordPress plugin: Provides the integration between WooCommerce and Google Analyt
 Will be required for WooCommerce shops using the integration from WooCommerce 2.1 and up.
 
 - [WordPress.org plugin page](https://wordpress.org/plugins/woocommerce-google-analytics-integration/)
-- [Woo.com product page (free)](https://woo.com/products/woocommerce-google-analytics/)
-- [User documentation](https://woo.com/document/google-analytics-integration/)
+- [WooCommerce.com product page (free)](https://woocommerce.com/products/woocommerce-google-analytics/)
+- [User documentation](https://woocommerce.com/document/google-analytics-integration/)
 
 ## NPM Scripts
 

--- a/includes/class-wc-google-analytics.php
+++ b/includes/class-wc-google-analytics.php
@@ -213,7 +213,7 @@ class WC_Google_Analytics extends WC_Integration {
 	/**
 	 * Hooks into woocommerce_tracker_data and tracks some of the analytic settings (just enabled|disabled status)
 	 * only if you have opted into WooCommerce tracking
-	 * https://woo.com/usage-tracking/
+	 * https://woocommerce.com/usage-tracking/
 	 *
 	 * @param  array $data Current WC tracker data.
 	 * @return array       Updated WC Tracker data.

--- a/readme.txt
+++ b/readme.txt
@@ -13,7 +13,7 @@ Provides integration between Google Analytics and WooCommerce.
 
 This plugin provides the integration between Google Analytics and the WooCommerce plugin. You can link a referral to a purchase and add transaction information to your Google Analytics data. It supports Global Site Tag (GA4) and eCommerce event tracking.
 
-Please visit the [documentation page for additional information](https://woo.com/document/google-analytics-integration/).
+Please visit the [documentation page for additional information](https://woocommerce.com/document/google-analytics-integration/).
 
 Contributions are welcome via the [GitHub repository](https://github.com/woocommerce/woocommerce-google-analytics-integration).
 

--- a/woocommerce-google-analytics-integration.php
+++ b/woocommerce-google-analytics-integration.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://wordpress.org/plugins/woocommerce-google-analytics-integration/
  * Description: Allows Google Analytics tracking code to be inserted into WooCommerce store pages.
  * Author: WooCommerce
- * Author URI: https://woo.com
+ * Author URI: https://woocommerce.com
  * Version: 2.1.1
  * WC requires at least: 8.4
  * WC tested up to: 9.0
@@ -111,7 +111,7 @@ if ( ! class_exists( 'WC_Google_Analytics_Integration' ) ) {
 		public function plugin_links( $links ) {
 			$settings_url = $this->get_settings_url();
 			$support_url  = 'https://wordpress.org/support/plugin/woocommerce-google-analytics-integration';
-			$docs_url     = 'https://woo.com/document/google-analytics-integration/?utm_source=wordpress&utm_medium=all-plugins-page&utm_campaign=doc-link&utm_content=woocommerce-google-analytics-integration';
+			$docs_url     = 'https://woocommerce.com/document/google-analytics-integration/?utm_source=wordpress&utm_medium=all-plugins-page&utm_campaign=doc-link&utm_content=woocommerce-google-analytics-integration';
 
 			$plugin_links = array(
 				'<a href="' . esc_url( $settings_url ) . '">' . esc_html__( 'Settings', 'woocommerce-google-analytics-integration' ) . '</a>',
@@ -206,7 +206,7 @@ if ( ! class_exists( 'WC_Google_Analytics_Integration' ) ) {
 			$notice_html = '<strong>' . esc_html__( 'Get detailed insights into your sales with Google Analytics Pro', 'woocommerce-google-analytics-integration' ) . '</strong><br><br>';
 
 			/* translators: 1: href link to GA pro */
-			$notice_html .= sprintf( __( 'Add advanced tracking for your sales funnel, coupons and more. [<a href="%s" target="_blank">Learn more</a> &gt;]', 'woocommerce-google-analytics-integration' ), 'https://woo.com/products/woocommerce-google-analytics-pro/?utm_source=woocommerce-google-analytics-integration&utm_medium=product&utm_campaign=google%20analytics%20free%20to%20pro%20extension%20upsell' );
+			$notice_html .= sprintf( __( 'Add advanced tracking for your sales funnel, coupons and more. [<a href="%s" target="_blank">Learn more</a> &gt;]', 'woocommerce-google-analytics-integration' ), 'https://woocommerce.com/products/woocommerce-google-analytics-pro/?utm_source=woocommerce-google-analytics-integration&utm_medium=product&utm_campaign=google%20analytics%20free%20to%20pro%20extension%20upsell' );
 
 			WC_Admin_Notices::add_custom_notice( 'woocommerce_google_analytics_pro_notice', $notice_html );
 			update_option( 'woocommerce_google_analytics_pro_notice_shown', true );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Project: peeuvX-1zs-p2

This PR reverts all the changes in https://github.com/woocommerce/woocommerce-google-analytics-integration/pull/325
that replaced woocommerce.com references with woo.com references.

So this PR will put back woocommerce.com as the domain.


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Confirm all changed URLs work.
2. Verify no woo.com references are left in the repo


### Additional details:


<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Tweak -  Replace woo.com references with woocommerce.com.