### PR TITLE
Fix E2E tests for WC 9.6

### DIFF
--- a/tests/e2e/bin/test-env-setup.sh
+++ b/tests/e2e/bin/test-env-setup.sh
@@ -25,3 +25,6 @@ wp-env run tests-cli wp option update blogname 'WooCommerce E2E Test Suite'
 
 echo -e 'Adding basic WooCommerce settings... \n'
 wp-env run tests-cli wp wc payment_gateway update cod --enabled=1 --user=admin
+
+echo -e 'Set the store as live \n'
+wp-env run tests-cli wp option update woocommerce_coming_soon 'no'


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

[Test are failing for 9.6.0 
](https://github.com/woocommerce/woocommerce-google-analytics-integration/actions/runs/12714045804/job/35443292245)

[As it happened](https://github.com/woocommerce/google-listings-and-ads/pull/2755) in Google for WooCommerce.
The reason is that Comming Soon page is blocking the store. So I did add a statement to disable the coming soon page.

### Checks:
<!-- Mark completed items with an [x] -->
* [ ] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Screenshots:




### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. See the [E2E tests passing for 9.6.0-beta.2](https://github.com/woocommerce/woocommerce-google-analytics-integration/actions/runs/12714481735)



### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Dev - Fix E2E tests for WC 9.6
