### PR TITLE
Add WordPress.org SVN credentials to deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -82,6 +82,8 @@ jobs:
           wccom_release: ${{ inputs.deploy_woo }}
           github_release: ${{ inputs.deploy_github }}
           deploy_pat: ${{ secrets.ORG_DEPLOY_SECRET }}
+          wporg_username: ${{ secrets.WPORG_SVN_USERNAME }}
+          wporg_password: ${{ secrets.WPORG_SVN_PASSWORD }}
           partner_user: ${{ secrets.ORG_PARTNER_USER }}
           partner_secret: ${{ secrets.ORG_PARTNER_DEPLOY_SECRET }}
           wccom_product_id: 1442927


### PR DESCRIPTION
## Summary
- Adds `wporg_username` and `wporg_password` parameters to the deploy workflow, referencing `WPORG_SVN_USERNAME` and `WPORG_SVN_PASSWORD` repo secrets
- Required for WordPress.org releases via the `woo-product-deploy` action

## Prerequisites
Before merging, add the following **repo-level secrets**:
- `WPORG_SVN_USERNAME` — WordPress.org SVN username
- `WPORG_SVN_PASSWORD` — WordPress.org SVN password

## Test plan
- [ ] Add repo secrets
- [ ] Merge this PR
- [ ] Trigger "Deploy Product" with **Dry run** mode and **Deploy to WordPress.org** enabled
- [ ] Verify simulation completes without SVN authentication errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)