### PR TITLE
Bump minimum WordPress version to 6.8, tested up to 6.9

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -3,7 +3,7 @@
 	<description>Generally-applicable sniffs for WordPress plugins</description>
 
 	<!-- Set the minimum WP version -->
-	<config name="minimum_supported_wp_version" value="6.7"/>
+	<config name="minimum_supported_wp_version" value="6.8"/>
 
 	<rule ref="WordPress">
 		<!-- We don't require conforming to WP file naming -->

--- a/readme.txt
+++ b/readme.txt
@@ -1,8 +1,8 @@
 === Google Analytics for WooCommerce ===
 Contributors: woocommerce, automattic, claudiosanches, bor0, royho, laurendavissmith001, cshultz88, mmjones, tomalec
 Tags: woocommerce, google analytics
-Requires at least: 6.7
-Tested up to: 6.8
+Requires at least: 6.8
+Tested up to: 6.9
 Stable tag: 2.1.19
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html

--- a/woocommerce-google-analytics-integration.php
+++ b/woocommerce-google-analytics-integration.php
@@ -8,9 +8,9 @@
  * Version: 2.1.19
  * WC requires at least: 10.2
  * WC tested up to: 10.3
- * Requires at least: 6.7
+ * Requires at least: 6.8
  * Requires Plugins: woocommerce
- * Tested up to: 6.8
+ * Tested up to: 6.9
  * Requires PHP: 7.4
  * License: GPLv3
  * License URI: https://www.gnu.org/licenses/gpl-3.0.html


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR bumps the minimum and tested up to WordPress versions to 6.8 and 6.9 respectively.

### Checks:
<!-- Mark completed items with an [x] -->
* [ ] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Screenshots:

N/A

### Detailed test instructions:

N/A

### Additional details:

N/A

### Changelog entry

> Update - Require WordPress 6.8+.
> Tweak - WordPress 6.9 compatibility.
