### PR TITLE
Ensure proper JSON encoding to wp_json_encode()

### DIFF
--- a/includes/class-wc-google-gtag-js.php
+++ b/includes/class-wc-google-gtag-js.php
@@ -102,8 +102,8 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 					esc_js( $this->get( 'ga_id' ) ),
 					esc_js( $this->tracker_function_name() ),
 					esc_js( static::DEVELOPER_ID ),
-					wp_json_encode( $this->get_consent_modes() ),
-					wp_json_encode( $this->get_site_tag_config() )
+					wp_json_encode( $this->get_consent_modes(), JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ),
+					wp_json_encode( $this->get_site_tag_config(), JSON_HEX_TAG | JSON_UNESCAPED_SLASHES )
 				)
 			)
 		);
@@ -162,6 +162,7 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 						'events'                => $this->get_enabled_events(),
 						'identifier'            => $this->get( 'ga_product_identifier' ),
 					),
+					JSON_HEX_TAG | JSON_UNESCAPED_SLASHES
 				),
 			)
 		);
@@ -246,7 +247,7 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 	 * @return string
 	 */
 	public function get_script_data(): string {
-		return wp_json_encode( $this->script_data );
+		return wp_json_encode( $this->script_data, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES );
 	}
 
 	/**


### PR DESCRIPTION
  ### Changes proposed in this Pull Request:

  This PR adds the required `JSON_HEX_TAG | JSON_UNESCAPED_SLASHES` flags to all `wp_json_encode()` calls that output data into inline scripts, following WordPress security best practices.

  ### Background

  When outputting JSON data into `<script>` tags using `wp_json_encode()`, the default flags are insufficient to prevent potential XSS vulnerabilities. Sequences like `</script>` or `<!--<script>` can break out of the script context or cause unexpected
  HTML parsing behavior due to the "script data double escaped state."

  ### Changes Made

  Updated `includes/class-wc-google-gtag-js.php` to use proper flags in all `wp_json_encode()` calls:

  1. **Line 105**: Added flags to consent modes encoding
  2. **Line 106**: Added flags to site tag config encoding
  3. **Line 165**: Added flags to settings array encoding
  4. **Line 250**: Added flags to script data encoding in `get_script_data()` method

  These flags ensure:
  - `JSON_HEX_TAG`: Converts `<` and `>` to `\u003C` and `\u003E`, preventing script tag injection
  - `JSON_UNESCAPED_SLASHES`: Keeps forward slashes unescaped for better readability while maintaining security

  ### Checks:
  * [x] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
  * [ ] Have you written new tests for your changes, as applicable?
  * [ ] Have you successfully run tests with your changes locally?
  * [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

  ### Detailed test instructions:

  1. Install and activate the plugin on a test site
  2. Navigate to a product page and view the page source
  3. Locate the inline `<script>` tags containing GA4 configuration data
  4. Verify that the JSON data is properly encoded (e.g., `<` appears as `\u003C`)
  5. Test all GA4 tracking events (view_item, add_to_cart, purchase, etc.) to ensure they still work correctly
  6. Check browser console for any JavaScript errors
  7. Verify tracking data appears correctly in Google Analytics

  ### Additional details:

  This change is purely defensive and should not alter any functionality. The encoded JSON will decode to the same values in JavaScript, but will be safer against edge cases involving malicious product names or other user-generated content that might 
  contain script tags.

  ### Changelog entry

  > Fix - Add safe script tag encoding flags to all `wp_json_encode()` calls in inline scripts