### PR TITLE
Fix CI workflows to auto-resolve when PR changes don't match path filters

### DIFF
--- a/.github/workflows/php-coding-standards.yml
+++ b/.github/workflows/php-coding-standards.yml
@@ -8,18 +8,32 @@ on:
       - "**.php"
       - .github/workflows/php-coding-standards.yml
   pull_request:
-    paths:
-      - "**.php"
-      - .github/workflows/php-coding-standards.yml
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  check-paths:
+    name: Check changed files
+    runs-on: ubuntu-latest
+    outputs:
+      should-run: ${{ steps.changes.outputs.php }}
+    steps:
+      - name: Check for relevant changes
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: changes
+        with:
+          filters: |
+            php:
+              - '**.php'
+              - '.github/workflows/php-coding-standards.yml'
+
   phpcs:
     name: PHP coding standards
     runs-on: ubuntu-latest
+    needs: check-paths
+    if: needs.check-paths.outputs.should-run == 'true'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -8,12 +8,16 @@ on:
       - "**.php"
       - composer.json
       - composer.lock
+      - package.json
+      - package-lock.json
       - .github/workflows/php-unit-tests.yml
   pull_request:
     paths:
       - "**.php"
       - composer.json
       - composer.lock
+      - package.json
+      - package-lock.json
       - .github/workflows/php-unit-tests.yml
   workflow_dispatch:
     inputs:


### PR DESCRIPTION


### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes # .

When a PR is created that does not touch the file paths listed in the `php-coding-standards.yml` workflow (e.g., a PR that only changes `package-lock.json`), the GitHub Action remains in a perpetual "pending" state. This blocks the merge because the required status check never reports a result — GitHub simply never triggers the workflow, so it never passes or fails.

This PR fixes that by restructuring the `php-coding-standards.yml` workflow to always trigger on `pull_request` events and use `dorny/paths-filter` to detect relevant file changes internally. When no relevant files are changed, the PHPCS job is **skipped**, which GitHub treats as a passing status for required checks.

**Changes:**

- **`php-coding-standards.yml`**: Removed `paths` filter from the `pull_request` trigger. Added a new `check-paths` job using `dorny/paths-filter@v3` to detect whether `.php` files or the workflow file itself changed. The `phpcs` job now depends on `check-paths` and only runs when relevant files are modified. When skipped, it reports a successful status to unblock the merge.
- **`php-unit-tests.yml`**: Added `package.json` and `package-lock.json` to the `paths` filter for both `push` and `pull_request` triggers to ensure unit tests run when JavaScript dependencies change (as these can affect the build/test environment).

_Replace this with a good description of your changes & reasoning._

### Checks:
<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. 
2. 
3. 


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
