### PR TITLE
Resolve plugin check errors and warnings

### DIFF
--- a/includes/class-wc-google-gtag-js.php
+++ b/includes/class-wc-google-gtag-js.php
@@ -102,8 +102,8 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 					esc_js( $this->get( 'ga_id' ) ),
 					esc_js( $this->tracker_function_name() ),
 					esc_js( static::DEVELOPER_ID ),
-					json_encode( $this->get_consent_modes() ),
-					json_encode( $this->get_site_tag_config() )
+					wp_json_encode( $this->get_consent_modes() ),
+					wp_json_encode( $this->get_site_tag_config() )
 				)
 			)
 		);

--- a/woocommerce-google-analytics-integration.php
+++ b/woocommerce-google-analytics-integration.php
@@ -12,7 +12,8 @@
  * Requires Plugins: woocommerce
  * Tested up to: 6.7
  * Requires PHP: 7.4
- * License: GPLv2 or later
+ * License: GPLv3
+ * License URI: https://www.gnu.org/licenses/gpl-3.0.html
  * Text Domain: woocommerce-google-analytics-integration
  * Domain Path: languages/
  */

--- a/woocommerce-google-analytics-integration.php
+++ b/woocommerce-google-analytics-integration.php
@@ -15,7 +15,7 @@
  * License: GPLv3
  * License URI: https://www.gnu.org/licenses/gpl-3.0.html
  * Text Domain: woocommerce-google-analytics-integration
- * Domain Path: languages/
+ * Domain Path: /languages
  */
 
 use Automattic\WooCommerce\Utilities\FeaturesUtil;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR resolves the errors and warnings which are identified in the [WordPress.org plugin check](https://wordpress.org/plugins/plugin-check/).

Changes include:
- Using `wp_json_encode` instead of `json_encode`
- Match up the license headers in readme and plugin file. Plugin handbook recommends to include them in the plugin header
- Ensure the Domain Path is set as [recommended in the plugin handbook](https://developer.wordpress.org/plugins/internationalization/how-to-internationalize-your-plugin/#domain-path)

Closes #485 

### Detailed test instructions:
1. Build a zip file from this branch `composer install && nvm use && npm run build`
2. Install the zip file on a test site
3. Install [plugin check](https://wordpress.org/plugins/plugin-check/)
4. Go to Tools > Plugin Check and run the check for the selected plugin
5. Confirm the tests now pass

> [!Note]
> We are ignoring the `trademarked_term` warnings as we've previously handled the plugin naming.

#### Testing snippet after wp_json_encode change
1. Go to WooCommerce > Settings > Integrations > Google Analytics
2. Add a tracking ID
3. View the frontend of the site in an incognito window
4. Search the page code for `window.dataLayer` and confirm that the consent mode and configuration values are output correctly, example:
```
/* Google Analytics for WooCommerce (gtag.js) */
window.dataLayer = window.dataLayer || [];
function gtag(){dataLayer.push(arguments);}
// Set up default consent state.
for ( const mode of [{"analytics_storage":"denied","ad_storage":"denied","ad_user_data":"denied","ad_personalization":"denied","region":["AT","BE","BG","HR","CY","CZ","DK","EE","FI","FR","DE","GR","HU","IS","IE","IT","LV","LI","LT","LU","MT","NL","NO","PL","PT","RO","SK","SI","ES","SE","GB","CH"]}] || [] ) {
	gtag( "consent", "default", { "wait_for_update": 500, ...mode } );
}
gtag("js", new Date());
gtag("set", "developer_id.dOGY3NW", true);
gtag("config", "G-NGBB258", {"track_404":true,"allow_google_signals":false,"logged_in":false,"custom_map":{"dimension1":"logged_in"}});
```

### Changelog entry
* Tweak - Resolve plugin check errors and warnings.