### PR TITLE
WordPress 6.7 Compatibility: Fix the issue that E2E test can't log in to wp-admin

### DIFF
--- a/tests/e2e/global-setup.js
+++ b/tests/e2e/global-setup.js
@@ -69,7 +69,7 @@ module.exports = async ( config ) => {
 			await adminPage
 				.locator( 'input[name="pwd"]' )
 				.fill( admin.password );
-			await adminPage.locator( 'text=Log In' ).click();
+			await adminPage.getByRole( 'button', { name: 'Log In' } ).click();
 			await adminPage.waitForLoadState( LOAD_STATE.DOM_CONTENT_LOADED );
 			await adminPage.goto( `/wp-admin` );
 			await adminPage.waitForLoadState( LOAD_STATE.DOM_CONTENT_LOADED );
@@ -110,7 +110,9 @@ module.exports = async ( config ) => {
 			await customerPage
 				.locator( 'input[name="pwd"]' )
 				.fill( customer.password );
-			await customerPage.locator( 'text=Log In' ).click();
+			await customerPage
+				.getByRole( 'button', { name: 'Log In' } )
+				.click();
 
 			await customerPage.goto( `/my-account` );
 			await expect(


### PR DESCRIPTION
### Changes proposed in this Pull Request:

With WordPress 6.7-RC3, the E2E test failed to start due to match two elements when trying to click the "Log In" button.

```
Trying to log-in as admin...
Admin log-in failed, Retrying... 0/5
locator.click: Error: strict mode violation: locator('text=Log In') resolved to 2 elements:
    1) <h1 class="screen-reader-text">Log In</h1> aka getByRole('heading', { name: 'Log In' })
    2) <input type="submit" id="wp-submit" value="Log In" name="wp-submit" class="button button-primary button-large"/> aka getByRole('button', { name: 'Log In' })
```

This PR ensures that it can locate the "Log In" button.

### Checks:

* [x] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Detailed test instructions:

View the successful run: https://github.com/woocommerce/woocommerce-google-analytics-integration/actions/runs/11792649422/job/32846651874

### Changelog entry

> Dev - WordPress 6.7 Compatibility: Fix the issue that E2E test can't log in to wp-admin.
