### PR TITLE
Expand PHP unit test coverage for data formatting and configuration

### DIFF
--- a/tests/unit-tests/Configuration.php
+++ b/tests/unit-tests/Configuration.php
@@ -12,8 +12,11 @@ use WC_Google_Analytics;
  */
 class Configuration extends EventsDataTest {
 
-	// --- get_site_tag_config ---
-
+	/**
+	 * Test that default config contains expected keys and values.
+	 *
+	 * @return void
+	 */
 	public function test_get_site_tag_config_default_values() {
 		$gtag   = new WC_Google_Gtag_JS();
 		$config = $gtag->get_site_tag_config();
@@ -27,6 +30,11 @@ class Configuration extends EventsDataTest {
 		$this->assertEquals( 'logged_in', $config['custom_map']['dimension1'] );
 	}
 
+	/**
+	 * Test that track_404 reflects the ga_404_tracking_enabled setting.
+	 *
+	 * @return void
+	 */
 	public function test_get_site_tag_config_track_404_reflects_setting() {
 		$gtag   = new WC_Google_Gtag_JS( [ 'ga_404_tracking_enabled' => 'yes' ] );
 		$config = $gtag->get_site_tag_config();
@@ -37,6 +45,11 @@ class Configuration extends EventsDataTest {
 		$this->assertFalse( $config['track_404'] );
 	}
 
+	/**
+	 * Test that allow_google_signals reflects the display advertising setting.
+	 *
+	 * @return void
+	 */
 	public function test_get_site_tag_config_allow_google_signals_reflects_setting() {
 		$gtag   = new WC_Google_Gtag_JS( [ 'ga_support_display_advertising' => 'yes' ] );
 		$config = $gtag->get_site_tag_config();
@@ -47,6 +60,11 @@ class Configuration extends EventsDataTest {
 		$this->assertFalse( $config['allow_google_signals'] );
 	}
 
+	/**
+	 * Test that logged_in reflects the current user state.
+	 *
+	 * @return void
+	 */
 	public function test_get_site_tag_config_logged_in_reflects_user_state() {
 		$gtag = new WC_Google_Gtag_JS();
 
@@ -60,6 +78,11 @@ class Configuration extends EventsDataTest {
 		wp_set_current_user( 0 );
 	}
 
+	/**
+	 * Test that linker domains are parsed from comma-separated setting.
+	 *
+	 * @return void
+	 */
 	public function test_get_site_tag_config_linker_domains_parses_comma_separated() {
 		$gtag   = new WC_Google_Gtag_JS( [ 'ga_linker_cross_domains' => 'example.com,example.net' ] );
 		$config = $gtag->get_site_tag_config();
@@ -67,16 +90,23 @@ class Configuration extends EventsDataTest {
 		$this->assertEquals( [ 'example.com', 'example.net' ], $config['linker']['domains'] );
 	}
 
+	/**
+	 * Test that whitespace in linker domains is preserved (documents current behavior).
+	 *
+	 * @return void
+	 */
 	public function test_get_site_tag_config_linker_domains_with_whitespace() {
-		// The source uses explode(',') without trim, so spaces are preserved.
-		// This documents current behavior — user input "example.com, example.net"
-		// results in a leading space on the second domain.
 		$gtag   = new WC_Google_Gtag_JS( [ 'ga_linker_cross_domains' => 'example.com, example.net' ] );
 		$config = $gtag->get_site_tag_config();
 
 		$this->assertEquals( [ 'example.com', ' example.net' ], $config['linker']['domains'] );
 	}
 
+	/**
+	 * Test that linker domains is empty when setting is empty.
+	 *
+	 * @return void
+	 */
 	public function test_get_site_tag_config_linker_domains_empty_when_setting_empty() {
 		$gtag   = new WC_Google_Gtag_JS( [ 'ga_linker_cross_domains' => '' ] );
 		$config = $gtag->get_site_tag_config();
@@ -84,6 +114,11 @@ class Configuration extends EventsDataTest {
 		$this->assertEquals( [], $config['linker']['domains'] );
 	}
 
+	/**
+	 * Test that linker allow_incoming reflects the setting.
+	 *
+	 * @return void
+	 */
 	public function test_get_site_tag_config_linker_allow_incoming_reflects_setting() {
 		$gtag   = new WC_Google_Gtag_JS( [ 'ga_linker_allow_incoming_enabled' => 'yes' ] );
 		$config = $gtag->get_site_tag_config();
@@ -94,6 +129,11 @@ class Configuration extends EventsDataTest {
 		$this->assertFalse( $config['linker']['allow_incoming'] );
 	}
 
+	/**
+	 * Test that the woocommerce_ga_gtag_config filter can modify config.
+	 *
+	 * @return void
+	 */
 	public function test_get_site_tag_config_filter_can_modify() {
 		$gtag     = new WC_Google_Gtag_JS();
 		$callback = function ( $config ) {
@@ -109,8 +149,11 @@ class Configuration extends EventsDataTest {
 		remove_filter( 'woocommerce_ga_gtag_config', $callback );
 	}
 
-	// --- get_consent_modes ---
-
+	/**
+	 * Test that get_consent_modes returns an array with one mode.
+	 *
+	 * @return void
+	 */
 	public function test_get_consent_modes_returns_array_with_one_mode() {
 		$gtag  = new WC_Google_Gtag_JS();
 		$modes = $this->call_protected_method( $gtag, 'get_consent_modes' );
@@ -119,6 +162,11 @@ class Configuration extends EventsDataTest {
 		$this->assertCount( 1, $modes );
 	}
 
+	/**
+	 * Test that all consent categories are denied by default.
+	 *
+	 * @return void
+	 */
 	public function test_get_consent_modes_all_categories_denied() {
 		$gtag  = new WC_Google_Gtag_JS();
 		$modes = $this->call_protected_method( $gtag, 'get_consent_modes' );
@@ -130,12 +178,16 @@ class Configuration extends EventsDataTest {
 		$this->assertEquals( 'denied', $mode['ad_personalization'] );
 	}
 
+	/**
+	 * Test that the region list contains 32 countries (27 EU + 3 EEA + GB + CH).
+	 *
+	 * @return void
+	 */
 	public function test_get_consent_modes_region_list() {
 		$gtag  = new WC_Google_Gtag_JS();
 		$modes = $this->call_protected_method( $gtag, 'get_consent_modes' );
 		$mode  = $modes[0];
 
-		// 27 EU + IS, LI, NO (EEA) + GB + CH = 32
 		$this->assertCount( 32, $mode['region'] );
 		$this->assertContains( 'GB', $mode['region'] );
 		$this->assertContains( 'CH', $mode['region'] );
@@ -145,10 +197,14 @@ class Configuration extends EventsDataTest {
 		$this->assertContains( 'LI', $mode['region'] );
 		$this->assertContains( 'NO', $mode['region'] );
 
-		// No duplicate entries
 		$this->assertCount( count( $mode['region'] ), array_unique( $mode['region'] ) );
 	}
 
+	/**
+	 * Test that the woocommerce_ga_gtag_consent_modes filter can modify modes.
+	 *
+	 * @return void
+	 */
 	public function test_get_consent_modes_filter_can_modify() {
 		$gtag     = new WC_Google_Gtag_JS();
 		$callback = function ( $modes ) {
@@ -164,8 +220,11 @@ class Configuration extends EventsDataTest {
 		remove_filter( 'woocommerce_ga_gtag_consent_modes', $callback );
 	}
 
-	// --- utm_nooverride ---
-
+	/**
+	 * Test that utm_nooverride adds the parameter to a URL.
+	 *
+	 * @return void
+	 */
 	public function test_utm_nooverride_adds_parameter() {
 		$ga  = $this->create_ga_instance();
 		$url = $ga->utm_nooverride( 'https://example.com/checkout/' );
@@ -173,6 +232,11 @@ class Configuration extends EventsDataTest {
 		$this->assertStringContainsString( 'utm_nooverride=1', $url );
 	}
 
+	/**
+	 * Test that utm_nooverride replaces an existing value without duplicates.
+	 *
+	 * @return void
+	 */
 	public function test_utm_nooverride_replaces_existing_value() {
 		$ga  = $this->create_ga_instance();
 		$url = $ga->utm_nooverride( 'https://example.com/checkout/?utm_nooverride=0' );
@@ -181,6 +245,11 @@ class Configuration extends EventsDataTest {
 		$this->assertEquals( 1, substr_count( $url, 'utm_nooverride' ) );
 	}
 
+	/**
+	 * Test that utm_nooverride preserves existing query parameters.
+	 *
+	 * @return void
+	 */
 	public function test_utm_nooverride_preserves_existing_query_params() {
 		$ga  = $this->create_ga_instance();
 		$url = $ga->utm_nooverride( 'https://example.com/checkout/?foo=bar&baz=qux' );
@@ -190,6 +259,11 @@ class Configuration extends EventsDataTest {
 		$this->assertStringContainsString( 'baz=qux', $url );
 	}
 
+	/**
+	 * Test that utm_nooverride escapes dangerous characters.
+	 *
+	 * @return void
+	 */
 	public function test_utm_nooverride_escapes_dangerous_characters() {
 		$ga  = $this->create_ga_instance();
 		$url = $ga->utm_nooverride( 'https://example.com/checkout/?key=val&x=<script>' );
@@ -198,10 +272,13 @@ class Configuration extends EventsDataTest {
 		$this->assertStringContainsString( 'utm_nooverride=1', $url );
 	}
 
-	// --- track_settings ---
-
+	/**
+	 * Test that track_settings returns all expected fields.
+	 *
+	 * @return void
+	 */
 	public function test_track_settings_returns_all_fields() {
-		$ga   = $this->create_ga_instance(
+		$ga      = $this->create_ga_instance(
 			[
 				'ga_id'                            => 'G-TEST123',
 				'ga_support_display_advertising'   => 'yes',
@@ -212,7 +289,7 @@ class Configuration extends EventsDataTest {
 				'ga_linker_cross_domains'          => 'example.com',
 			]
 		);
-		$data = $ga->track_settings( [] );
+		$data    = $ga->track_settings( [] );
 		$ga_data = $data['wc-google-analytics'];
 
 		$this->assertEquals( 'yes', $ga_data['support_display_advertising'] );
@@ -224,12 +301,17 @@ class Configuration extends EventsDataTest {
 		$this->assertEquals( 'G', $ga_data['ga_id'] );
 	}
 
+	/**
+	 * Test that GA ID prefix is extracted correctly for various formats.
+	 *
+	 * @return void
+	 */
 	public function test_track_settings_ga_id_prefix_extraction() {
 		$cases = [
 			'G-XXXX'  => 'G',
 			'GT-XXXX' => 'GT',
 			'UA-XXXX' => 'UA',
-			''         => '',
+			''        => '',
 			'ZZ-XXXX' => 'X',
 		];
 
@@ -255,8 +337,12 @@ class Configuration extends EventsDataTest {
 		}
 	}
 
+	/**
+	 * Test that linker_allow_incoming is normalized to yes/no.
+	 *
+	 * @return void
+	 */
 	public function test_track_settings_linker_allow_incoming_normalization() {
-		// Source normalizes: empty() => 'no', otherwise => 'yes'
 		$ga   = $this->create_ga_instance(
 			[
 				'ga_id'                            => 'G-TEST',
@@ -287,17 +373,27 @@ class Configuration extends EventsDataTest {
 	}
 
 	/**
-	 * Helper to call protected/private static methods via reflection.
+	 * Call a protected or private method via reflection.
+	 *
+	 * @param mixed  $instance    The object instance to call the method on.
+	 * @param string $method_name The method name to call.
+	 * @param array  $args        Arguments to pass to the method.
+	 *
+	 * @return mixed The method return value.
 	 */
-	private function call_protected_method( $object, $method_name, $args = [] ) {
-		$reflection = new \ReflectionMethod( get_class( $object ), $method_name );
+	private function call_protected_method( $instance, $method_name, $args = [] ) {
+		$reflection = new \ReflectionMethod( get_class( $instance ), $method_name );
 		$reflection->setAccessible( true );
-		return $reflection->invokeArgs( $object, $args );
+		return $reflection->invokeArgs( $instance, $args );
 	}
 
 	/**
-	 * Helper to create a WC_Google_Analytics instance with test settings
-	 * using a mock to avoid the full constructor side effects.
+	 * Create a WC_Google_Analytics instance with test settings using a mock
+	 * to avoid the full constructor side effects.
+	 *
+	 * @param array $settings Settings to inject.
+	 *
+	 * @return WC_Google_Analytics The mock instance.
 	 */
 	private function create_ga_instance( $settings = [] ) {
 		$ga = $this->getMockBuilder( WC_Google_Analytics::class )

--- a/tests/unit-tests/Configuration.php
+++ b/tests/unit-tests/Configuration.php
@@ -1,0 +1,314 @@
+<?php
+
+namespace GoogleAnalyticsIntegration\Tests;
+
+use WC_Google_Gtag_JS;
+use WC_Google_Analytics;
+
+/**
+ * Unit tests for configuration methods on WC_Google_Gtag_JS and WC_Google_Analytics.
+ *
+ * @package GoogleAnalyticsIntegration\Tests
+ */
+class Configuration extends EventsDataTest {
+
+	// --- get_site_tag_config ---
+
+	public function test_get_site_tag_config_default_values() {
+		$gtag   = new WC_Google_Gtag_JS();
+		$config = $gtag->get_site_tag_config();
+
+		$this->assertFalse( $config['track_404'], 'track_404 should be false when setting is unset' );
+		$this->assertFalse( $config['allow_google_signals'], 'allow_google_signals should be false when setting is unset' );
+		$this->assertFalse( $config['logged_in'], 'logged_in should be false in test context' );
+		$this->assertIsArray( $config['linker'] );
+		$this->assertEquals( [], $config['linker']['domains'] );
+		$this->assertFalse( $config['linker']['allow_incoming'] );
+		$this->assertEquals( 'logged_in', $config['custom_map']['dimension1'] );
+	}
+
+	public function test_get_site_tag_config_track_404_reflects_setting() {
+		$gtag   = new WC_Google_Gtag_JS( [ 'ga_404_tracking_enabled' => 'yes' ] );
+		$config = $gtag->get_site_tag_config();
+		$this->assertTrue( $config['track_404'] );
+
+		$gtag   = new WC_Google_Gtag_JS( [ 'ga_404_tracking_enabled' => 'no' ] );
+		$config = $gtag->get_site_tag_config();
+		$this->assertFalse( $config['track_404'] );
+	}
+
+	public function test_get_site_tag_config_allow_google_signals_reflects_setting() {
+		$gtag   = new WC_Google_Gtag_JS( [ 'ga_support_display_advertising' => 'yes' ] );
+		$config = $gtag->get_site_tag_config();
+		$this->assertTrue( $config['allow_google_signals'] );
+
+		$gtag   = new WC_Google_Gtag_JS( [ 'ga_support_display_advertising' => 'no' ] );
+		$config = $gtag->get_site_tag_config();
+		$this->assertFalse( $config['allow_google_signals'] );
+	}
+
+	public function test_get_site_tag_config_logged_in_reflects_user_state() {
+		$gtag = new WC_Google_Gtag_JS();
+
+		$config = $gtag->get_site_tag_config();
+		$this->assertFalse( $config['logged_in'] );
+
+		wp_set_current_user( 1 );
+		$config = $gtag->get_site_tag_config();
+		$this->assertTrue( $config['logged_in'] );
+
+		wp_set_current_user( 0 );
+	}
+
+	public function test_get_site_tag_config_linker_domains_parses_comma_separated() {
+		$gtag   = new WC_Google_Gtag_JS( [ 'ga_linker_cross_domains' => 'example.com,example.net' ] );
+		$config = $gtag->get_site_tag_config();
+
+		$this->assertEquals( [ 'example.com', 'example.net' ], $config['linker']['domains'] );
+	}
+
+	public function test_get_site_tag_config_linker_domains_with_whitespace() {
+		// The source uses explode(',') without trim, so spaces are preserved.
+		// This documents current behavior — user input "example.com, example.net"
+		// results in a leading space on the second domain.
+		$gtag   = new WC_Google_Gtag_JS( [ 'ga_linker_cross_domains' => 'example.com, example.net' ] );
+		$config = $gtag->get_site_tag_config();
+
+		$this->assertEquals( [ 'example.com', ' example.net' ], $config['linker']['domains'] );
+	}
+
+	public function test_get_site_tag_config_linker_domains_empty_when_setting_empty() {
+		$gtag   = new WC_Google_Gtag_JS( [ 'ga_linker_cross_domains' => '' ] );
+		$config = $gtag->get_site_tag_config();
+
+		$this->assertEquals( [], $config['linker']['domains'] );
+	}
+
+	public function test_get_site_tag_config_linker_allow_incoming_reflects_setting() {
+		$gtag   = new WC_Google_Gtag_JS( [ 'ga_linker_allow_incoming_enabled' => 'yes' ] );
+		$config = $gtag->get_site_tag_config();
+		$this->assertTrue( $config['linker']['allow_incoming'] );
+
+		$gtag   = new WC_Google_Gtag_JS( [ 'ga_linker_allow_incoming_enabled' => 'no' ] );
+		$config = $gtag->get_site_tag_config();
+		$this->assertFalse( $config['linker']['allow_incoming'] );
+	}
+
+	public function test_get_site_tag_config_filter_can_modify() {
+		$gtag     = new WC_Google_Gtag_JS();
+		$callback = function ( $config ) {
+			$config['custom_key'] = 'custom_value';
+			return $config;
+		};
+
+		add_filter( 'woocommerce_ga_gtag_config', $callback );
+
+		$config = $gtag->get_site_tag_config();
+		$this->assertEquals( 'custom_value', $config['custom_key'] );
+
+		remove_filter( 'woocommerce_ga_gtag_config', $callback );
+	}
+
+	// --- get_consent_modes ---
+
+	public function test_get_consent_modes_returns_array_with_one_mode() {
+		$gtag  = new WC_Google_Gtag_JS();
+		$modes = $this->call_protected_method( $gtag, 'get_consent_modes' );
+
+		$this->assertIsArray( $modes );
+		$this->assertCount( 1, $modes );
+	}
+
+	public function test_get_consent_modes_all_categories_denied() {
+		$gtag  = new WC_Google_Gtag_JS();
+		$modes = $this->call_protected_method( $gtag, 'get_consent_modes' );
+		$mode  = $modes[0];
+
+		$this->assertEquals( 'denied', $mode['analytics_storage'] );
+		$this->assertEquals( 'denied', $mode['ad_storage'] );
+		$this->assertEquals( 'denied', $mode['ad_user_data'] );
+		$this->assertEquals( 'denied', $mode['ad_personalization'] );
+	}
+
+	public function test_get_consent_modes_region_list() {
+		$gtag  = new WC_Google_Gtag_JS();
+		$modes = $this->call_protected_method( $gtag, 'get_consent_modes' );
+		$mode  = $modes[0];
+
+		// 27 EU + IS, LI, NO (EEA) + GB + CH = 32
+		$this->assertCount( 32, $mode['region'] );
+		$this->assertContains( 'GB', $mode['region'] );
+		$this->assertContains( 'CH', $mode['region'] );
+		$this->assertContains( 'DE', $mode['region'] );
+		$this->assertContains( 'FR', $mode['region'] );
+		$this->assertContains( 'IS', $mode['region'] );
+		$this->assertContains( 'LI', $mode['region'] );
+		$this->assertContains( 'NO', $mode['region'] );
+
+		// No duplicate entries
+		$this->assertCount( count( $mode['region'] ), array_unique( $mode['region'] ) );
+	}
+
+	public function test_get_consent_modes_filter_can_modify() {
+		$gtag     = new WC_Google_Gtag_JS();
+		$callback = function ( $modes ) {
+			$modes[0]['analytics_storage'] = 'granted';
+			return $modes;
+		};
+
+		add_filter( 'woocommerce_ga_gtag_consent_modes', $callback );
+
+		$modes = $this->call_protected_method( $gtag, 'get_consent_modes' );
+		$this->assertEquals( 'granted', $modes[0]['analytics_storage'] );
+
+		remove_filter( 'woocommerce_ga_gtag_consent_modes', $callback );
+	}
+
+	// --- utm_nooverride ---
+
+	public function test_utm_nooverride_adds_parameter() {
+		$ga  = $this->create_ga_instance();
+		$url = $ga->utm_nooverride( 'https://example.com/checkout/' );
+
+		$this->assertStringContainsString( 'utm_nooverride=1', $url );
+	}
+
+	public function test_utm_nooverride_replaces_existing_value() {
+		$ga  = $this->create_ga_instance();
+		$url = $ga->utm_nooverride( 'https://example.com/checkout/?utm_nooverride=0' );
+
+		$this->assertStringContainsString( 'utm_nooverride=1', $url );
+		$this->assertEquals( 1, substr_count( $url, 'utm_nooverride' ) );
+	}
+
+	public function test_utm_nooverride_preserves_existing_query_params() {
+		$ga  = $this->create_ga_instance();
+		$url = $ga->utm_nooverride( 'https://example.com/checkout/?foo=bar&baz=qux' );
+
+		$this->assertStringContainsString( 'utm_nooverride=1', $url );
+		$this->assertStringContainsString( 'foo=bar', $url );
+		$this->assertStringContainsString( 'baz=qux', $url );
+	}
+
+	public function test_utm_nooverride_escapes_dangerous_characters() {
+		$ga  = $this->create_ga_instance();
+		$url = $ga->utm_nooverride( 'https://example.com/checkout/?key=val&x=<script>' );
+
+		$this->assertStringNotContainsString( '<script>', $url );
+		$this->assertStringContainsString( 'utm_nooverride=1', $url );
+	}
+
+	// --- track_settings ---
+
+	public function test_track_settings_returns_all_fields() {
+		$ga   = $this->create_ga_instance(
+			[
+				'ga_id'                            => 'G-TEST123',
+				'ga_support_display_advertising'   => 'yes',
+				'ga_404_tracking_enabled'          => 'yes',
+				'ga_ecommerce_tracking_enabled'    => 'yes',
+				'ga_event_tracking_enabled'        => 'no',
+				'ga_linker_allow_incoming_enabled' => 'no',
+				'ga_linker_cross_domains'          => 'example.com',
+			]
+		);
+		$data = $ga->track_settings( [] );
+		$ga_data = $data['wc-google-analytics'];
+
+		$this->assertEquals( 'yes', $ga_data['support_display_advertising'] );
+		$this->assertEquals( 'yes', $ga_data['ga_404_tracking_enabled'] );
+		$this->assertEquals( 'yes', $ga_data['ecommerce_tracking_enabled'] );
+		$this->assertEquals( 'no', $ga_data['event_tracking_enabled'] );
+		$this->assertEquals( WC_GOOGLE_ANALYTICS_INTEGRATION_VERSION, $ga_data['plugin_version'] );
+		$this->assertEquals( 'example.com', $ga_data['linker_cross_domains'] );
+		$this->assertEquals( 'G', $ga_data['ga_id'] );
+	}
+
+	public function test_track_settings_ga_id_prefix_extraction() {
+		$cases = [
+			'G-XXXX'  => 'G',
+			'GT-XXXX' => 'GT',
+			'UA-XXXX' => 'UA',
+			''         => '',
+			'ZZ-XXXX' => 'X',
+		];
+
+		foreach ( $cases as $ga_id => $expected_prefix ) {
+			$ga   = $this->create_ga_instance(
+				[
+					'ga_id'                            => $ga_id,
+					'ga_support_display_advertising'   => 'yes',
+					'ga_404_tracking_enabled'          => 'yes',
+					'ga_ecommerce_tracking_enabled'    => 'yes',
+					'ga_event_tracking_enabled'        => 'yes',
+					'ga_linker_allow_incoming_enabled' => 'no',
+					'ga_linker_cross_domains'          => '',
+				]
+			);
+			$data = $ga->track_settings( [] );
+
+			$this->assertEquals(
+				$expected_prefix,
+				$data['wc-google-analytics']['ga_id'],
+				"GA ID prefix for '{$ga_id}' should be '{$expected_prefix}'"
+			);
+		}
+	}
+
+	public function test_track_settings_linker_allow_incoming_normalization() {
+		// Source normalizes: empty() => 'no', otherwise => 'yes'
+		$ga   = $this->create_ga_instance(
+			[
+				'ga_id'                            => 'G-TEST',
+				'ga_support_display_advertising'   => 'yes',
+				'ga_404_tracking_enabled'          => 'yes',
+				'ga_ecommerce_tracking_enabled'    => 'yes',
+				'ga_event_tracking_enabled'        => 'yes',
+				'ga_linker_allow_incoming_enabled' => 'yes',
+				'ga_linker_cross_domains'          => '',
+			]
+		);
+		$data = $ga->track_settings( [] );
+		$this->assertEquals( 'yes', $data['wc-google-analytics']['linker_allow_incoming_enabled'] );
+
+		$ga   = $this->create_ga_instance(
+			[
+				'ga_id'                            => 'G-TEST',
+				'ga_support_display_advertising'   => 'yes',
+				'ga_404_tracking_enabled'          => 'yes',
+				'ga_ecommerce_tracking_enabled'    => 'yes',
+				'ga_event_tracking_enabled'        => 'yes',
+				'ga_linker_allow_incoming_enabled' => '',
+				'ga_linker_cross_domains'          => '',
+			]
+		);
+		$data = $ga->track_settings( [] );
+		$this->assertEquals( 'no', $data['wc-google-analytics']['linker_allow_incoming_enabled'] );
+	}
+
+	/**
+	 * Helper to call protected/private static methods via reflection.
+	 */
+	private function call_protected_method( $object, $method_name, $args = [] ) {
+		$reflection = new \ReflectionMethod( get_class( $object ), $method_name );
+		$reflection->setAccessible( true );
+		return $reflection->invokeArgs( $object, $args );
+	}
+
+	/**
+	 * Helper to create a WC_Google_Analytics instance with test settings
+	 * using a mock to avoid the full constructor side effects.
+	 */
+	private function create_ga_instance( $settings = [] ) {
+		$ga = $this->getMockBuilder( WC_Google_Analytics::class )
+					->disableOriginalConstructor()
+					->onlyMethods( [] )
+					->getMock();
+
+		$reflection = new \ReflectionProperty( WC_Google_Analytics::class, 'settings' );
+		$reflection->setAccessible( true );
+		$reflection->setValue( $ga, $settings );
+
+		return $ga;
+	}
+}

--- a/tests/unit-tests/DataFormatting.php
+++ b/tests/unit-tests/DataFormatting.php
@@ -1,0 +1,263 @@
+<?php
+
+namespace GoogleAnalyticsIntegration\Tests;
+
+use WC_Google_Gtag_JS;
+use WC_Helper_Product;
+use WC_Helper_Customer;
+use WC_Helper_Order;
+
+/**
+ * Unit tests for data formatting methods on WC_Abstract_Google_Analytics_JS
+ * tested via the WC_Google_Gtag_JS concrete class.
+ *
+ * @package GoogleAnalyticsIntegration\Tests
+ */
+class DataFormatting extends EventsDataTest {
+
+	/** @var WC_Google_Gtag_JS */
+	private $gtag;
+
+	public function set_up() {
+		parent::set_up();
+		$this->gtag = new WC_Google_Gtag_JS( [ 'ga_product_identifier' => 'product_id' ] );
+	}
+
+	public function tear_down() {
+		if ( WC()->cart ) {
+			WC()->cart->empty_cart();
+		}
+		parent::tear_down();
+	}
+
+	// --- get_formatted_price ---
+
+	public function test_get_formatted_price_standard() {
+		$this->assertEquals( 1000, $this->gtag->get_formatted_price( 10.00 ) );
+	}
+
+	public function test_get_formatted_price_zero() {
+		$this->assertEquals( 0, $this->gtag->get_formatted_price( 0 ) );
+	}
+
+	public function test_get_formatted_price_string_input() {
+		$this->assertEquals( 999, $this->gtag->get_formatted_price( '9.99' ) );
+	}
+
+	public function test_get_formatted_price_rounding_up() {
+		// 9.995 * 100 = 999.5, rounded = 1000
+		$this->assertEquals( 1000, $this->gtag->get_formatted_price( 9.995 ) );
+	}
+
+	public function test_get_formatted_price_rounding_down() {
+		// 10.004 * 100 = 1000.4, round gives 1000 (not 1001 like ceil would)
+		$this->assertEquals( 1000, $this->gtag->get_formatted_price( 10.004 ) );
+	}
+
+	public function test_get_formatted_price_negative() {
+		$this->assertEquals( -1000, $this->gtag->get_formatted_price( -10.00 ) );
+	}
+
+	// --- get_formatted_product ---
+
+	public function test_get_formatted_product_simple_structure_and_values() {
+		$product   = $this->get_product();
+		$formatted = $this->gtag->get_formatted_product( $product );
+
+		$this->assertEquals( $product->get_id(), $formatted['id'] );
+		$this->assertEquals( $product->get_title(), $formatted['name'] );
+		$this->assertIsArray( $formatted['categories'] );
+
+		$this->assertEquals( $this->gtag->get_formatted_price( $product->get_price() ), $formatted['prices']['price'] );
+		$this->assertEquals( wc_get_price_decimals(), $formatted['prices']['currency_minor_unit'] );
+
+		$this->assertEquals(
+			$product->get_id(),
+			$formatted['extensions']['woocommerce_google_analytics_integration']['identifier']
+		);
+	}
+
+	public function test_get_formatted_product_with_sku_identifier() {
+		$gtag_sku = new WC_Google_Gtag_JS( [ 'ga_product_identifier' => 'product_sku' ] );
+		$product  = WC_Helper_Product::create_simple_product();
+		$product->set_sku( 'TEST-SKU-123' );
+		$product->save();
+
+		$formatted = $gtag_sku->get_formatted_product( $product );
+
+		$this->assertEquals(
+			'TEST-SKU-123',
+			$formatted['extensions']['woocommerce_google_analytics_integration']['identifier']
+		);
+	}
+
+	public function test_get_formatted_product_with_variation_id_uses_variation_price() {
+		$variation_product = WC_Helper_Product::create_variation_product();
+		$variations        = $variation_product->get_children();
+		$variation_id      = $variations[0];
+		$variation         = wc_get_product( $variation_id );
+
+		$formatted = $this->gtag->get_formatted_product( $variation_product, $variation_id );
+
+		$expected_price = $this->gtag->get_formatted_price( $variation->get_price() );
+		$this->assertEquals( $expected_price, $formatted['prices']['price'] );
+	}
+
+	public function test_get_formatted_product_with_variation_array() {
+		$product   = $this->get_product();
+		$variation = [
+			'attribute_color' => 'red',
+			'attribute_size'  => 'large',
+		];
+
+		$formatted = $this->gtag->get_formatted_product( $product, 0, $variation );
+
+		$this->assertArrayHasKey( 'variation', $formatted );
+		$this->assertEquals( 'color: red, size: large', $formatted['variation'] );
+	}
+
+	public function test_get_formatted_product_variation_type_uses_parent_id_and_attributes() {
+		$variation_product = WC_Helper_Product::create_variation_product();
+		$variations        = $variation_product->get_children();
+		$variation         = wc_get_product( $variations[0] );
+
+		$formatted = $this->gtag->get_formatted_product( $variation );
+
+		$this->assertEquals( $variation->get_parent_id(), $formatted['id'] );
+		$this->assertArrayHasKey( 'variation', $formatted );
+		$this->assertNotEmpty( $formatted['variation'], 'Variation string should contain attribute data' );
+	}
+
+	public function test_get_formatted_product_with_quantity() {
+		$product   = $this->get_product();
+		$formatted = $this->gtag->get_formatted_product( $product, 0, false, 3 );
+
+		$this->assertArrayHasKey( 'quantity', $formatted );
+		$this->assertEquals( 3, $formatted['quantity'] );
+	}
+
+	public function test_get_formatted_product_without_quantity() {
+		$product   = $this->get_product();
+		$formatted = $this->gtag->get_formatted_product( $product );
+
+		$this->assertArrayNotHasKey( 'quantity', $formatted );
+	}
+
+	public function test_get_formatted_product_categories_limited_to_five() {
+		$product = WC_Helper_Product::create_simple_product();
+
+		$category_ids = [];
+		for ( $i = 0; $i < 7; $i++ ) {
+			$term           = wp_insert_term( "CatLimit{$i}_" . uniqid(), 'product_cat' );
+			$category_ids[] = $term['term_id'];
+		}
+		wp_set_object_terms( $product->get_id(), $category_ids, 'product_cat' );
+		clean_object_term_cache( $product->get_id(), 'product' );
+
+		$formatted = $this->gtag->get_formatted_product( $product );
+
+		$this->assertCount( 5, $formatted['categories'] );
+		foreach ( $formatted['categories'] as $cat ) {
+			$this->assertArrayHasKey( 'name', $cat );
+		}
+	}
+
+	// --- get_formatted_order ---
+
+	private function create_order_with_product() {
+		$product  = WC_Helper_Product::create_simple_product();
+		$customer = WC_Helper_Customer::create_customer( 'fmt_' . uniqid(), 'pw', uniqid() . '@test.test' );
+		return WC_Helper_Order::create_order( $customer->get_id(), $product );
+	}
+
+	public function test_get_formatted_order_returns_id_and_affiliation() {
+		$order     = $this->create_order_with_product();
+		$formatted = $this->gtag->get_formatted_order( $order );
+
+		$this->assertEquals( $order->get_id(), $formatted['id'] );
+		$this->assertEquals( get_bloginfo( 'name' ), $formatted['affiliation'] );
+	}
+
+	public function test_get_formatted_order_totals_values() {
+		$order     = $this->create_order_with_product();
+		$formatted = $this->gtag->get_formatted_order( $order );
+		$totals    = $formatted['totals'];
+
+		$this->assertEquals( $order->get_currency(), $totals['currency_code'] );
+		$this->assertEquals( wc_get_price_decimals(), $totals['currency_minor_unit'] );
+		$this->assertEquals( $this->gtag->get_formatted_price( $order->get_total_tax() ), $totals['tax_total'] );
+		$this->assertEquals( $this->gtag->get_formatted_price( $order->get_total_shipping() ), $totals['shipping_total'] );
+		$this->assertEquals( $this->gtag->get_formatted_price( $order->get_total() ), $totals['total_price'] );
+	}
+
+	public function test_get_formatted_order_items_contain_product_data() {
+		$order     = $this->create_order_with_product();
+		$formatted = $this->gtag->get_formatted_order( $order );
+
+		$this->assertNotEmpty( $formatted['items'] );
+
+		$item       = $formatted['items'][0];
+		$order_item = array_values( $order->get_items() )[0];
+		$product    = $order_item->get_product();
+
+		// Values from get_formatted_product (merged)
+		$this->assertEquals( $product->get_id(), $item['id'] );
+		$this->assertEquals( $product->get_title(), $item['name'] );
+		$this->assertArrayHasKey( 'categories', $item );
+		$this->assertArrayHasKey( 'prices', $item );
+		$this->assertArrayHasKey( 'extensions', $item );
+
+		// Order-specific fields
+		$this->assertEquals( $order_item->get_quantity(), $item['quantity'] );
+		$this->assertEquals(
+			$this->gtag->get_formatted_price( $order_item->get_total() ),
+			$item['price_after_coupon_discount']
+		);
+	}
+
+	// --- get_formatted_cart ---
+
+	public function test_get_formatted_cart_null_cart_returns_empty_array() {
+		$original_cart = WC()->cart;
+		try {
+			WC()->cart = null;
+
+			$formatted = $this->gtag->get_formatted_cart();
+
+			$this->assertIsArray( $formatted );
+			$this->assertEmpty( $formatted );
+		} finally {
+			WC()->cart = $original_cart;
+		}
+	}
+
+	public function test_get_formatted_cart_empty_cart() {
+		$formatted = $this->gtag->get_formatted_cart();
+
+		$this->assertArrayHasKey( 'items', $formatted );
+		$this->assertEmpty( $formatted['items'] );
+		$this->assertArrayHasKey( 'totals', $formatted );
+	}
+
+	public function test_get_formatted_cart_with_items() {
+		$product = WC_Helper_Product::create_simple_product();
+		WC()->cart->add_to_cart( $product->get_id(), 2 );
+
+		$formatted = $this->gtag->get_formatted_cart();
+
+		$this->assertNotEmpty( $formatted['items'] );
+		$this->assertArrayHasKey( 'coupons', $formatted );
+
+		$item = $formatted['items'][0];
+		$this->assertEquals( $product->get_id(), $item['id'] );
+		$this->assertEquals( $product->get_title(), $item['name'] );
+		$this->assertEquals( 2, $item['quantity'] );
+		$this->assertArrayHasKey( 'prices', $item );
+		$this->assertEquals( wc_get_price_decimals(), $item['prices']['currency_minor_unit'] );
+
+		$totals = $formatted['totals'];
+		$this->assertEquals( get_woocommerce_currency(), $totals['currency_code'] );
+		$this->assertEquals( wc_get_price_decimals(), $totals['currency_minor_unit'] );
+		$this->assertIsInt( $totals['total_price'] );
+	}
+}

--- a/tests/unit-tests/DataFormatting.php
+++ b/tests/unit-tests/DataFormatting.php
@@ -18,11 +18,21 @@ class DataFormatting extends EventsDataTest {
 	/** @var WC_Google_Gtag_JS */
 	private $gtag;
 
+	/**
+	 * Set up test fixtures.
+	 *
+	 * @return void
+	 */
 	public function set_up() {
 		parent::set_up();
 		$this->gtag = new WC_Google_Gtag_JS( [ 'ga_product_identifier' => 'product_id' ] );
 	}
 
+	/**
+	 * Clean up after each test.
+	 *
+	 * @return void
+	 */
 	public function tear_down() {
 		if ( WC()->cart ) {
 			WC()->cart->empty_cart();
@@ -30,36 +40,65 @@ class DataFormatting extends EventsDataTest {
 		parent::tear_down();
 	}
 
-	// --- get_formatted_price ---
-
+	/**
+	 * Test that a standard price is formatted correctly.
+	 *
+	 * @return void
+	 */
 	public function test_get_formatted_price_standard() {
 		$this->assertEquals( 1000, $this->gtag->get_formatted_price( 10.00 ) );
 	}
 
+	/**
+	 * Test that zero price returns zero.
+	 *
+	 * @return void
+	 */
 	public function test_get_formatted_price_zero() {
 		$this->assertEquals( 0, $this->gtag->get_formatted_price( 0 ) );
 	}
 
+	/**
+	 * Test that string input is cast to float before formatting.
+	 *
+	 * @return void
+	 */
 	public function test_get_formatted_price_string_input() {
 		$this->assertEquals( 999, $this->gtag->get_formatted_price( '9.99' ) );
 	}
 
+	/**
+	 * Test that half-cent values round up correctly.
+	 *
+	 * @return void
+	 */
 	public function test_get_formatted_price_rounding_up() {
-		// 9.995 * 100 = 999.5, rounded = 1000
 		$this->assertEquals( 1000, $this->gtag->get_formatted_price( 9.995 ) );
 	}
 
+	/**
+	 * Test that sub-half-cent values round down (not ceil).
+	 *
+	 * @return void
+	 */
 	public function test_get_formatted_price_rounding_down() {
-		// 10.004 * 100 = 1000.4, round gives 1000 (not 1001 like ceil would)
 		$this->assertEquals( 1000, $this->gtag->get_formatted_price( 10.004 ) );
 	}
 
+	/**
+	 * Test that negative prices (refunds) are formatted correctly.
+	 *
+	 * @return void
+	 */
 	public function test_get_formatted_price_negative() {
 		$this->assertEquals( -1000, $this->gtag->get_formatted_price( -10.00 ) );
 	}
 
-	// --- get_formatted_product ---
-
+	/**
+	 * Test that a simple product returns correct structure and values.
+	 *
+	 * @return void
+	 */
 	public function test_get_formatted_product_simple_structure_and_values() {
 		$product   = $this->get_product();
 		$formatted = $this->gtag->get_formatted_product( $product );
@@ -77,6 +116,11 @@ class DataFormatting extends EventsDataTest {
 		);
 	}
 
+	/**
+	 * Test that the SKU-based identifier is used when ga_product_identifier is product_sku.
+	 *
+	 * @return void
+	 */
 	public function test_get_formatted_product_with_sku_identifier() {
 		$gtag_sku = new WC_Google_Gtag_JS( [ 'ga_product_identifier' => 'product_sku' ] );
 		$product  = WC_Helper_Product::create_simple_product();
@@ -91,6 +135,11 @@ class DataFormatting extends EventsDataTest {
 		);
 	}
 
+	/**
+	 * Test that passing a variation_id uses the variation's price.
+	 *
+	 * @return void
+	 */
 	public function test_get_formatted_product_with_variation_id_uses_variation_price() {
 		$variation_product = WC_Helper_Product::create_variation_product();
 		$variations        = $variation_product->get_children();
@@ -103,6 +152,11 @@ class DataFormatting extends EventsDataTest {
 		$this->assertEquals( $expected_price, $formatted['prices']['price'] );
 	}
 
+	/**
+	 * Test that a variation array is formatted as "attr: value, attr2: value2".
+	 *
+	 * @return void
+	 */
 	public function test_get_formatted_product_with_variation_array() {
 		$product   = $this->get_product();
 		$variation = [
@@ -116,6 +170,11 @@ class DataFormatting extends EventsDataTest {
 		$this->assertEquals( 'color: red, size: large', $formatted['variation'] );
 	}
 
+	/**
+	 * Test that a variation-type product uses the parent ID and includes attribute data.
+	 *
+	 * @return void
+	 */
 	public function test_get_formatted_product_variation_type_uses_parent_id_and_attributes() {
 		$variation_product = WC_Helper_Product::create_variation_product();
 		$variations        = $variation_product->get_children();
@@ -128,6 +187,11 @@ class DataFormatting extends EventsDataTest {
 		$this->assertNotEmpty( $formatted['variation'], 'Variation string should contain attribute data' );
 	}
 
+	/**
+	 * Test that quantity is included when passed.
+	 *
+	 * @return void
+	 */
 	public function test_get_formatted_product_with_quantity() {
 		$product   = $this->get_product();
 		$formatted = $this->gtag->get_formatted_product( $product, 0, false, 3 );
@@ -136,6 +200,11 @@ class DataFormatting extends EventsDataTest {
 		$this->assertEquals( 3, $formatted['quantity'] );
 	}
 
+	/**
+	 * Test that quantity is omitted when not passed.
+	 *
+	 * @return void
+	 */
 	public function test_get_formatted_product_without_quantity() {
 		$product   = $this->get_product();
 		$formatted = $this->gtag->get_formatted_product( $product );
@@ -143,6 +212,11 @@ class DataFormatting extends EventsDataTest {
 		$this->assertArrayNotHasKey( 'quantity', $formatted );
 	}
 
+	/**
+	 * Test that categories are limited to 5.
+	 *
+	 * @return void
+	 */
 	public function test_get_formatted_product_categories_limited_to_five() {
 		$product = WC_Helper_Product::create_simple_product();
 
@@ -162,14 +236,22 @@ class DataFormatting extends EventsDataTest {
 		}
 	}
 
-	// --- get_formatted_order ---
-
+	/**
+	 * Create a fresh order with its own product and customer for test isolation.
+	 *
+	 * @return \WC_Order
+	 */
 	private function create_order_with_product() {
 		$product  = WC_Helper_Product::create_simple_product();
 		$customer = WC_Helper_Customer::create_customer( 'fmt_' . uniqid(), 'pw', uniqid() . '@test.test' );
 		return WC_Helper_Order::create_order( $customer->get_id(), $product );
 	}
 
+	/**
+	 * Test that order ID and blog name affiliation are returned.
+	 *
+	 * @return void
+	 */
 	public function test_get_formatted_order_returns_id_and_affiliation() {
 		$order     = $this->create_order_with_product();
 		$formatted = $this->gtag->get_formatted_order( $order );
@@ -178,6 +260,11 @@ class DataFormatting extends EventsDataTest {
 		$this->assertEquals( get_bloginfo( 'name' ), $formatted['affiliation'] );
 	}
 
+	/**
+	 * Test that order totals contain correct currency, decimal, and price values.
+	 *
+	 * @return void
+	 */
 	public function test_get_formatted_order_totals_values() {
 		$order     = $this->create_order_with_product();
 		$formatted = $this->gtag->get_formatted_order( $order );
@@ -190,6 +277,11 @@ class DataFormatting extends EventsDataTest {
 		$this->assertEquals( $this->gtag->get_formatted_price( $order->get_total() ), $totals['total_price'] );
 	}
 
+	/**
+	 * Test that order items contain merged product data and order-specific fields.
+	 *
+	 * @return void
+	 */
 	public function test_get_formatted_order_items_contain_product_data() {
 		$order     = $this->create_order_with_product();
 		$formatted = $this->gtag->get_formatted_order( $order );
@@ -200,14 +292,12 @@ class DataFormatting extends EventsDataTest {
 		$order_item = array_values( $order->get_items() )[0];
 		$product    = $order_item->get_product();
 
-		// Values from get_formatted_product (merged)
 		$this->assertEquals( $product->get_id(), $item['id'] );
 		$this->assertEquals( $product->get_title(), $item['name'] );
 		$this->assertArrayHasKey( 'categories', $item );
 		$this->assertArrayHasKey( 'prices', $item );
 		$this->assertArrayHasKey( 'extensions', $item );
 
-		// Order-specific fields
 		$this->assertEquals( $order_item->get_quantity(), $item['quantity'] );
 		$this->assertEquals(
 			$this->gtag->get_formatted_price( $order_item->get_total() ),
@@ -215,8 +305,11 @@ class DataFormatting extends EventsDataTest {
 		);
 	}
 
-	// --- get_formatted_cart ---
-
+	/**
+	 * Test that a null cart returns an empty array.
+	 *
+	 * @return void
+	 */
 	public function test_get_formatted_cart_null_cart_returns_empty_array() {
 		$original_cart = WC()->cart;
 		try {
@@ -231,6 +324,11 @@ class DataFormatting extends EventsDataTest {
 		}
 	}
 
+	/**
+	 * Test that an empty (non-null) cart returns the expected structure.
+	 *
+	 * @return void
+	 */
 	public function test_get_formatted_cart_empty_cart() {
 		$formatted = $this->gtag->get_formatted_cart();
 
@@ -239,6 +337,11 @@ class DataFormatting extends EventsDataTest {
 		$this->assertArrayHasKey( 'totals', $formatted );
 	}
 
+	/**
+	 * Test that a cart with items returns correct product data and totals.
+	 *
+	 * @return void
+	 */
 	public function test_get_formatted_cart_with_items() {
 		$product = WC_Helper_Product::create_simple_product();
 		WC()->cart->add_to_cart( $product->get_id(), 2 );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Adds 40 new PHP unit tests across two new test files, expanding coverage from ~13% (7 tests) to cover the previously untested data formatting and configuration methods that handle all GA4 event payloads and tracking setup.

**`tests/unit-tests/DataFormatting.php`** (20 tests, 58 assertions)
- `get_formatted_price()` — standard, zero, string input, rounding up/down, negative (refund) values
- `get_formatted_product()` — structure + value correctness, SKU vs product ID identifiers, variation ID price, variation array formatting, variation-type parent ID + attributes, quantity inclusion/exclusion, category limit of 5
- `get_formatted_order()` — ID/affiliation, totals with actual currency and price values, items with merged product fields and coupon discount
- `get_formatted_cart()` — null cart, empty cart, cart with items including value assertions on product data and totals

**`tests/unit-tests/Configuration.php`** (20 tests, 57 assertions)
- `get_site_tag_config()` — default values, track_404, allow_google_signals, logged_in user state, linker domain parsing (including whitespace behavior), allow_incoming, custom_map, filter extensibility
- `get_consent_modes()` — single mode returned, all 4 categories denied by default, 32 EEA+GB+CH regions with no duplicates, filter extensibility
- `utm_nooverride()` — adds parameter, replaces existing, preserves other query params, escapes dangerous characters
- `track_settings()` — all tracked field values, GA ID prefix extraction (G/GT/UA/empty/unknown), linker_allow_incoming normalization, plugin version

### Checks:

* [x] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Detailed test instructions:

1. Check out this branch
2. Set up the test environment per README instructions (`bin/install-unit-tests.sh`)
3. Run `vendor/bin/phpunit` — all 47 tests should pass (7 existing + 40 new)
4. Run `vendor/bin/phpunit --filter DataFormatting` — 20 tests, 58 assertions
5. Run `vendor/bin/phpunit --filter Configuration` — 20 tests, 57 assertions

### Changelog entry

> Dev - Expand PHP unit test coverage for data formatting and configuration methods