### PR TITLE
Update the `caniuse-lite` package to the latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8173,9 +8173,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001727",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001727.tgz",
-      "integrity": "sha512-pB68nIHmbN6L/4C6MH1DokyR3bYqFwjaSs/sWDHGj4CTcFtQUQMuJftVwWkXq7mNWOybD3KhUv3oWHoGxgP14Q==",
+      "version": "1.0.30001762",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001762.tgz",
+      "integrity": "sha512-PxZwGNvH7Ak8WX5iXzoK1KPZttBXNPuaOvI2ZYU7NrlM+d9Ov+TUvlLOBNGzVXAntMSMMlJPd+jY6ovrVjSmUw==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "overrides": {
     "@babel/runtime": "^7.27.6",
     "webpack-dev-server": "^5.2.2",
-		"node-forge": "^1.3.3"
+    "node-forge": "^1.3.3"
   },
   "assets": {
     "js": {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The following warning shows when running `npm start`. This PR updates the `caniuse-lite` package to the latest version to avoid the warnings.

```
Browserslist: browsers data (caniuse-lite) is 7 months old. Please run:
  npx update-browserslist-db@latest
  Why you should do it regularly: https://github.com/browserslist/update-db#readme
```

### Detailed test instructions:

1. `npm install`
2. `npm start` to check if the warning doesn't appear anymore.

### Changelog entry
