### PR TITLE
Ensure the tracking script for catching are among the first in the footer

### DIFF
--- a/includes/class-wc-google-gtag-js.php
+++ b/includes/class-wc-google-gtag-js.php
@@ -54,7 +54,6 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 		$this->register_scripts();
 		// Setup frontend scripts
 		add_action( 'wp_enqueue_scripts', array( $this, 'enquque_tracker' ), 5 );
-		add_action( 'wp_footer', array( $this, 'inline_script_data' ) );
 	}
 
 	/**
@@ -120,27 +119,10 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 			Plugin::get_instance()->get_js_asset_version( 'main' ),
 			true
 		);
-	}
 
-	/**
-	 * Enqueue tracker scripts and its inline config.
-	 * We need to execute tracker.js w/ `gtag` configuration before any trackable action may happen.
-	 *
-	 * @return void
-	 */
-	public function enquque_tracker(): void {
-		wp_enqueue_script( 'google-tag-manager' );
-		// tracker.js needs to be executed ASAP, the remaining bits for main.js could be deffered,
-		// but to reduce the traffic, we ship it all together.
-		wp_enqueue_script( $this->script_handle );
-	}
-
-	/**
-	 * Add all event data via an inline script in the footer to ensure all the data is collected in time.
-	 *
-	 * @return void
-	 */
-	public function inline_script_data(): void {
+		/**
+		 * Add all event data via an inline script in the footer to ensure all the data is collected in time.
+		 */
 		wp_register_script(
 			$this->data_script_handle,
 			'',
@@ -167,6 +149,19 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 		);
 
 		wp_enqueue_script( $this->data_script_handle );
+	}
+
+	/**
+	 * Enqueue tracker scripts and its inline config.
+	 * We need to execute tracker.js w/ `gtag` configuration before any trackable action may happen.
+	 *
+	 * @return void
+	 */
+	public function enquque_tracker(): void {
+		wp_enqueue_script( 'google-tag-manager' );
+		// tracker.js needs to be executed ASAP, the remaining bits for main.js could be deffered,
+		// but to reduce the traffic, we ship it all together.
+		wp_enqueue_script( $this->script_handle );
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR fixes the begin_checkout event not being tracked. WooCommerce checkout was firing filters before the tracking script hooked into them. 

Closes STORMA-60


### Checks:
<!-- Mark completed items with an [x] -->
* [ ] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?


### Detailed test instructions:
TODO

1. 
2. 
3. 


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Restore tracking of begin_checkout in block checkout page
