### PR TITLE
Add npm `^9` as supported engines for dependabot

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ Google Analytics for WooCommerce utilizes npm scripts for task management utilit
 
 `npm run build` - Runs the tasks necessary for a release. These may include building JavaScript, SASS, CSS minification, and language files.
 
+The `engines` in package.json includes npm `^9` to allow dependabot to update our dependencies. However, it's not the version intended to be used in development.
+
+-   See https://github.com/dependabot/dependabot-core/issues/9277
 
 ## Unit tests
 ### Running PHP unit tests in your local dev environment

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
       },
       "engines": {
         "node": ">=20",
-        "npm": ">=10"
+        "npm": ">=10 || ^9"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   },
   "engines": {
     "node": ">=20",
-    "npm": ">=10"
+    "npm": ">=10 || ^9"
   },
   "config": {
     "wp_org_slug": "woocommerce-google-analytics-integration",


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Add npm `^9` to facilitate dependabot upgrades npm package by opening PRs since dependabot is using an npm version that doesn't pair with Node.js 20.

💡 I will be skipping code review process as this change cannot be verified in local env and it's a developer-facing only change.

### Checks:

* [x] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changelog entry
