### PR TITLE
Fix STORMA-39: Backfill missing settings defaults on fresh activation

### DIFF
--- a/includes/class-wc-google-analytics.php
+++ b/includes/class-wc-google-analytics.php
@@ -38,6 +38,17 @@ class WC_Google_Analytics extends WC_Integration {
 		$this->init_form_fields();
 		$this->init_settings();
 
+		// Backfill any settings keys not yet stored in the database.
+		// On a fresh activation, maybe_set_defaults() writes a partial settings array before
+		// init_settings() runs. WC_Integration::init_settings() only applies defaults when no
+		// settings exist at all, so keys missing from a partial array would be absent from
+		// $this->settings. We fill them in here using the same fallback logic as get_option().
+		foreach ( $this->get_form_fields() as $key => $field ) {
+			if ( ! array_key_exists( $key, $this->settings ) ) {
+				$this->settings[ $key ] = $this->get_field_default( $field );
+			}
+		}
+
 		add_action( 'admin_notices', array( $this, 'universal_analytics_upgrade_notice' ) );
 
 		include_once 'class-wc-abstract-google-analytics-js.php';

--- a/tests/unit-tests/Configuration.php
+++ b/tests/unit-tests/Configuration.php
@@ -373,6 +373,48 @@ class Configuration extends EventsDataTest {
 	}
 
 	/**
+	 * Test that $this->settings is fully populated when the database contains only the partial
+	 * defaults written by maybe_set_defaults() on a fresh activation.
+	 *
+	 * @return void
+	 */
+	public function test_settings_are_complete_after_partial_activation_defaults() {
+		// Simulate what maybe_set_defaults() writes on a fresh install.
+		update_option( 'woocommerce_google_analytics_settings', [ 'ga_product_identifier' => 'product_id' ] );
+
+		$ga = new WC_Google_Analytics();
+
+		$reflection = new \ReflectionProperty( WC_Google_Analytics::class, 'settings' );
+		$reflection->setAccessible( true );
+		$settings = $reflection->getValue( $ga );
+
+		$expected_keys = [
+			'ga_product_identifier',
+			'ga_id',
+			'ga_support_display_advertising',
+			'ga_404_tracking_enabled',
+			'ga_linker_allow_incoming_enabled',
+			'ga_ecommerce_tracking_enabled',
+			'ga_event_tracking_enabled',
+			'ga_enhanced_remove_from_cart_enabled',
+			'ga_enhanced_product_impression_enabled',
+			'ga_enhanced_product_click_enabled',
+			'ga_enhanced_product_detail_view_enabled',
+			'ga_enhanced_checkout_process_enabled',
+			'ga_linker_cross_domains',
+		];
+
+		foreach ( $expected_keys as $key ) {
+			$this->assertArrayHasKey( $key, $settings, "Expected '{$key}' to be present in settings after construction with partial defaults." );
+		}
+
+		// The value set by maybe_set_defaults() should be preserved, not overwritten.
+		$this->assertEquals( 'product_id', $settings['ga_product_identifier'] );
+
+		delete_option( 'woocommerce_google_analytics_settings' );
+	}
+
+	/**
 	 * Call a protected or private method via reflection.
 	 *
 	 * @param mixed  $instance    The object instance to call the method on.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Fixes the init ordering issue where `maybe_set_defaults()` on activation writes a partial settings array to the database, causing `WC_Integration::init_settings()` to skip applying form field defaults for all other keys.

**Root cause:** On plugin activation, `maybe_set_defaults()` creates `woocommerce_google_analytics_settings` in the database containing only `ga_product_identifier`. When `WC_Google_Analytics::__construct()` later calls `init_settings()`, the WooCommerce parent method sees the option exists and uses the partial array as-is — it only writes defaults when no settings exist at all. This leaves `$this->settings` missing 12 of 13 keys, causing undefined array key notices in `track_settings()` and any code that reads `$this->settings` directly.

**Fix:** After `init_settings()` in the constructor, loop over all form fields and backfill any missing keys using `get_field_default()` — the same fallback logic already used by `get_option()`. In-memory only, no additional database writes. The `ga_product_identifier` value set by `maybe_set_defaults()` is preserved.

Closes #408

### Checks:
* [x] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [x] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Detailed test instructions:

1. Deactivate and uninstall the plugin, then remove the `woocommerce_google_analytics_settings` row from `wp_options` (or use `wp option delete woocommerce_google_analytics_settings`).
2. Install and activate the plugin: `wp plugin activate woocommerce-google-analytics-integration`
3. Check the stored option: `wp option get woocommerce_google_analytics_settings`
4. Confirm all expected keys are present (e.g. `ga_404_tracking_enabled`, `ga_event_tracking_enabled`, `ga_ecommerce_tracking_enabled`, etc.) with their correct defaults.
5. Visit a product page as a guest and confirm no PHP undefined array key notices appear.

Automated regression test added in `tests/unit-tests/Configuration.php::test_settings_are_complete_after_partial_activation_defaults`.

### Additional details:

### Changelog entry

> Fix - Ensure all settings defaults are populated in `$this->settings` on fresh activation, preventing undefined array key notices.

---

This PR was created during the [Woo Bug Blitz](https://woohappyp2.wordpress.com/2026/03/18/extensions-bug-blitz/) via team Ceres' [`/bug-blitz` Claude skill](https://github.com/Automattic/public-resources-squad/blob/trunk/.claude/skills/bug-blitz/skill.md). The fix was authored with Claude Code assistance by a Happiness Engineer who encounters this bug in support tickets.