### PR TITLE
Update .github/release.yml to exclude bot accounts from GitHub release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -4,7 +4,9 @@ changelog:
       - "changelog: none"
     authors:
       - dependabot
+      - dependabot[bot]
       - github-actions
+      - github-actions[bot]
 
   categories:
     # Major level


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR update .github/release.yml to exclude bot accounts from GitHub release notes.

Originally, PRs created by the github-actions bot would not have been included, but they have been recently.

<img width="659" height="170" alt="image" src="https://github.com/user-attachments/assets/172920dd-2f01-4e79-ab55-3de934e83e01" />

### Checks:

* [x] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changelog entry
