### PR TITLE
Add "Prepare Release via Woo Deploy" workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,76 @@
+name: Deploy Product
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to deploy (e.g., 2.1.21)'
+        required: true
+        type: string
+      deploy_woo:
+        description: 'Deploy to Woo.com'
+        required: false
+        default: true
+        type: boolean
+      deploy_github:
+        description: 'Deploy to GitHub'
+        required: false
+        default: true
+        type: boolean
+      simulate:
+        description: 'Dry run mode'
+        required: false
+        default: true
+        type: boolean
+  workflow_call:
+    inputs:
+      version:
+        description: 'Version to deploy (e.g., 2.1.21)'
+        required: true
+        type: string
+      deploy_woo:
+        description: 'Deploy to Woo.com'
+        required: false
+        default: true
+        type: boolean
+      deploy_github:
+        description: 'Deploy to GitHub'
+        required: false
+        default: true
+        type: boolean
+      simulate:
+        description: 'Dry run mode'
+        required: false
+        default: true
+        type: boolean
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Checkout the private action repository
+      - name: Checkout woo-product-deploy action
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          repository: woocommerce/woo-product-deploy
+          ref: trunk
+          path: ./.github/actions/woo-product-deploy
+          token: ${{ secrets.ORG_DEPLOY_SECRET }}  # Need PAT with access to the action repository
+
+      # Use the action we checked out
+      - name: Deploy Product
+        uses: ./.github/actions/woo-product-deploy
+        with:
+          repo_url: https://github.com/woocommerce/woocommerce-google-analytics-integration
+          branch: ${{ github.ref_name }}
+          version: ${{ inputs.version }}
+          node_version: '20'
+          npm_version: '10'
+          simulate: ${{ inputs.simulate }}
+          wccom_release: ${{ inputs.deploy_woo }}
+          github_release: ${{ inputs.deploy_github }}
+          deploy_pat: ${{ secrets.ORG_DEPLOY_SECRET }}
+          partner_user: ${{ secrets.ORG_PARTNER_USER }}
+          partner_secret: ${{ secrets.ORG_PARTNER_DEPLOY_SECRET }}
+          wccom_product_id: 1442927

--- a/.github/workflows/prepare-release-via-deploy.yml
+++ b/.github/workflows/prepare-release-via-deploy.yml
@@ -1,0 +1,63 @@
+name: 'Prepare New Release (via Woo Deploy)'
+run-name: Prepare New Release `release/${{ github.event.inputs.version }}` by @${{ github.actor }}
+
+# **What it does**: Creates the release branch and PR with a checklist for releases done via the Deploy workflow.
+# **Why we have it**: To support devs automating a few manual steps, and to leave a nice reference for consumers.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version number to be released'
+        required: true
+
+jobs:
+  PrepareRelease:
+    name: Prepare Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Validate version format
+        env:
+          VERSION: ${{ github.event.inputs.version }}
+        run: |
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+            echo "::error::Invalid version format '$VERSION'. Expected format: X.Y.Z (e.g., 2.1.22) or X.Y.Z-suffix (e.g., 2.1.22-beta.1)"
+            exit 1
+          fi
+
+      - name: Set release branch name
+        id: release-vars
+        env:
+          VERSION: ${{ github.event.inputs.version }}
+        run: echo "branch=release/${VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Create release branch
+        env:
+          BRANCH_NAME: ${{ steps.release-vars.outputs.branch }}
+        run: |
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git checkout -b "${BRANCH_NAME}"
+          git commit --allow-empty -q -m "Start \`${BRANCH_NAME}\`."
+          git push --set-upstream origin "${BRANCH_NAME}"
+
+      - name: Create a pull request for the release
+        id: prepare-release-pr
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const { default: script } = await import( `${ process.env.GITHUB_WORKSPACE }/.github/workflows/scripts/create-release-pr.mjs` );
+            return await script( {
+              context,
+              github,
+              version: process.env.VERSION,
+            } );
+        env:
+          VERSION: ${{ github.event.inputs.version }}
+
+      - name: Generate summary
+        run: |
+          echo "Release PR created at ${{ fromJSON(steps.prepare-release-pr.outputs.result).html_url }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/scripts/create-release-pr.mjs
+++ b/.github/workflows/scripts/create-release-pr.mjs
@@ -1,0 +1,53 @@
+export default async ( { context, github, version } ) => {
+	const refName = 'release/' + version;
+	const extensionPackageName = context.payload.repository.name;
+	const repoURL =
+		context.payload.repository.html_url + '/tree/release/' + version;
+
+	const title = `Release ${ version }`;
+
+	const body = `## Checklist
+1. [ ] Check if the version, base, and target branches are as you desire.
+1. [ ] Make sure you have \`woorelease\` installed and set up.
+1. [ ] Go to your local repo clone, and check out this PR to be able to commit any potential adjustments.
+   \`\`\`sh
+   git fetch origin ${ refName }
+   git checkout ${ refName }
+   \`\`\`
+1. [ ] Remove older changelog entries from \`readme.txt\` (keep the last two versions, since we will be adding a third during the release), commit changes.
+1. [ ] Update version and generate changelog. You will be asked to review the changelog and as result this will add a couple of commits to this PR
+   \`\`\`sh
+   woorelease vb:change --release --generate_changelog --product_version=${ version } ${ repoURL }
+   woorelease vb:replace --release --product_version=${ version } ${ repoURL }
+   woorelease cl:generate --release --product_version=${ version } ${ repoURL }
+   \`\`\`
+1. [ ] Automated tests are passing.
+1. [ ] Run [Woo Deploy Action](${ context.payload.repository.html_url }/actions/workflows/deploy.yml) — select branch \`release/${ version }\`, version \`${ version }\`, and **Dry run** mode.
+1. [ ] Test the package
+   1. [ ] Install the .zip package from the artifact from the dry run on a test site
+   1. [ ] Confirm it activates without warnings/errors and is showing the right versions
+   1. [ ] Run a few basic smoke tests
+
+## Next steps
+1. [ ] Do the final release
+   1. [ ] Run [Woo Deploy Action](${ context.payload.repository.html_url }/actions/workflows/deploy.yml) — select branch \`release/${ version }\`, version \`${ version }\`, and **production** mode (disable **Dry run**).
+1. [ ] Confirm the release using the activation link from your email.
+   When releasing to WordPress.org, _"release notifications"_ have been enabled, so each committer will be sent an email with an action link to confirm the release. This must be done after committing in SVN before the release becomes available. See the following page for releases pending notifications: https://wordpress.org/plugins/developers/releases/
+1. [ ] Go to ${ context.payload.repository.html_url }/releases/${ version }, generate GitHub release notes, and paste them as a comment here.
+1. [ ] Merge this PR after the new release is successfully created and the version tags are updated.
+1. [ ] Merge \`trunk\` to \`develop\` (PR), if applicable for this repo.
+1. [ ] Update documentation
+   - [ ] Publish any new required docs
+   - [ ] Update triggers/rules/actions listing pages
+1. [ ] Mark related ideas complete [on the feature requests page](https://woocommerce.com/feature-requests/${ extensionPackageName }/).
+`;
+
+	const pull = await github.rest.pulls.create( {
+		...context.repo,
+		base: 'trunk',
+		head: refName,
+		title,
+		body,
+	} );
+	return pull.data;
+};


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds workflows for releasing the plugin via the Woo Deploy Action:

- **`deploy.yml`** — Deploys the plugin using `woo-product-deploy` (with dry run as default)
- **`prepare-release-via-deploy.yml`** — Creates a release branch and PR with a step-by-step checklist
- **`create-release-pr.mjs`** — Script that generates the release PR body with the checklist

Key features:
- Version format validation (must match `X.Y.Z` or `X.Y.Z-suffix`)
- Dry run mode enabled by default for safe testing
- Release checklist includes WordPress.org confirmation step and `readme.txt` cleanup
- Actions pinned to commit SHAs for security
- Uses `inputs.*` context (compatible with both `workflow_dispatch` and `workflow_call`)

This follows the same pattern as the deploy workflow in [AutomateWoo](https://github.com/woocommerce/automatewoo).

### Detailed test instructions:

1. Merge this PR
2. Go to **Actions → "Prepare New Release (via Woo Deploy)"**
3. Trigger with a test version (e.g., `2.1.22-test`)
4. Verify the release branch and PR are created correctly
5. From the PR checklist, run the **Deploy** workflow in **dry run** mode
6. Download and smoke test the `.zip` artifact
7. Clean up: close the test PR and delete the test branch

### Changelog entry

> Dev - Add Woo Deploy workflow for streamlined releases.