### PR TITLE
WooCommerce 9.8 compatibility: Fix the issue where a "JavaScript file position" E2E test case was unable to locate scripts

### DIFF
--- a/tests/e2e/specs/js-scripts/load-order.test.js
+++ b/tests/e2e/specs/js-scripts/load-order.test.js
@@ -50,7 +50,7 @@ test.describe( 'JavaScript file position', () => {
 
 		await expect(
 			page.locator(
-				'#woocommerce-google-analytics-integration-data-js-after + #woocommerce-google-analytics-integration-js'
+				'#woocommerce-google-analytics-integration-data-js-after ~ #woocommerce-google-analytics-integration-js'
 			)
 		).toBeAttached();
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR fixes the issue where a "JavaScript file position" E2E test case was unable to locate scripts

- Test case: Tracking is functional if main.js is loaded after the inline script data
- The cause of failure to locate is that since WooCommerce 9.8, other elements may appear between the two scripts to be located.
   ![1](https://github.com/user-attachments/assets/5ed5cc71-3889-4b05-a2e5-239e7624e51c)

### Checks:

* [x] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Detailed test instructions:

1. Check if the E2E test can pass with WooCommerce 9.8.1
   - https://github.com/woocommerce/woocommerce-google-analytics-integration/actions/runs/14371730885/job/40295945869
2. Check if the E2E test can pass with WooCommerce 9.7.1
   - https://github.com/woocommerce/woocommerce-google-analytics-integration/actions/runs/14371815072/job/40296170201

### Changelog entry
