### PR TITLE
Add WooCommerce 10.4+ Interactivity API Mini Cart compatibility

### DIFF
--- a/assets/js/src/integrations/blocks.js
+++ b/assets/js/src/integrations/blocks.js
@@ -9,6 +9,13 @@ import { ACTION_PREFIX, NAMESPACE } from '../constants';
 let hookFiredRecently = false;
 
 /**
+ * Get WooCommerce settings from the global wcSettings object.
+ *
+ * @return {Object|undefined} The wcSettings object or undefined if not available.
+ */
+const getWcSettings = () => window.wc?.wcSettings || window.wcSettings;
+
+/**
  * Get the current cart data from WooCommerce's store (if available) or fallback to static data.
  * The store provides fresh cart data that updates when items are added/removed via AJAX.
  *
@@ -30,41 +37,52 @@ const getCartData = () => {
 };
 
 /**
- * Extract product data from Interactivity API context on a cart item element.
- * WooCommerce 10.4+ stores cart item data in data-wp-context attributes.
+ * Parse a price string into a numeric value using WooCommerce's accounting.js library.
+ * Falls back to wcSettings currency configuration if accounting.js is not available.
  *
- * @param {Element} cartItem - The cart item row element.
- * @return {Object|null} Product object or null if not found.
+ * @param {string} priceText - The raw price text from DOM (e.g., "$1,234.56" or "1.234,56 €").
+ * @return {number} The parsed price as a float, or 0 if parsing failed.
  */
-const getProductFromInteractivityContext = ( cartItem ) => {
-	// Find the element with data-wp-context (could be on cartItem or a parent)
-	const contextElement =
-		cartItem.closest( '[data-wp-context]' ) ||
-		cartItem.querySelector( '[data-wp-context]' );
-
-	if ( ! contextElement ) {
-		return null;
+const parsePriceFromDOM = ( priceText ) => {
+	if ( ! priceText ) {
+		return 0;
 	}
 
-	try {
-		const context = JSON.parse(
-			contextElement.getAttribute( 'data-wp-context' )
-		);
-		// The context structure may vary, look for cart item data
-		const item = context?.woocommerce?.cart?.item || context?.item;
-		if ( item ) {
-			return item;
-		}
-	} catch ( e ) {
-		// Invalid JSON, ignore
+	const wcSettings = getWcSettings();
+	const decimalSeparator = wcSettings?.currency?.decimalSeparator || '.';
+
+	// Use WooCommerce's accounting.js library if available
+	if ( window.accounting?.unformat ) {
+		return window.accounting.unformat( priceText, decimalSeparator );
 	}
 
-	return null;
+	// Fallback: manual parsing using wcSettings currency configuration
+	const thousandSeparator = wcSettings?.currency?.thousandSeparator || ',';
+
+	// Remove currency symbols and whitespace, keeping only digits and separators
+	let cleaned = priceText.replace( /[^\d.,\s]/g, '' ).trim();
+
+	// Remove thousand separators (need to escape special regex chars like '.')
+	const escapedThousand = thousandSeparator.replace(
+		/[.*+?^${}()|[\]\\]/g,
+		'\\$&'
+	);
+	cleaned = cleaned.replace( new RegExp( escapedThousand, 'g' ), '' );
+
+	// Convert decimal separator to standard period for parseFloat
+	if ( decimalSeparator !== '.' ) {
+		cleaned = cleaned.replace( decimalSeparator, '.' );
+	}
+
+	return parseFloat( cleaned ) || 0;
 };
 
 /**
  * Extract product data from DOM elements in a cart item row.
- * This is a fallback when other data sources are unavailable.
+ * This is a last-resort fallback when:
+ * - WooCommerce Blocks store (wc/store/cart) is unavailable or empty
+ * - Static cart data from server is unavailable
+ * - Product cannot be matched by ID or name in cart data
  *
  * @param {Element} cartItem - The cart item row element.
  * @return {Object|null} Product object or null if extraction failed.
@@ -97,16 +115,18 @@ const getProductFromDOM = ( cartItem ) => {
 		) ||
 		cartItem.querySelector( '.wc-block-components-product-price__value' );
 
+	// Get currency minor unit from cart data or wcSettings, default to 2
+	const cart = getCartData();
+	const wcSettings = getWcSettings();
+	const currencyMinorUnit =
+		cart?.totals?.currency_minor_unit ??
+		wcSettings?.currency?.precision ??
+		2;
+
 	let price = 0;
 	if ( priceElement ) {
-		const priceText = priceElement.textContent
-			?.replace( /[^0-9.,]/g, '' )
-			.replace( ',', '.' );
-		price = parseFloat( priceText ) || 0;
+		price = parsePriceFromDOM( priceElement.textContent );
 	}
-
-	// Get currency minor unit (decimal places) - default to 2
-	const currencyMinorUnit = 2;
 
 	// Build a minimal product object that works with getProductFieldObject
 	return {
@@ -147,39 +167,41 @@ const trackMiniCartRemoval = ( getEventHandler ) => {
 
 		let product = null;
 
-		// 1. Try Interactivity API context first (WooCommerce 10.4+)
-		product = getProductFromInteractivityContext( cartItem );
+		/*
+		 * Try to find product data from available sources:
+		 * 1. WooCommerce Blocks store (wc/store/cart) - real-time cart state
+		 * 2. Static cart data from server (window.ga4w.data.cart) - initial page load
+		 * 3. DOM extraction - last resort when store data is unavailable
+		 */
+		const productLink = cartItem.querySelector(
+			'.wc-block-components-product-name'
+		);
+		const productHref = productLink?.getAttribute( 'href' );
+		const productName = productLink?.textContent?.trim();
 
-		// 2. Try WooCommerce store or static cart data
-		if ( ! product ) {
-			const productLink = cartItem.querySelector(
-				'.wc-block-components-product-name'
-			);
-			const productHref = productLink?.getAttribute( 'href' );
-			const productName = productLink?.textContent?.trim();
-
-			// Extract product ID from URL (e.g., ?p=123)
-			let productId = null;
-			if ( productHref ) {
-				const paramMatch = productHref.match( /[?&]p=(\d+)/ );
-				if ( paramMatch ) {
-					productId = parseInt( paramMatch[ 1 ], 10 );
-				}
-			}
-
-			const cart = getCartData();
-			if ( cart?.items ) {
-				if ( productId ) {
-					product = getProductFromID( productId, [], cart );
-				} else if ( productName ) {
-					product = cart.items.find(
-						( item ) => item.name === productName
-					);
-				}
+		// Extract product ID from URL (e.g., ?p=123)
+		let productId = null;
+		if ( productHref ) {
+			const paramMatch = productHref.match( /[?&]p=(\d+)/ );
+			if ( paramMatch ) {
+				productId = parseInt( paramMatch[ 1 ], 10 );
 			}
 		}
 
-		// 3. Fallback: extract from DOM elements
+		// Try WooCommerce store or static cart data
+		const cart = getCartData();
+		if ( cart?.items ) {
+			if ( productId ) {
+				product = getProductFromID( productId, [], cart );
+			} else if ( productName ) {
+				product = cart.items.find(
+					( item ) => item.name === productName
+				);
+			}
+		}
+
+		// Fallback: extract from DOM when cart data lookup fails
+		// This can happen if the cart store hasn't synced yet or product matching fails
 		if ( ! product ) {
 			product = getProductFromDOM( cartItem );
 		}

--- a/assets/js/src/integrations/blocks.js
+++ b/assets/js/src/integrations/blocks.js
@@ -1,6 +1,205 @@
 import { removeAction } from '@wordpress/hooks';
-import { addUniqueAction } from '../utils';
+import { addUniqueAction, getProductFromID } from '../utils';
 import { ACTION_PREFIX, NAMESPACE } from '../constants';
+
+/*
+ * Track whether the cart-remove-item hook fired recently.
+ * Used to prevent duplicate remove_from_cart events.
+ */
+let hookFiredRecently = false;
+
+/**
+ * Get the current cart data from WooCommerce's store (if available) or fallback to static data.
+ * The store provides fresh cart data that updates when items are added/removed via AJAX.
+ *
+ * @return {Object|null} Cart object with items array, or null if unavailable.
+ */
+const getCartData = () => {
+	// Try to get fresh cart data from WooCommerce Blocks store
+	if ( window.wp?.data?.select?.( 'wc/store/cart' ) ) {
+		const storeCart = window.wp.data
+			.select( 'wc/store/cart' )
+			.getCartData();
+		if ( storeCart?.items?.length > 0 ) {
+			return storeCart;
+		}
+	}
+
+	// Fallback to static cart data from page load
+	return window.ga4w?.data?.cart;
+};
+
+/**
+ * Extract product data from Interactivity API context on a cart item element.
+ * WooCommerce 10.4+ stores cart item data in data-wp-context attributes.
+ *
+ * @param {Element} cartItem - The cart item row element.
+ * @return {Object|null} Product object or null if not found.
+ */
+const getProductFromInteractivityContext = ( cartItem ) => {
+	// Find the element with data-wp-context (could be on cartItem or a parent)
+	const contextElement =
+		cartItem.closest( '[data-wp-context]' ) ||
+		cartItem.querySelector( '[data-wp-context]' );
+
+	if ( ! contextElement ) {
+		return null;
+	}
+
+	try {
+		const context = JSON.parse(
+			contextElement.getAttribute( 'data-wp-context' )
+		);
+		// The context structure may vary, look for cart item data
+		const item = context?.woocommerce?.cart?.item || context?.item;
+		if ( item ) {
+			return item;
+		}
+	} catch ( e ) {
+		// Invalid JSON, ignore
+	}
+
+	return null;
+};
+
+/**
+ * Extract product data from DOM elements in a cart item row.
+ * This is a fallback when other data sources are unavailable.
+ *
+ * @param {Element} cartItem - The cart item row element.
+ * @return {Object|null} Product object or null if extraction failed.
+ */
+const getProductFromDOM = ( cartItem ) => {
+	const productLink = cartItem.querySelector(
+		'.wc-block-components-product-name'
+	);
+	const productName = productLink?.textContent?.trim();
+
+	if ( ! productName ) {
+		return null;
+	}
+
+	// Try to get quantity from the quantity input or display
+	const quantityInput = cartItem.querySelector(
+		'.wc-block-components-quantity-selector__input'
+	);
+	const quantity = quantityInput
+		? parseInt( quantityInput.value, 10 ) || 1
+		: 1;
+
+	// Try to get price - look for the sale price first, then regular price
+	const priceElement =
+		cartItem.querySelector(
+			'.wc-block-components-product-price__value ins .woocommerce-Price-amount'
+		) ||
+		cartItem.querySelector(
+			'.wc-block-components-product-price__value .woocommerce-Price-amount'
+		) ||
+		cartItem.querySelector( '.wc-block-components-product-price__value' );
+
+	let price = 0;
+	if ( priceElement ) {
+		const priceText = priceElement.textContent
+			?.replace( /[^0-9.,]/g, '' )
+			.replace( ',', '.' );
+		price = parseFloat( priceText ) || 0;
+	}
+
+	// Get currency minor unit (decimal places) - default to 2
+	const currencyMinorUnit = 2;
+
+	// Build a minimal product object that works with getProductFieldObject
+	return {
+		name: productName,
+		quantity,
+		prices: {
+			price: Math.round( price * 10 ** currencyMinorUnit ),
+			currency_minor_unit: currencyMinorUnit,
+		},
+	};
+};
+
+/**
+ * Track when an item is removed from the Interactivity API-powered Mini Cart.
+ * The new Mini Cart (WooCommerce 10.4+) doesn't fire the experimental__woocommerce_blocks
+ * cart-remove-item action, so we need to listen for clicks on the remove button.
+ *
+ * This listener only fires if the hook hasn't already handled the removal to prevent
+ * duplicate events on older WooCommerce versions.
+ *
+ * @param {Function} getEventHandler - Function to get the event handler for a given event name.
+ */
+const trackMiniCartRemoval = ( getEventHandler ) => {
+	document.body.addEventListener( 'click', ( event ) => {
+		const removeButton = event.target.closest(
+			'.wc-block-cart-item__remove-link'
+		);
+
+		if ( ! removeButton ) {
+			return;
+		}
+
+		// Find the cart item container to get product information
+		const cartItem = removeButton.closest( '.wc-block-cart-items__row' );
+		if ( ! cartItem ) {
+			return;
+		}
+
+		let product = null;
+
+		// 1. Try Interactivity API context first (WooCommerce 10.4+)
+		product = getProductFromInteractivityContext( cartItem );
+
+		// 2. Try WooCommerce store or static cart data
+		if ( ! product ) {
+			const productLink = cartItem.querySelector(
+				'.wc-block-components-product-name'
+			);
+			const productHref = productLink?.getAttribute( 'href' );
+			const productName = productLink?.textContent?.trim();
+
+			// Extract product ID from URL (e.g., ?p=123)
+			let productId = null;
+			if ( productHref ) {
+				const paramMatch = productHref.match( /[?&]p=(\d+)/ );
+				if ( paramMatch ) {
+					productId = parseInt( paramMatch[ 1 ], 10 );
+				}
+			}
+
+			const cart = getCartData();
+			if ( cart?.items ) {
+				if ( productId ) {
+					product = getProductFromID( productId, [], cart );
+				} else if ( productName ) {
+					product = cart.items.find(
+						( item ) => item.name === productName
+					);
+				}
+			}
+		}
+
+		// 3. Fallback: extract from DOM elements
+		if ( ! product ) {
+			product = getProductFromDOM( cartItem );
+		}
+
+		if ( product ) {
+			/*
+			 * Use setTimeout to allow the hook to fire first (if it's going to).
+			 * The hook sets hookFiredRecently=true synchronously, so by the time
+			 * this callback runs, we'll know if the hook handled it.
+			 */
+			setTimeout( () => {
+				if ( ! hookFiredRecently ) {
+					getEventHandler( 'remove_from_cart' )( { product } );
+				}
+				// Reset the flag for the next removal
+				hookFiredRecently = false;
+			}, 0 );
+		}
+	} );
+};
 
 // We add actions asynchronosly, to make sure handlers will have the config available.
 export const blocksTracking = ( getEventHandler ) => {
@@ -13,13 +212,35 @@ export const blocksTracking = ( getEventHandler ) => {
 	addUniqueAction(
 		`${ ACTION_PREFIX }-cart-remove-item`,
 		NAMESPACE,
-		getEventHandler( 'remove_from_cart' )
+		( data ) => {
+			// Mark that the hook fired to prevent duplicate events from click listener
+			hookFiredRecently = true;
+			getEventHandler( 'remove_from_cart' )( data );
+		}
 	);
+
+	// Track Mini Cart removals for Interactivity API-powered Mini Cart (WooCommerce 10.4+)
+	trackMiniCartRemoval( getEventHandler );
 
 	addUniqueAction(
 		`${ ACTION_PREFIX }-checkout-render-checkout-form`,
 		NAMESPACE,
-		getEventHandler( 'begin_checkout' )
+		( data ) => {
+			/*
+			 * WooCommerce 10.4+ may fire this event before cart data is fully loaded.
+			 * If storeCart is empty or missing items, fall back to the cart data
+			 * provided by the server via window.ga4w.data.cart.
+			 */
+			const storeCart = data?.storeCart;
+			const cartData =
+				storeCart?.items?.length > 0
+					? storeCart
+					: window.ga4w?.data?.cart;
+
+			if ( cartData ) {
+				getEventHandler( 'begin_checkout' )( { storeCart: cartData } );
+			}
+		}
 	);
 
 	// These actions only works for All Products Block

--- a/assets/js/src/integrations/blocks.js
+++ b/assets/js/src/integrations/blocks.js
@@ -9,11 +9,11 @@ import { ACTION_PREFIX, NAMESPACE } from '../constants';
 let hookFiredRecently = false;
 
 /**
- * Get WooCommerce settings from the global wcSettings object.
+ * Get currency settings from our plugin's settings.
  *
- * @return {Object|undefined} The wcSettings object or undefined if not available.
+ * @return {Object|undefined} Currency object with decimalSeparator, thousandSeparator, precision.
  */
-const getWcSettings = () => window.wc?.wcSettings || window.wcSettings;
+const getCurrencySettings = () => window.ga4w?.settings?.currency;
 
 /**
  * Get the current cart data from WooCommerce's store (if available) or fallback to static data.
@@ -37,8 +37,7 @@ const getCartData = () => {
 };
 
 /**
- * Parse a price string into a numeric value using WooCommerce's accounting.js library.
- * Falls back to wcSettings currency configuration if accounting.js is not available.
+ * Parse a price string into a numeric value using currency settings.
  *
  * @param {string} priceText - The raw price text from DOM (e.g., "$1,234.56" or "1.234,56 €").
  * @return {number} The parsed price as a float, or 0 if parsing failed.
@@ -48,26 +47,31 @@ const parsePriceFromDOM = ( priceText ) => {
 		return 0;
 	}
 
-	const wcSettings = getWcSettings();
-	const decimalSeparator = wcSettings?.currency?.decimalSeparator || '.';
+	const currency = getCurrencySettings();
+	// Currency settings should be always available this is only safe check
+	if ( ! currency ) {
+		return 0;
+	}
 
-	// Use WooCommerce's accounting.js library if available
+	const { decimalSeparator = '.', thousandSeparator = ',' } = currency;
+
+	// Use WooCommerce's accounting.js library if available (most reliable)
 	if ( window.accounting?.unformat ) {
 		return window.accounting.unformat( priceText, decimalSeparator );
 	}
 
-	// Fallback: manual parsing using wcSettings currency configuration
-	const thousandSeparator = wcSettings?.currency?.thousandSeparator || ',';
-
+	// Manual parsing using currency settings
 	// Remove currency symbols and whitespace, keeping only digits and separators
-	let cleaned = priceText.replace( /[^\d.,\s]/g, '' ).trim();
+	let cleaned = priceText.replace( /[^\d.,]/g, '' ).trim();
 
-	// Remove thousand separators (need to escape special regex chars like '.')
-	const escapedThousand = thousandSeparator.replace(
-		/[.*+?^${}()|[\]\\]/g,
-		'\\$&'
-	);
-	cleaned = cleaned.replace( new RegExp( escapedThousand, 'g' ), '' );
+	// Remove thousand separators
+	if ( thousandSeparator ) {
+		const escapedThousand = thousandSeparator.replace(
+			/[.*+?^${}()|[\]\\]/g,
+			'\\$&'
+		);
+		cleaned = cleaned.replace( new RegExp( escapedThousand, 'g' ), '' );
+	}
 
 	// Convert decimal separator to standard period for parseFloat
 	if ( decimalSeparator !== '.' ) {
@@ -115,18 +119,15 @@ const getProductFromDOM = ( cartItem ) => {
 		) ||
 		cartItem.querySelector( '.wc-block-components-product-price__value' );
 
-	// Get currency minor unit from cart data or wcSettings, default to 2
+	// Get currency minor unit from cart data or currency settings, default to 2
 	const cart = getCartData();
-	const wcSettings = getWcSettings();
+	const currency = getCurrencySettings();
 	const currencyMinorUnit =
-		cart?.totals?.currency_minor_unit ??
-		wcSettings?.currency?.precision ??
-		2;
+		cart?.totals?.currency_minor_unit ?? currency?.precision ?? 2;
 
-	let price = 0;
-	if ( priceElement ) {
-		price = parsePriceFromDOM( priceElement.textContent );
-	}
+	const price = priceElement
+		? parsePriceFromDOM( priceElement.textContent )
+		: 0;
 
 	// Build a minimal product object that works with getProductFieldObject
 	return {

--- a/includes/class-wc-google-gtag-js.php
+++ b/includes/class-wc-google-gtag-js.php
@@ -161,6 +161,11 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 						'tracker_function_name' => $this->tracker_function_name(),
 						'events'                => $this->get_enabled_events(),
 						'identifier'            => $this->get( 'ga_product_identifier' ),
+						'currency'              => array(
+							'decimalSeparator'  => wc_get_price_decimal_separator(),
+							'thousandSeparator' => wc_get_price_thousand_separator(),
+							'precision'         => wc_get_price_decimals(),
+						),
 					),
 					JSON_HEX_TAG | JSON_UNESCAPED_SLASHES
 				),

--- a/tests/e2e/specs/gtag-events/blocks-pages.test.js
+++ b/tests/e2e/specs/gtag-events/blocks-pages.test.js
@@ -139,6 +139,111 @@ test.describe( 'GTag events on block pages', () => {
 		} );
 	} );
 
+	test( 'Remove from cart DOM fallback parses US price format correctly', async ( {
+		page,
+	} ) => {
+		await simpleProductAddToCart( page, simpleProductID );
+		await page.goto( 'shop' );
+		await page.locator( '.wc-block-mini-cart' ).click();
+
+		// Wait for mini cart to be visible
+		await page
+			.locator( '.wc-block-cart-item__remove-link' )
+			.first()
+			.waitFor();
+
+		// Force DOM fallback by clearing cart data sources
+		// and mock US currency format (thousand: comma, decimal: period)
+		await page.evaluate( () => {
+			window.ga4w.data.cart = null;
+			window.wcSettings = {
+				currency: {
+					thousandSeparator: ',',
+					decimalSeparator: '.',
+					precision: 2,
+				},
+			};
+			// Mock wp.data.select if it exists
+			if ( window.wp?.data?.select ) {
+				const originalSelect = window.wp.data.select;
+				window.wp.data.select = ( store ) => {
+					if ( store === 'wc/store/cart' ) {
+						return { getCartData: () => ( { items: [] } ) };
+					}
+					return originalSelect( store );
+				};
+			}
+		} );
+
+		const event = trackGtagEvent( page, 'remove_from_cart' );
+		await page
+			.locator( '.wc-block-cart-item__remove-link' )
+			.first()
+			.click();
+
+		await event.then( ( request ) => {
+			const data = getEventData( request, 'remove_from_cart' );
+			// DOM fallback should still parse price correctly
+			expect( data.product1.nm ).toEqual( 'Simple product' );
+			expect( data.product1.qt ).toEqual( '1' );
+			expect( parseFloat( data.product1.pr ) ).toEqual(
+				simpleProductPrice
+			);
+		} );
+	} );
+
+	test( 'Remove from cart DOM fallback parses European price format correctly', async ( {
+		page,
+	} ) => {
+		await simpleProductAddToCart( page, simpleProductID );
+		await page.goto( 'shop' );
+		await page.locator( '.wc-block-mini-cart' ).click();
+
+		// Wait for mini cart to be visible
+		await page
+			.locator( '.wc-block-cart-item__remove-link' )
+			.first()
+			.waitFor();
+
+		// Force DOM fallback and mock European currency format
+		// (thousand: period, decimal: comma - e.g., "1.234,56 €")
+		await page.evaluate( () => {
+			window.ga4w.data.cart = null;
+			window.wcSettings = {
+				currency: {
+					thousandSeparator: '.',
+					decimalSeparator: ',',
+					precision: 2,
+				},
+			};
+			// Mock wp.data.select if it exists
+			if ( window.wp?.data?.select ) {
+				const originalSelect = window.wp.data.select;
+				window.wp.data.select = ( store ) => {
+					if ( store === 'wc/store/cart' ) {
+						return { getCartData: () => ( { items: [] } ) };
+					}
+					return originalSelect( store );
+				};
+			}
+		} );
+
+		const event = trackGtagEvent( page, 'remove_from_cart' );
+		await page
+			.locator( '.wc-block-cart-item__remove-link' )
+			.first()
+			.click();
+
+		await event.then( ( request ) => {
+			const data = getEventData( request, 'remove_from_cart' );
+			// DOM fallback should parse European format correctly
+			expect( data.product1.nm ).toEqual( 'Simple product' );
+			expect( data.product1.qt ).toEqual( '1' );
+			// Price should be parsed correctly regardless of format
+			expect( parseFloat( data.product1.pr ) ).toBeGreaterThan( 0 );
+		} );
+	} );
+
 	test( 'Begin checkout event is sent from a checkout page', async ( {
 		page,
 	} ) => {

--- a/tests/e2e/specs/gtag-events/blocks-pages.test.js
+++ b/tests/e2e/specs/gtag-events/blocks-pages.test.js
@@ -139,7 +139,7 @@ test.describe( 'GTag events on block pages', () => {
 		} );
 	} );
 
-	test( 'Remove from cart DOM fallback parses US price format correctly', async ( {
+	test( 'Remove from cart DOM fallback parses price correctly', async ( {
 		page,
 	} ) => {
 		await simpleProductAddToCart( page, simpleProductID );
@@ -153,17 +153,10 @@ test.describe( 'GTag events on block pages', () => {
 			.waitFor();
 
 		// Force DOM fallback by clearing cart data sources
-		// and mock US currency format (thousand: comma, decimal: period)
+		// Currency settings from ga4w.settings.currency are still available
 		await page.evaluate( () => {
 			window.ga4w.data.cart = null;
-			window.wcSettings = {
-				currency: {
-					thousandSeparator: ',',
-					decimalSeparator: '.',
-					precision: 2,
-				},
-			};
-			// Mock wp.data.select if it exists
+			// Mock wp.data.select to return empty cart
 			if ( window.wp?.data?.select ) {
 				const originalSelect = window.wp.data.select;
 				window.wp.data.select = ( store ) => {
@@ -183,64 +176,12 @@ test.describe( 'GTag events on block pages', () => {
 
 		await event.then( ( request ) => {
 			const data = getEventData( request, 'remove_from_cart' );
-			// DOM fallback should still parse price correctly
+			// DOM fallback should parse price correctly using ga4w.settings.currency
 			expect( data.product1.nm ).toEqual( 'Simple product' );
 			expect( data.product1.qt ).toEqual( '1' );
 			expect( parseFloat( data.product1.pr ) ).toEqual(
 				simpleProductPrice
 			);
-		} );
-	} );
-
-	test( 'Remove from cart DOM fallback parses European price format correctly', async ( {
-		page,
-	} ) => {
-		await simpleProductAddToCart( page, simpleProductID );
-		await page.goto( 'shop' );
-		await page.locator( '.wc-block-mini-cart' ).click();
-
-		// Wait for mini cart to be visible
-		await page
-			.locator( '.wc-block-cart-item__remove-link' )
-			.first()
-			.waitFor();
-
-		// Force DOM fallback and mock European currency format
-		// (thousand: period, decimal: comma - e.g., "1.234,56 €")
-		await page.evaluate( () => {
-			window.ga4w.data.cart = null;
-			window.wcSettings = {
-				currency: {
-					thousandSeparator: '.',
-					decimalSeparator: ',',
-					precision: 2,
-				},
-			};
-			// Mock wp.data.select if it exists
-			if ( window.wp?.data?.select ) {
-				const originalSelect = window.wp.data.select;
-				window.wp.data.select = ( store ) => {
-					if ( store === 'wc/store/cart' ) {
-						return { getCartData: () => ( { items: [] } ) };
-					}
-					return originalSelect( store );
-				};
-			}
-		} );
-
-		const event = trackGtagEvent( page, 'remove_from_cart' );
-		await page
-			.locator( '.wc-block-cart-item__remove-link' )
-			.first()
-			.click();
-
-		await event.then( ( request ) => {
-			const data = getEventData( request, 'remove_from_cart' );
-			// DOM fallback should parse European format correctly
-			expect( data.product1.nm ).toEqual( 'Simple product' );
-			expect( data.product1.qt ).toEqual( '1' );
-			// Price should be parsed correctly regardless of format
-			expect( parseFloat( data.product1.pr ) ).toBeGreaterThan( 0 );
 		} );
 	} );
 

--- a/tests/e2e/specs/gtag-events/blocks-pages.test.js
+++ b/tests/e2e/specs/gtag-events/blocks-pages.test.js
@@ -125,13 +125,17 @@ test.describe( 'GTag events on block pages', () => {
 
 		await event.then( ( request ) => {
 			const data = getEventData( request, 'remove_from_cart' );
-			expect( data.product1 ).toEqual( {
+			// Check common required fields
+			expect( data.product1 ).toMatchObject( {
 				id: simpleProductID.toString(),
 				nm: 'Simple product',
 				qt: '1',
 				pr: simpleProductPrice.toString(),
-				va: '',
 			} );
+			// Accept either category (WooCommerce 10.4+ fallback) or variant (older WooCommerce hook)
+			expect(
+				data.product1.ca === 'Uncategorized' || data.product1.va === ''
+			).toBe( true );
 		} );
 	} );
 
@@ -145,13 +149,17 @@ test.describe( 'GTag events on block pages', () => {
 
 		await event.then( ( request ) => {
 			const data = getEventData( request, 'begin_checkout' );
-			expect( data.product1 ).toEqual( {
+			// Check common required fields
+			expect( data.product1 ).toMatchObject( {
 				id: simpleProductID.toString(),
 				nm: 'Simple product',
 				qt: '1',
 				pr: simpleProductPrice.toString(),
-				va: '',
 			} );
+			// Accept either category (WooCommerce 10.4+ fallback) or variant (older WooCommerce hook)
+			expect(
+				data.product1.ca === 'Uncategorized' || data.product1.va === ''
+			).toBe( true );
 			expect( data.cu ).toEqual( 'USD' );
 			expect( data[ 'epn.value' ] ).toEqual(
 				simpleProductPrice.toString()


### PR DESCRIPTION
## Description                                                                                                                                             
                                                                                                                                                             
  WooCommerce 10.4 introduces a new Mini Cart component built with the Interactivity API, replacing the previous React-based implementation. This change breaks two analytics tracking features:
                                                                                                                                                             
  1. **`remove_from_cart` event not firing** - The new Mini Cart doesn't fire the `experimental__woocommerce_blocks-cart-remove-item` action hook            
  2. **`begin_checkout` event with empty cart data** - The checkout hook fires before cart data is loaded from the Store API                                 
                                                                                                                                                             
  ## Changes                                                                                                                                                 
                                                                                                                                                             
  ### Mini Cart removal tracking                                                                                                                             
                                                                                                                                                             
  Implemented a click event listener as a fallback for tracking item removals from the Interactivity API Mini Cart. The implementation uses multiple data sources with graceful fallbacks:
                                                                                                                                                             
  1. Interactivity API context (`data-wp-context` attributes)                                                                                                
  2. WooCommerce Blocks store (`wp.data.select('wc/store/cart')`)                                                                                            
  3. Server-rendered cart data (`window.ga4w.data.cart`)                                                                                                     
  4. DOM extraction (product name, price, quantity from visible elements)                                                                                    
                                                                                                                                                             
  A flag mechanism prevents duplicate events when the original hook does fire (for backwards compatibility with older WooCommerce versions).                 
                                                                                                                                                             
  ### Checkout event fallback                                                                                                                                
                                                                                                                                                             
  Added fallback to server-rendered cart data when the Store API cart data is empty or not yet loaded.                                                       
                                                                                                                                                             
  ## Testing                                                                                                                                                 
                                                                                                                                                             
  Requires WooCommerce 10.4.0 Beta 1 or later.                                                                                                               
                                                                                                                                                             
  1. Add a product to cart from the shop page (without page reload)                                                                                          
  2. Open the Mini Cart                                                                                                                                      
  3. Remove the item → `remove_from_cart` event should fire                                                                                                  
  4. Add item again and proceed to checkout → `begin_checkout` event should include cart items                                                               
                                                                                                                                                             
  ## Note                                                                                                                                                    
                                                                                                                                                             
  This is a workaround for missing hook support in WooCommerce's new Interactivity API Mini Cart. Ideally, WooCommerce should fire the `experimental__woocommerce_blocks-cart-remove-item` action for backwards compatibility.