### PR TITLE
Fix STORMA-159: Rename enquque_tracker() to enqueue_tracker()

### DIFF
--- a/includes/class-wc-google-gtag-js.php
+++ b/includes/class-wc-google-gtag-js.php
@@ -53,13 +53,13 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 
 		$this->register_scripts();
 		// Setup frontend scripts
-		add_action( 'wp_enqueue_scripts', array( $this, 'enquque_tracker' ), 5 );
+		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_tracker' ), 5 );
 		add_action( 'wp_footer', array( $this, 'inline_script_data' ) );
 	}
 
 	/**
 	 * Register manager and tracker scripts.
-	 * Call early so other extensions could add inline date to it.
+	 * Call early so other extensions could add inline data to it.
 	 *
 	 * @return void
 	 */
@@ -128,11 +128,19 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 	 *
 	 * @return void
 	 */
-	public function enquque_tracker(): void {
+	public function enqueue_tracker(): void {
 		wp_enqueue_script( 'google-tag-manager' );
-		// tracker.js needs to be executed ASAP, the remaining bits for main.js could be deffered,
+		// tracker.js needs to be executed ASAP, the remaining bits for main.js could be deferred,
 		// but to reduce the traffic, we ship it all together.
 		wp_enqueue_script( $this->script_handle );
+	}
+
+	/**
+	 * @deprecated 2.2.0 Use enqueue_tracker() instead.
+	 */
+	public function enquque_tracker(): void {
+		_deprecated_function( __METHOD__, '2.2.0', 'WC_Google_Gtag_JS::enqueue_tracker' );
+		$this->enqueue_tracker();
 	}
 
 	/**

--- a/tests/unit-tests/WCGoogleGtagJS.php
+++ b/tests/unit-tests/WCGoogleGtagJS.php
@@ -163,12 +163,12 @@ class WCGoogleGtagJS extends EventsDataTest {
 	 * Test that the deprecated enquque_tracker() method delegates to enqueue_tracker()
 	 * and triggers a deprecation notice.
 	 *
+	 * @expectedDeprecated WC_Google_Gtag_JS::enquque_tracker
+	 *
 	 * @return void
 	 */
 	public function test_enquque_tracker_deprecation(): void {
 		$gtag = new WC_Google_Gtag_JS();
-
-		$this->setExpectedDeprecated( 'WC_Google_Gtag_JS::enquque_tracker' );
 
 		$gtag->enquque_tracker();
 

--- a/tests/unit-tests/WCGoogleGtagJS.php
+++ b/tests/unit-tests/WCGoogleGtagJS.php
@@ -160,6 +160,23 @@ class WCGoogleGtagJS extends EventsDataTest {
 	}
 
 	/**
+	 * Test that the deprecated enquque_tracker() method delegates to enqueue_tracker()
+	 * and triggers a deprecation notice.
+	 *
+	 * @return void
+	 */
+	public function test_enquque_tracker_deprecation(): void {
+		$gtag = new WC_Google_Gtag_JS();
+
+		$this->setExpectedDeprecated( 'WC_Google_Gtag_JS::enquque_tracker' );
+
+		$gtag->enquque_tracker();
+
+		$this->assertTrue( wp_script_is( 'google-tag-manager', 'enqueued' ), 'google-tag-manager script should be enqueued by the deprecated method' );
+		$this->assertTrue( wp_script_is( $gtag->script_handle, 'enqueued' ), 'Main script should be enqueued by the deprecated method' );
+	}
+
+	/**
 	 * Test only events enabled in settings will be returned for config
 	 *
 	 * @return void


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Fixes a longstanding typo in the public method name `enquque_tracker()` in `WC_Google_Gtag_JS`. The method has been misspelled since its introduction — it's missing the first `e` in "enqueue". WordPress resolves action callbacks by reference so the plugin works correctly internally, but the public visibility of the method means:

- IDE autocompletion suggests the wrong name to developers extending the plugin
- Third-party code calling `$instance->enqueue_tracker()` (the correctly-spelled, WP-convention name) gets a fatal error
- The name is inconsistent with WordPress naming conventions (`wp_enqueue_scripts`, `wp_enqueue_style`, etc.)

**Changes:**
- Rename `enquque_tracker()` → `enqueue_tracker()` and update the `add_action` reference
- Keep `enquque_tracker()` as a deprecated alias (since 2.2.0) so any third-party code that adapted to the typo keeps working with a deprecation notice rather than a fatal error
- Fix two comment typos in the same file: `"add inline date to it"` → `"add inline data to it"` and `"could be deffered"` → `"could be deferred"`

Closes #573

### Checks:
* [x] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [x] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Detailed test instructions:

1. Open `includes/class-wc-google-gtag-js.php` and confirm `enqueue_tracker()` is the primary method and `enquque_tracker()` is the deprecated alias.
2. Enable `WP_DEBUG` and `WP_DEBUG_LOG` on a test site.
3. Activate the plugin — confirm no deprecation notice fires on normal page loads (the alias is not called in normal operation).
4. Manually call `WC_Google_Gtag_JS::get_instance()->enquque_tracker()` from a test snippet — confirm a deprecation notice is logged pointing to `enqueue_tracker()`.
5. Confirm the plugin still enqueues GA scripts correctly on the frontend.

### Additional details:

### Changelog entry

> Fix - Rename misspelled public method `enquque_tracker()` to `enqueue_tracker()`; keep deprecated alias for backward compatibility.

---

This PR was created during the [Woo Bug Blitz](https://woohappyp2.wordpress.com/2026/03/18/extensions-bug-blitz/) via team Ceres' [`/bug-blitz` Claude skill](https://github.com/Automattic/public-resources-squad/blob/trunk/.claude/skills/bug-blitz/skill.md). The fix was authored with Claude Code assistance by a Happiness Engineer who encounters this bug in support tickets.