### PR TITLE
Bump required WordPress to 6.6 and WooCommerce to 9.5

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -3,7 +3,7 @@
 	<description>Generally-applicable sniffs for WordPress plugins</description>
 
 	<!-- Set the minimum WP version -->
-	<config name="minimum_supported_wp_version" value="5.8"/>
+	<config name="minimum_supported_wp_version" value="6.6"/>
 
 	<rule ref="WordPress">
 		<!-- We don't require conforming to WP file naming -->

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Google Analytics for WooCommerce ===
 Contributors: woocommerce, automattic, claudiosanches, bor0, royho, laurendavissmith001, cshultz88, mmjones, tomalec
 Tags: woocommerce, google analytics
-Requires at least: 6.2
+Requires at least: 6.6
 Tested up to: 6.8
 Stable tag: 2.1.15
 License: GPLv3

--- a/woocommerce-google-analytics-integration.php
+++ b/woocommerce-google-analytics-integration.php
@@ -6,7 +6,7 @@
  * Author: WooCommerce
  * Author URI: https://woocommerce.com
  * Version: 2.1.15
- * WC requires at least: 8.4
+ * WC requires at least: 9.5
  * WC tested up to: 9.9
  * Requires at least: 6.6
  * Requires Plugins: woocommerce
@@ -27,7 +27,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 if ( ! class_exists( 'WC_Google_Analytics_Integration' ) ) {
 
 	define( 'WC_GOOGLE_ANALYTICS_INTEGRATION_VERSION', '2.1.15' ); // WRCS: DEFINED_VERSION.
-	define( 'WC_GOOGLE_ANALYTICS_INTEGRATION_MIN_WC_VER', '6.8' );
+	define( 'WC_GOOGLE_ANALYTICS_INTEGRATION_MIN_WC_VER', '9.5' );
 
 	// Maybe show the GA Pro notice on plugin activation.
 	register_activation_hook(

--- a/woocommerce-google-analytics-integration.php
+++ b/woocommerce-google-analytics-integration.php
@@ -8,7 +8,7 @@
  * Version: 2.1.15
  * WC requires at least: 8.4
  * WC tested up to: 9.9
- * Requires at least: 6.2
+ * Requires at least: 6.6
  * Requires Plugins: woocommerce
  * Tested up to: 6.8
  * Requires PHP: 7.4


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes STORMA-50.

_Replace this with a good description of your changes & reasoning._

### Checks:
<!-- Mark completed items with an [x] -->
* [ ] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Screenshots:

<img width="889" alt="Screenshot 2025-06-12 at 22 34 47" src="https://github.com/user-attachments/assets/b0cbf91c-a58a-411c-ba60-b7225568d946" />

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Activate Google Analytics for WooCommerce on WordPress < 6.6 or WooCommerce < 9.5 to see that it's not possible.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Update - Require WordPress 6.6+.
> Update - Require WooCommerce 9.5+.
