### PR TITLE
Update `#billing-state` locator to fix failing E2E test

### DIFF
--- a/tests/e2e/utils/customer.js
+++ b/tests/e2e/utils/customer.js
@@ -126,7 +126,7 @@ export async function checkout( page ) {
 			.fill( user.addressfirstline );
 		await page.getByLabel( 'City' ).fill( user.city );
 		await page.getByLabel( 'ZIP Code' ).fill( user.postcode );
-		await page.locator( '#billing-state input' ).fill( user.statename );
+		await page.locator( '#billing-state' ).fill( user.statename );
 	}
 
 	//TODO: See if there's an alternative method to click the button without relying on waitForTimeout.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #452

Adjusts the locator for the `#billing-state` input to fix the failing E2E test with WooCommerce `9.2.0-rc.1`

### Detailed test instructions:

1. `npm run wp-env:up`
2. `npm run -- wp-env run tests-cli -- wp plugin update woocommerce --version=9.1.0-rc.1`
3. `npm run -- wp-env run tests-cli -- wp wc update`
4. `npm run test:e2e`
4. Confirm tests pass

### Changelog entry
