### PR TITLE
Skip instead of throwing error when product id is not found for legacy Ajax add-to-cart

### DIFF
--- a/assets/js/src/integrations/classic.js
+++ b/assets/js/src/integrations/classic.js
@@ -60,13 +60,15 @@ export function classicTracking(
 		}
 		// Get product ID from data attribute (archive pages) or value (single product pages).
 		const productID = parseInt(
-			button?.[ 0 ]?.dataset.product_id || button?.[ 0 ]?.value
+			button?.[ 0 ]?.dataset?.product_id || button?.[ 0 ]?.value
 		);
 
 		if ( Number.isNaN( productID ) ) {
-			throw new Error(
+			// eslint-disable-next-line no-console
+			console.error(
 				'Google Analytics for WooCommerce: Could not read product ID from the button given in `added_to_cart` event. Check whether WooCommerce Core events or elements are malformed by other extensions.'
 			);
+			return;
 		}
 
 		// If the current product doesn't match search by ID.
@@ -102,12 +104,14 @@ export function classicTracking(
 	 * @param {HTMLElement|Object} element - The HTML element clicked on to trigger this event
 	 */
 	function removeFromCartHandler( element ) {
-		const productID = parseInt( element.target?.dataset.product_id );
+		const productID = parseInt( element.target?.dataset?.product_id );
 
 		if ( Number.isNaN( productID ) ) {
-			throw new Error(
+			// eslint-disable-next-line no-console
+			console.error(
 				'Google Analytics for WooCommerce: Could not read product ID from the target element given to remove from cart event. Check whether WooCommerce Core events or elements are malformed by other extensions.'
 			);
+			return;
 		}
 		getEventHandler( 'remove_from_cart' )( {
 			product: getProductFromID( productID, products, cart ),

--- a/assets/js/src/integrations/classic.js
+++ b/assets/js/src/integrations/classic.js
@@ -60,7 +60,7 @@ export function classicTracking(
 		}
 		// Get product ID from data attribute (archive pages) or value (single product pages).
 		const productID = parseInt(
-			button?.[ 0 ]?.dataset?.product_id || button?.[ 0 ]?.value
+			button?.[ 0 ]?.dataset.product_id || button?.[ 0 ]?.value
 		);
 
 		if ( Number.isNaN( productID ) ) {
@@ -104,7 +104,7 @@ export function classicTracking(
 	 * @param {HTMLElement|Object} element - The HTML element clicked on to trigger this event
 	 */
 	function removeFromCartHandler( element ) {
-		const productID = parseInt( element.target?.dataset?.product_id );
+		const productID = parseInt( element.target?.dataset.product_id );
 
 		if ( Number.isNaN( productID ) ) {
 			// eslint-disable-next-line no-console


### PR DESCRIPTION


### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #451


This PR skips the rest of the checks and consoles the error message instead of throwing the error, which might interfere with other scripts or processing.

The main aim of this PR is not to change the functionality, but rather to ensure that errors thrown here do not interfere with other scripts that might depend on the same event listener. 

### Checks:
<!-- Mark completed items with an [x] -->
* [ ] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->




### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Tweak - Don't throw errors when the product ID is not found for legacy Ajax add-to-cart
