### PR TITLE
Remove the use of `BOT_GH_TOKEN` from the PHP Unit Tests workflow in GitHub Actions

### DIFF
--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -94,9 +94,6 @@ jobs:
           WC_VERSIONS=$(echo "${{ matrix.wc-versions }}" | sed -r "s/ *, */ /g")
           WC_VERSIONS=($WC_VERSIONS)
 
-          URL_CONFIG="url.https://${{ secrets.BOT_GH_TOKEN }}:x-oauth-basic@github.com/.insteadOf git@github.com:"
-          git config --global $URL_CONFIG
-
           INIT_INSTALL=true
 
           for WC_VERSION in "${WC_VERSIONS[@]}"; do
@@ -112,8 +109,6 @@ jobs:
 
             vendor/bin/phpunit
           done
-
-          git config --global --unset $URL_CONFIG
 
   ReleaseCandidateUnitTests:
     if: github.event_name == 'workflow_dispatch'


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR removes the use of `BOT_GH_TOKEN` from the PHP Unit Tests workflow in GitHub Actions. This repository only uses a public GitHub repository that can be cloned directly.

https://linear.app/a8c/issue/STOMAIL-7512

### Checks:

* [x] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Screenshots:

Screenshot of https://github.com/woocommerce/woocommerce-google-analytics-integration/actions/runs/16876565109?pr=516

<img width="1033" height="486" alt="image" src="https://github.com/user-attachments/assets/a33ca2e3-9cdc-4982-a970-2713fbaa8477" />

### Changelog entry
