### PR TITLE
Make the value entering of the billing state field in e2e test compatible with WC < 9.2

### DIFF
--- a/tests/e2e/utils/customer.js
+++ b/tests/e2e/utils/customer.js
@@ -126,7 +126,17 @@ export async function checkout( page ) {
 			.fill( user.addressfirstline );
 		await page.getByLabel( 'City' ).fill( user.city );
 		await page.getByLabel( 'ZIP Code' ).fill( user.postcode );
-		await page.locator( '#billing-state' ).selectOption( user.statename );
+
+		const stateField = page.getByRole( 'combobox', { name: /State$/ } );
+		const stateFieldTagName = await stateField.evaluate(
+			( element ) => element.tagName
+		);
+		if ( stateFieldTagName === 'SELECT' ) {
+			stateField.selectOption( user.statename );
+		} else {
+			// compatibility-code "WC < 9.2"
+			stateField.fill( user.statename );
+		}
 	}
 
 	//TODO: See if there's an alternative method to click the button without relying on waitForTimeout.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

While performing the release in #456, the e2e test keep failing. Ref: #454

This PR make it compatible with WC < 9.2.

### Checks:

* [x] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Detailed test instructions:

1. `npm run wp-env:up`
2. `npm run -- wp-env run tests-cli -- wp plugin update woocommerce --version=9.1.4 && npm run -- wp-env run tests-cli -- wp wc update`
3. `npm run test:e2e`
4. Confirm tests pass
5. `npm run -- wp-env run tests-cli -- wp plugin update woocommerce --version=9.2.0-rc.1 && npm run -- wp-env run tests-cli -- wp wc update`
6. `npm run test:e2e`
7. Confirm tests pass

### Changelog entry
