### PR TITLE
Fix `#billing-state` option select in e2e tests

### DIFF
--- a/tests/e2e/utils/customer.js
+++ b/tests/e2e/utils/customer.js
@@ -126,7 +126,7 @@ export async function checkout( page ) {
 			.fill( user.addressfirstline );
 		await page.getByLabel( 'City' ).fill( user.city );
 		await page.getByLabel( 'ZIP Code' ).fill( user.postcode );
-		await page.locator( '#billing-state' ).fill( user.statename );
+		await page.locator( '#billing-state' ).selectOption( user.statename );
 	}
 
 	//TODO: See if there's an alternative method to click the button without relying on waitForTimeout.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Follow-up from #453 to fix `#billing-state` option select in e2e tests

### Detailed test instructions:

1. `npm run wp-env:up`
2. `npm run -- wp-env run tests-cli -- wp plugin update woocommerce --version=9.1.0-rc.1`
3. `npm run -- wp-env run tests-cli -- wp wc update`
4. `npm run test:e2e`
4. Confirm tests pass

### Changelog entry
