### PR TITLE
Bump the npm package `axios` from 1.11.0 to 1.12.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@wordpress/eslint-plugin": "^19.0.1",
         "@wordpress/scripts": "^30.19.0",
         "@wordpress/url": "^4.26.0",
-        "axios": "^1.11.0",
+        "axios": "^1.12.2",
         "eslint": "^8.3.0",
         "node-wp-i18n": "~1.2.8",
         "prettier": "npm:wp-prettier@^3.0.3"
@@ -7371,9 +7371,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
-      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
+      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@wordpress/eslint-plugin": "^19.0.1",
     "@wordpress/scripts": "^30.19.0",
     "@wordpress/url": "^4.26.0",
-    "axios": "^1.11.0",
+    "axios": "^1.12.2",
     "eslint": "^8.3.0",
     "node-wp-i18n": "~1.2.8",
     "prettier": "npm:wp-prettier@^3.0.3"


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR updates the npm package `axios` from 1.11.0 to 1.12.2

<img width="316" height="111" alt="image" src="https://github.com/user-attachments/assets/6cb1e9f4-5a58-447a-ab74-5d2f1007cd8e" />

<img width="670" height="51" alt="image" src="https://github.com/user-attachments/assets/58dcf676-5ddf-43a6-afa0-808ce35ce824" />

### Detailed test instructions:

- This repo doesn't use Jest.
- Checked that E2E testing can be run.

<img width="1103" height="1250" alt="image" src="https://github.com/user-attachments/assets/2bd36e53-a6d6-4a91-8834-e68364a4ab34" />

### Changelog entry
