### PR TITLE
Add npm scripts to run PHPUnit tests via wp-env

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,10 +48,12 @@ npm run lint:php      # PHPCS (WordPress Coding Standards)
 ### Test
 
 ```sh
-vendor/bin/phpunit                # Run PHP unit tests (see README.md for setup requirements)
 npm run wp-env:up                 # Start local WordPress Docker environment
+npm run test:php:setup            # Install WooCommerce + deps for PHPUnit (once after wp-env:up)
+npm run test:php                  # Run PHP unit tests via wp-env
 npm run test:e2e                  # Run Playwright E2E tests (headless, requires wp-env)
 npm run test:e2e-dev              # Run E2E tests in debug mode with browser visible
+vendor/bin/phpunit                # Run PHP unit tests locally (see README.md for setup)
 ```
 
 ### Local Environment (wp-env)

--- a/README.md
+++ b/README.md
@@ -24,12 +24,27 @@ The `engines` in package.json includes npm `^9` to allow dependabot to update ou
 -   See https://github.com/dependabot/dependabot-core/issues/9277
 
 ## Unit tests
-### Running PHP unit tests in your local dev environment
+
+### Running PHP unit tests via wp-env (recommended)
+
+This uses the same Docker environment as E2E tests — no local MySQL, svn, or manual setup required.
+
+1. Make sure Docker is running
+2. `npm run wp-env:up` to start the environment
+3. `npm run test:php:setup` to install WooCommerce from source and dependencies (only needed once after starting the environment)
+4. `npm run test:php` to run all PHPUnit tests
+
+To test against a specific WooCommerce version:
+
+`npm run test:php:setup -- --wc-version=9.6.0`
+
+### Running PHP unit tests locally (without Docker)
+
 1. Install prerequisites: composer, git, xdebug, svn, wget or curl, mysqladmin
 2. `cd` into the `woocommerce-google-analytics-integration/` plugin directory
 3. Run `composer install`
 4. Run `bin/install-unit-tests.sh <db-name> <db-user> <db-pass> [db-host] [wp-version] [wc-version] [skip-database-creation]` e.g. `bin/install-unit-tests.sh wordpress_test root root localhost latest latest`
-5. Run `XDEBUG_MODE=coverage vendor/bin/phpunit --coverage-text` to run all unit test
+5. Run `XDEBUG_MODE=coverage vendor/bin/phpunit --coverage-text` to run all unit tests
 
 _For more info see: [WordPress.org > Plugin Unit Tests](https://make.wordpress.org/cli/handbook/misc/plugin-unit-tests/#running-tests-locally)._
 

--- a/package.json
+++ b/package.json
@@ -46,6 +46,8 @@
     "prebuild": "rm -rf ./vendor",
     "test:e2e": "npx playwright test --config=tests/e2e/config/playwright.config.js",
     "test:e2e-dev": "npx playwright test --config=tests/e2e/config/playwright.config.js --debug",
+    "test:php:setup": "./tests/bin/setup-phpunit-env.sh",
+    "test:php": "wp-env run tests-cli --env-cwd=wp-content/plugins/woocommerce-google-analytics-integration vendor/bin/phpunit",
     "wp-env": "wp-env",
     "wp-env:up": "npm run -- wp-env start --update",
     "wp-env:down": "npm run wp-env stop"

--- a/tests/bin/setup-phpunit-env.sh
+++ b/tests/bin/setup-phpunit-env.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+#
+# Setup wp-env for running PHPUnit tests.
+# Ensures WooCommerce is installed and downloads the WooCommerce test framework
+# files (not included in the wordpress.org zip) that PHPUnit bootstrap requires.
+#
+# Usage: npm run test:php:setup [-- --wc-version=X.Y.Z]
+#
+# This script only needs to be run once after `npm run wp-env:up`.
+
+set -e
+
+WC_VERSION=""
+
+# Parse arguments
+for arg in "$@"; do
+	case $arg in
+		--wc-version=*)
+			WC_VERSION="${arg#*=}"
+			;;
+	esac
+done
+
+# Install WooCommerce if not already present, or if a specific version was requested
+if [ -n "$WC_VERSION" ]; then
+	echo "==> Installing WooCommerce ${WC_VERSION}..."
+	wp-env run tests-cli -- wp plugin install woocommerce --version="${WC_VERSION}" --activate --force
+else
+	# Check if WooCommerce is already installed
+	INSTALLED=$(wp-env run tests-cli wp plugin list --field=name 2>/dev/null | grep '^woocommerce$' || true)
+	if [ -z "$INSTALLED" ]; then
+		echo "==> Installing WooCommerce (latest)..."
+		wp-env run tests-cli -- wp plugin install woocommerce --activate
+	fi
+
+	WC_VERSION=$(wp-env run tests-cli wp plugin get woocommerce --field=version 2>/dev/null | tail -1)
+fi
+
+if [ -z "$WC_VERSION" ]; then
+	echo "Error: Could not determine WooCommerce version." >&2
+	exit 1
+fi
+
+echo "==> Using WooCommerce ${WC_VERSION}"
+echo "==> Downloading test framework files from GitHub..."
+
+# The wordpress.org zip doesn't include tests/. The PHPUnit bootstrap needs
+# specific test helpers from the WooCommerce source. Download them individually
+# from the GitHub monorepo rather than cloning or downloading the full archive.
+RAW_BASE="https://raw.githubusercontent.com/woocommerce/woocommerce/${WC_VERSION}/plugins/woocommerce"
+
+# Files required by tests/class-unittestsbootstrap.php includes() method
+TEST_FILES=(
+	"tests/legacy/includes/wp-http-testcase.php"
+	"tests/legacy/framework/helpers/class-wc-helper-coupon.php"
+	"tests/legacy/framework/helpers/class-wc-helper-product.php"
+	"tests/legacy/framework/helpers/class-wc-helper-order.php"
+	"tests/legacy/framework/helpers/class-wc-helper-shipping.php"
+	"tests/legacy/framework/helpers/class-wc-helper-customer.php"
+)
+
+# Also need the legacy bootstrap marker so the bootstrap detects the legacy path
+TEST_FILES+=("tests/legacy/bootstrap.php")
+
+wp-env run tests-cli bash -c "
+	set -e
+	WC_DIR=/var/www/html/wp-content/plugins/woocommerce
+	RAW_BASE='${RAW_BASE}'
+
+	for file in ${TEST_FILES[*]}; do
+		dir=\$(dirname \"\${WC_DIR}/\${file}\")
+		mkdir -p \"\${dir}\"
+		echo \"    Downloading \${file}\"
+		curl -sf \"\${RAW_BASE}/\${file}\" -o \"\${WC_DIR}/\${file}\"
+	done
+
+	echo '    Test framework files installed.'
+"
+
+echo "==> Installing plugin composer dependencies..."
+wp-env run tests-cli --env-cwd=wp-content/plugins/woocommerce-google-analytics-integration composer install --no-interaction 2>&1 | tail -3
+
+echo ""
+echo "==> PHPUnit environment ready. Run tests with: npm run test:php"

--- a/tests/class-unittestsbootstrap.php
+++ b/tests/class-unittestsbootstrap.php
@@ -60,10 +60,18 @@ class UnitTestsBootstrap {
 	 * Set directory paths.
 	 */
 	public function set_path_props() {
-		$this->tests_dir    = __DIR__;
-		$this->plugin_dir   = dirname( $this->tests_dir );
-		$this->plugins_dir  = sys_get_temp_dir() . '/wordpress/wp-content/plugins';
-		$this->wp_tests_dir = sys_get_temp_dir() . '/wordpress-tests-lib';
+		$this->tests_dir  = __DIR__;
+		$this->plugin_dir = dirname( $this->tests_dir );
+
+		// Support wp-env: WP_TESTS_DIR is set inside wp-env containers.
+		$wp_tests_dir = getenv( 'WP_TESTS_DIR' );
+		if ( $wp_tests_dir ) {
+			$this->wp_tests_dir = $wp_tests_dir;
+			$this->plugins_dir  = '/var/www/html/wp-content/plugins';
+		} else {
+			$this->wp_tests_dir = sys_get_temp_dir() . '/wordpress-tests-lib';
+			$this->plugins_dir  = sys_get_temp_dir() . '/wordpress/wp-content/plugins';
+		}
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #552.

Adds `npm run test:php` and `npm run test:php:setup` scripts so PHPUnit tests can run inside the existing wp-env Docker environment. No local MySQL, svn, or manual `bin/install-unit-tests.sh` setup required.

**What changed:**
- **`tests/class-unittestsbootstrap.php`** — `set_path_props()` detects wp-env via the `WP_TESTS_DIR` env var (already set in wp-env containers) and uses container paths. Falls back to the original `sys_get_temp_dir()` paths when not in wp-env, so CI is unaffected.
- **`tests/bin/setup-phpunit-env.sh`** (new) — Lightweight setup script that ensures WooCommerce is installed, downloads 7 specific WC test framework files from GitHub (not included in the wordpress.org zip), and runs `composer install` for the plugin's dev deps.
- **`package.json`** — Two new scripts: `test:php:setup` and `test:php`.
- **`README.md`** / **`AGENTS.md`** — Updated docs.

### Checks:

* [x] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Detailed test instructions:

1. `npm run wp-env:up`
2. `npm run test:php:setup` — should install WooCommerce, download test files, install composer deps
3. `npm run test:php` — should run all 7 PHPUnit tests and pass
4. Optionally test with a specific WC version: `npm run test:php:setup -- --wc-version=9.6.0`
5. Verify CI still passes (the bootstrap change is backward-compatible)

### Changelog entry

> Dev - Add npm scripts to run PHPUnit tests via wp-env for simpler local development.