### PR TITLE
Change the `get-plugin-releases` action to get the WooCommerce releases from GitHub

### DIFF
--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -37,22 +37,23 @@ jobs:
     name: Get WP and WC version Matrix
     runs-on: ubuntu-latest
     outputs:
-        wp-versions: ${{ steps.wp.outputs.versions }}
-        wc-versions: ${{ steps.wc.outputs.versions }}
+      wp-versions: ${{ steps.wp.outputs.versions }}
+      wc-versions: ${{ steps.wc.outputs.versions }}
     steps:
       - name: Get Release versions from Wordpress
         id: wp
         uses: woocommerce/grow/get-plugin-releases@actions-v2
         with:
-            slug: wordpress
-            releases: 2
+          slug: wordpress
+          releases: 2
       - name: Get Release versions from WooCommerce
         id: wc
         uses: woocommerce/grow/get-plugin-releases@actions-v2
         with:
-            slug: woocommerce
-            releases: 2
-            includeRC: true # If an RC is upcoming, test it preferably.
+          source: github
+          slug: woocommerce/woocommerce
+          releases: 2
+          includeRC: true # If an RC is upcoming, test it preferably.
 
   UnitTests:
     if: github.event_name != 'workflow_dispatch'


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Due to occasional inconsistencies between WooCommerce releases on WPORG and GitHub, the PHP Unit Tests workflow on GitHub Actions that gets WooCommerce versions and subsequently clones them from GitHub may be problematic under these circumstances. This PR changes the workflow to get versions from GitHub to avoid issues.

### Detailed test instructions:

Confirmed that the PHP Unit Tests workflow has been successfully run and passed.

https://github.com/woocommerce/woocommerce-google-analytics-integration/actions/runs/20655741530?pr=535

<img width="937" height="452" alt="image" src="https://github.com/user-attachments/assets/6c483dcf-cd42-487e-95f3-177a8152f665" />

### Changelog entry
