### PR TITLE
Bump the minimum required WordPress to 6.7 and WooCommerce to 9.9

### DIFF
--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -51,6 +51,8 @@ jobs:
         uses: woocommerce/grow/get-plugin-releases@actions-v2
         with:
             slug: woocommerce
+            releases: 2
+            includeRC: true # If an RC is upcoming, test it preferably.
 
   UnitTests:
     if: github.event_name != 'workflow_dispatch'
@@ -67,7 +69,7 @@ jobs:
         include:
           - php: 7.4
             wp-version: ${{ fromJson(needs.GetMatrix.outputs.wp-versions)[1] }} # L-1 WP Version support
-            wc-versions: ${{ fromJson(needs.GetMatrix.outputs.wc-versions)[2] }} # L-2 WC Version support
+            wc-versions: ${{ fromJson(needs.GetMatrix.outputs.wc-versions)[1] }} # L-1 WC Version support
           - php: 8.3
             wp-version: latest
             wc-versions: latest

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -45,6 +45,7 @@ jobs:
         uses: woocommerce/grow/get-plugin-releases@actions-v2
         with:
             slug: wordpress
+            releases: 2
       - name: Get Release versions from WooCommerce
         id: wc
         uses: woocommerce/grow/get-plugin-releases@actions-v2
@@ -65,7 +66,7 @@ jobs:
         wc-versions: [ '${{ join(fromJson(needs.GetMatrix.outputs.wc-versions)) }}' ]
         include:
           - php: 7.4
-            wp-version: ${{ fromJson(needs.GetMatrix.outputs.wp-versions)[2] }} # L-2 WP Version support
+            wp-version: ${{ fromJson(needs.GetMatrix.outputs.wp-versions)[1] }} # L-1 WP Version support
             wc-versions: ${{ fromJson(needs.GetMatrix.outputs.wc-versions)[2] }} # L-2 WC Version support
           - php: 8.3
             wp-version: latest

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -3,7 +3,7 @@
 	<description>Generally-applicable sniffs for WordPress plugins</description>
 
 	<!-- Set the minimum WP version -->
-	<config name="minimum_supported_wp_version" value="6.6"/>
+	<config name="minimum_supported_wp_version" value="6.7"/>
 
 	<rule ref="WordPress">
 		<!-- We don't require conforming to WP file naming -->

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Google Analytics for WooCommerce ===
 Contributors: woocommerce, automattic, claudiosanches, bor0, royho, laurendavissmith001, cshultz88, mmjones, tomalec
 Tags: woocommerce, google analytics
-Requires at least: 6.6
+Requires at least: 6.7
 Tested up to: 6.8
 Stable tag: 2.1.15
 License: GPLv3

--- a/woocommerce-google-analytics-integration.php
+++ b/woocommerce-google-analytics-integration.php
@@ -6,7 +6,7 @@
  * Author: WooCommerce
  * Author URI: https://woocommerce.com
  * Version: 2.1.15
- * WC requires at least: 9.5
+ * WC requires at least: 9.9
  * WC tested up to: 9.9
  * Requires at least: 6.7
  * Requires Plugins: woocommerce
@@ -27,7 +27,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 if ( ! class_exists( 'WC_Google_Analytics_Integration' ) ) {
 
 	define( 'WC_GOOGLE_ANALYTICS_INTEGRATION_VERSION', '2.1.15' ); // WRCS: DEFINED_VERSION.
-	define( 'WC_GOOGLE_ANALYTICS_INTEGRATION_MIN_WC_VER', '9.5' );
+	define( 'WC_GOOGLE_ANALYTICS_INTEGRATION_MIN_WC_VER', '9.9' );
 
 	// Maybe show the GA Pro notice on plugin activation.
 	register_activation_hook(

--- a/woocommerce-google-analytics-integration.php
+++ b/woocommerce-google-analytics-integration.php
@@ -8,7 +8,7 @@
  * Version: 2.1.15
  * WC requires at least: 9.5
  * WC tested up to: 9.9
- * Requires at least: 6.6
+ * Requires at least: 6.7
  * Requires Plugins: woocommerce
  * Tested up to: 6.8
  * Requires PHP: 7.4


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR bumps the minimum required WordPress to 6.7 and WooCommerce to 9.9.

### Checks:

* [x] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Screenshots:

1. Activate this plugin on WordPress < 6.7 or WooCommerce < 9.9 to see that it's not possible.
2. View the PHP Unit Tests run on GitHub Actions to see if all tests pass and if the version matrices are L-1.
   https://github.com/woocommerce/woocommerce-google-analytics-integration/actions/runs/15970159975

### Changelog entry

> Update - Require WordPress 6.7+.
