### PR TITLE
Add required PHP header

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,9 @@
         "yoast/phpunit-polyfills": "^1.1.0"
     },
     "config": {
+        "platform": {
+            "php": "7.4.33"
+        },
         "allow-plugins": {
             "dealerdirect/phpcodesniffer-composer-installer": true
         }

--- a/woocommerce-google-analytics-integration.php
+++ b/woocommerce-google-analytics-integration.php
@@ -11,6 +11,7 @@
  * Requires at least: 6.2
  * Requires Plugins: woocommerce
  * Tested up to: 6.7
+ * Requires PHP: 7.4
  * License: GPLv2 or later
  * Text Domain: woocommerce-google-analytics-integration
  * Domain Path: languages/


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds the required PHP header in the main plugin file. It also sets the PHP version for composer packages. Note that this is only for dev packages, since we don't bundle any packages in the release.

Closes #486 

> [!Note]
> Since this doesn't have any effect on the release bundle I'll go ahead and merge without a review.

### Changelog entry
* Tweak - Add required PHP header.
