### PR TITLE
Fix flaky E2E tests caused by race conditions

### DIFF
--- a/tests/e2e/bin/test-env-setup.sh
+++ b/tests/e2e/bin/test-env-setup.sh
@@ -26,5 +26,10 @@ wp-env run tests-cli wp option update blogname 'WooCommerce E2E Test Suite'
 echo -e 'Adding basic WooCommerce settings... \n'
 wp-env run tests-cli wp wc payment_gateway update cod --enabled=1 --user=admin
 
+echo -e 'Disable default shipping methods \n'
+wp-env run tests-cli wp wc shipping_zone_method list 0 --field=instance_id --user=admin | while read -r id; do
+	wp-env run tests-cli wp wc shipping_zone_method delete 0 "$id" --force --user=admin
+done
+
 echo -e 'Set the store as live \n'
 wp-env run tests-cli wp option update woocommerce_coming_soon 'no'

--- a/tests/e2e/specs/gtag-events/classic-pages.test.js
+++ b/tests/e2e/specs/gtag-events/classic-pages.test.js
@@ -196,21 +196,26 @@ test.describe( 'GTag events on classic pages', () => {
 
 		await event.then( ( request ) => {
 			const data = getEventData( request, 'view_item_list' );
-			expect( data.product1 ).toEqual( {
+			const products = [ data.product1, data.product2 ];
+			const simple = products.find(
+				( p ) => p.id === simpleProductID.toString()
+			);
+			const variable = products.find(
+				( p ) => p.id === variableProductID.toString()
+			);
+			expect( simple ).toMatchObject( {
 				id: simpleProductID.toString(),
 				nm: 'Simple product',
 				ln: 'Product List',
 				ca: 'Uncategorized',
 				pr: simpleProductPrice.toString(),
-				lp: '1',
 			} );
-			expect( data.product2 ).toEqual( {
+			expect( variable ).toMatchObject( {
 				id: variableProductID.toString(),
 				nm: 'Variable product',
 				ln: 'Product List',
 				ca: 'Uncategorized',
 				pr: '17.99', // Lowest price for variable products.
-				lp: '2',
 			} );
 			expect( data[ 'ep.item_list_id' ] ).toEqual( 'engagement' );
 			expect( data[ 'ep.item_list_name' ] ).toEqual( 'Viewing products' );

--- a/tests/e2e/utils/api.js
+++ b/tests/e2e/utils/api.js
@@ -52,9 +52,9 @@ export async function createVariableProduct() {
 		.post( 'products', config.products.variable )
 		.then( ( response ) => response.data.id );
 
-	config.products.variations.map( async ( variation ) => {
+	for ( const variation of config.products.variations ) {
 		await api().post( `products/${ parentID }/variations`, variation );
-	} );
+	}
 
 	return parentID;
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Fixes three sources of E2E test flakiness discovered during WooCommerce 10.7.0-beta.2 compatibility testing:

1. **Variable product price race condition** — `createVariableProduct()` used `.map(async ...)` without awaiting the returned promises, so the function returned before all variations were created. WC's parent product price sync would see incomplete variations, resulting in non-deterministic pricing (17.99, 18.99, or 19.99 depending on which variation finished last). Fixed by creating variations sequentially with `for...of`.

2. **Product ordering assumption** — The `view_item_list` test assumed simple product would always be `product1` and variable `product2`. When products share the same creation timestamp, WC's sort order is non-deterministic. Fixed by finding products by ID instead of assuming fixed positions.

3. **Default shipping methods** — Newer WooCommerce versions may add a default flat rate shipping method, inflating cart totals by $10 and breaking checkout/purchase value assertions. Fixed by removing any default shipping methods during test environment setup.

### Checks:

* [x] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Screenshots:

_N/A_

### Detailed test instructions:

1. Run `npm run wp-env:up` to start the local environment
2. Run `npm run test:e2e` — all 42 tests should pass
3. Run `npx playwright test --config=tests/e2e/config/playwright.config.js -g "View item list event is sent from a classic shop page" --repeat-each=10` — should pass all 10 runs consistently

### Additional details:

_N/A_ — These are test-only changes with no user-facing impact.

### Changelog entry

> Dev - Fix flaky E2E tests caused by race conditions in variable product creation and non-deterministic product ordering.