### PR TITLE
Install SVN on PHP unit test runner

### DIFF
--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -83,6 +83,9 @@ jobs:
       - name: Set up MySQL
         uses: woocommerce/grow/prepare-mysql@actions-v2
 
+      - name: Install svn (used for installing WP versions)
+        run: sudo apt-get -y install subversion
+
       - name: Run PHP unit tests
         run: |
           WC_VERSIONS=$(echo "${{ matrix.wc-versions }}" | sed -r "s/ *, */ /g")
@@ -125,6 +128,9 @@ jobs:
 
       - name: Prepare MySQL
         uses: woocommerce/grow/prepare-mysql@actions-v2
+
+      - name: Install svn (used for installing WP versions)
+        run: sudo apt-get -y install subversion
 
       - name: Install WP tests
         env:


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Install SVN on PHP unit test runner

As the latest Ubuntu does not have it preinstalled

https://github.com/woocommerce/google-listings-and-ads/pull/2723 for the reference


### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Check the PHP unit tests are running successfully for this branch.
2. Check that [the manual workflow](https://github.com/woocommerce/woocommerce-google-analytics-integration/actions/workflows/php-unit-tests.yml) works as well 

### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Dev - Fix PHP unit tests - install svn.
