### PR TITLE
Add deploy workflow and release preparation via Woo Deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,8 +7,8 @@ on:
         description: 'Version to deploy (e.g., 2.1.21)'
         required: true
         type: string
-      deploy_woo:
-        description: 'Deploy to Woo.com'
+      deploy_wporg:
+        description: 'Deploy to WordPress.org'
         required: false
         default: true
         type: boolean
@@ -28,8 +28,8 @@ on:
         description: 'Version to deploy (e.g., 2.1.21)'
         required: true
         type: string
-      deploy_woo:
-        description: 'Deploy to Woo.com'
+      deploy_wporg:
+        description: 'Deploy to WordPress.org'
         required: false
         default: true
         type: boolean
@@ -68,9 +68,8 @@ jobs:
           node_version: '20'
           npm_version: '10'
           simulate: ${{ inputs.simulate }}
-          wccom_release: ${{ inputs.deploy_woo }}
+          wporg_release: ${{ inputs.deploy_wporg }}
           github_release: ${{ inputs.deploy_github }}
           deploy_pat: ${{ secrets.ORG_DEPLOY_SECRET }}
           partner_user: ${{ secrets.ORG_PARTNER_USER }}
           partner_secret: ${{ secrets.ORG_PARTNER_DEPLOY_SECRET }}
-          wccom_product_id: 1442927

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,6 +12,11 @@ on:
         required: false
         default: true
         type: boolean
+      deploy_woo:
+        description: 'Deploy to Woo.com'
+        required: false
+        default: true
+        type: boolean
       deploy_github:
         description: 'Deploy to GitHub'
         required: false
@@ -30,6 +35,11 @@ on:
         type: string
       deploy_wporg:
         description: 'Deploy to WordPress.org'
+        required: false
+        default: true
+        type: boolean
+      deploy_woo:
+        description: 'Deploy to Woo.com'
         required: false
         default: true
         type: boolean
@@ -69,7 +79,9 @@ jobs:
           npm_version: '10'
           simulate: ${{ inputs.simulate }}
           wporg_release: ${{ inputs.deploy_wporg }}
+          wccom_release: ${{ inputs.deploy_woo }}
           github_release: ${{ inputs.deploy_github }}
           deploy_pat: ${{ secrets.ORG_DEPLOY_SECRET }}
           partner_user: ${{ secrets.ORG_PARTNER_USER }}
           partner_secret: ${{ secrets.ORG_PARTNER_DEPLOY_SECRET }}
+          wccom_product_id: 1442927


### PR DESCRIPTION
## Summary
- Adds a **Deploy Product** workflow using `woo-product-deploy` action for WordPress.org and GitHub releases
- Adds a **Prepare New Release** workflow that creates a release branch and PR with a checklist
- Includes version format validation and SHA-pinned actions

Adapted from the [AutomateWoo deploy workflow](https://github.com/woocommerce/automatewoo/pull/2023) for WordPress.org plugins (uses `wporg_release` instead of `wccom_release`).

Related AUTOM8-192

## Test plan
- [ ] Merge this PR
- [ ] Trigger "Prepare New Release (via Woo Deploy)" from `trunk` with a test version (e.g., `2.1.22-test`)
- [ ] From the generated release PR, trigger "Deploy Product" in **dry run** mode
- [ ] Verify the `.zip` artifact is valid and installable
🤖 Generated with [Claude Code](https://claude.com/claude-code)