### PR TITLE
Fix STORMA-36: Use page context for item_list_id and item_list_name in view_item_list events

### DIFF
--- a/assets/js/src/integrations/classic.js
+++ b/assets/js/src/integrations/classic.js
@@ -20,10 +20,19 @@ import { getProductFromID } from '../utils';
  * @param {Object}   data.product       - The single product object.
  * @param {Object}   data.added_to_cart - The product added to cart.
  * @param {Object}   data.order         - The order object.
+ * @param {string}   data.list_name     - The name of the product list for the current page context.
  */
 export function classicTracking(
 	getEventHandler,
-	{ events, cart, products, product, added_to_cart: addedToCart, order }
+	{
+		events,
+		cart,
+		products,
+		product,
+		added_to_cart: addedToCart,
+		order,
+		list_name: listName,
+	}
 ) {
 	// Instantly track the events listed in the `events` object.
 	Object.values( events ?? {} ).forEach( ( eventName ) => {
@@ -35,6 +44,7 @@ export function classicTracking(
 				products,
 				product,
 				order,
+				listName,
 			} );
 		}
 	} );

--- a/assets/js/src/tracker/data-formatting.js
+++ b/assets/js/src/tracker/data-formatting.js
@@ -25,11 +25,11 @@ export const view_item_list = ( {
 	}
 
 	return {
-		item_list_id: 'engagement',
-		item_list_name: __(
-			'Viewing products',
-			'woocommerce-google-analytics-integration'
-		),
+		item_list_id: listName
+			.toLowerCase()
+			.replace( /[^a-z0-9]+/g, '_' )
+			.replace( /(^_+|_+$)/g, '' ),
+		item_list_name: listName,
 		items: products.map( ( product, index ) => ( {
 			...getProductImpressionObject( product, listName ),
 			index: index + 1,

--- a/includes/class-wc-abstract-google-analytics-js.php
+++ b/includes/class-wc-abstract-google-analytics-js.php
@@ -86,6 +86,13 @@ abstract class WC_Abstract_Google_Analytics_JS {
 			5
 		);
 
+		add_action(
+			'wp_head',
+			function () {
+				$this->set_script_data( 'list_name', $this->get_list_name() );
+			}
+		);
+
 		add_filter(
 			'woocommerce_loop_add_to_cart_link',
 			function ( $button, $product ) {
@@ -116,6 +123,40 @@ abstract class WC_Abstract_Google_Analytics_JS {
 				}
 			}
 		);
+	}
+
+	/**
+	 * Returns the product list name for the current page context.
+	 * Used to populate item_list_name in view_item_list GA4 events for classic pages.
+	 *
+	 * @return string
+	 */
+	public function get_list_name(): string {
+		if ( is_shop() ) {
+			return __( 'Shop', 'woocommerce-google-analytics-integration' );
+		}
+
+		if ( is_product_category() ) {
+			return sprintf(
+				/* translators: %s: Product category name */
+				__( 'Category: %s', 'woocommerce-google-analytics-integration' ),
+				single_term_title( '', false )
+			);
+		}
+
+		if ( is_product_tag() ) {
+			return sprintf(
+				/* translators: %s: Product tag name */
+				__( 'Tag: %s', 'woocommerce-google-analytics-integration' ),
+				single_term_title( '', false )
+			);
+		}
+
+		if ( is_search() ) {
+			return __( 'Search Results', 'woocommerce-google-analytics-integration' );
+		}
+
+		return __( 'Product List', 'woocommerce-google-analytics-integration' );
 	}
 
 	/**

--- a/tests/e2e/specs/gtag-events/blocks-pages.test.js
+++ b/tests/e2e/specs/gtag-events/blocks-pages.test.js
@@ -382,8 +382,12 @@ test.describe( 'GTag events on block pages', () => {
 				pr: simpleProductPrice.toString(),
 				lp: '1',
 			} );
-			expect( data[ 'ep.item_list_id' ] ).toEqual( 'woocommerce_all_products' );
-			expect( data[ 'ep.item_list_name' ] ).toEqual( 'woocommerce/all-products' );
+			expect( data[ 'ep.item_list_id' ] ).toEqual(
+				'woocommerce_all_products'
+			);
+			expect( data[ 'ep.item_list_name' ] ).toEqual(
+				'woocommerce/all-products'
+			);
 		} );
 	} );
 

--- a/tests/e2e/specs/gtag-events/blocks-pages.test.js
+++ b/tests/e2e/specs/gtag-events/blocks-pages.test.js
@@ -79,8 +79,8 @@ test.describe( 'GTag events on block pages', () => {
 				pr: simpleProductPrice.toString(),
 				lp: '1',
 			} );
-			expect( data[ 'ep.item_list_id' ] ).toEqual( 'engagement' );
-			expect( data[ 'ep.item_list_name' ] ).toEqual( 'Viewing products' );
+			expect( data[ 'ep.item_list_id' ] ).toEqual( 'product_list' );
+			expect( data[ 'ep.item_list_name' ] ).toEqual( 'Product List' );
 		} );
 	} );
 
@@ -253,8 +253,8 @@ test.describe( 'GTag events on block pages', () => {
 				pr: simpleProductPrice.toString(),
 				lp: '1',
 			} );
-			expect( data[ 'ep.item_list_id' ] ).toEqual( 'engagement' );
-			expect( data[ 'ep.item_list_name' ] ).toEqual( 'Viewing products' );
+			expect( data[ 'ep.item_list_id' ] ).toEqual( 'product_list' );
+			expect( data[ 'ep.item_list_name' ] ).toEqual( 'Product List' );
 		} );
 	} );
 
@@ -333,8 +333,8 @@ test.describe( 'GTag events on block pages', () => {
 				pr: simpleProductPrice.toString(),
 				lp: '1',
 			} );
-			expect( data[ 'ep.item_list_id' ] ).toEqual( 'engagement' );
-			expect( data[ 'ep.item_list_name' ] ).toEqual( 'Viewing products' );
+			expect( data[ 'ep.item_list_id' ] ).toEqual( 'product_list' );
+			expect( data[ 'ep.item_list_name' ] ).toEqual( 'Product List' );
 		} );
 	} );
 
@@ -382,8 +382,8 @@ test.describe( 'GTag events on block pages', () => {
 				pr: simpleProductPrice.toString(),
 				lp: '1',
 			} );
-			expect( data[ 'ep.item_list_id' ] ).toEqual( 'engagement' );
-			expect( data[ 'ep.item_list_name' ] ).toEqual( 'Viewing products' );
+			expect( data[ 'ep.item_list_id' ] ).toEqual( 'woocommerce_all_products' );
+			expect( data[ 'ep.item_list_name' ] ).toEqual( 'woocommerce/all-products' );
 		} );
 	} );
 

--- a/tests/e2e/specs/gtag-events/classic-pages.test.js
+++ b/tests/e2e/specs/gtag-events/classic-pages.test.js
@@ -217,8 +217,8 @@ test.describe( 'GTag events on classic pages', () => {
 				ca: 'Uncategorized',
 				pr: '17.99', // Lowest price for variable products.
 			} );
-			expect( data[ 'ep.item_list_id' ] ).toEqual( 'engagement' );
-			expect( data[ 'ep.item_list_name' ] ).toEqual( 'Viewing products' );
+			expect( data[ 'ep.item_list_id' ] ).toEqual( 'product_list' );
+			expect( data[ 'ep.item_list_name' ] ).toEqual( 'Product List' );
 		} );
 	} );
 

--- a/tests/unit-tests/GetListName.php
+++ b/tests/unit-tests/GetListName.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace GoogleAnalyticsIntegration\Tests;
+
+use WC_Google_Gtag_JS;
+
+/**
+ * Unit tests for WC_Abstract_Google_Analytics_JS::get_list_name().
+ *
+ * @package GoogleAnalyticsIntegration\Tests
+ */
+class GetListName extends \WP_UnitTestCase {
+
+	/** @var WC_Google_Gtag_JS */
+	private $gtag;
+
+	/** @var \WP_Query */
+	private $original_wp_query;
+
+	/**
+	 * Set up test fixtures.
+	 *
+	 * @return void
+	 */
+	public function set_up() {
+		parent::set_up();
+		$this->gtag = new WC_Google_Gtag_JS();
+
+		global $wp_query;
+		$this->original_wp_query = clone $wp_query;
+	}
+
+	/**
+	 * Restore original $wp_query after each test.
+	 *
+	 * @return void
+	 */
+	public function tear_down() {
+		global $wp_query;
+		$wp_query = clone $this->original_wp_query;
+		parent::tear_down();
+	}
+
+	/**
+	 * Returns 'Product List' when no specific page context is detected.
+	 *
+	 * @return void
+	 */
+	public function test_returns_product_list_as_default() {
+		$this->assertEquals(
+			'Product List',
+			$this->gtag->get_list_name()
+		);
+	}
+
+	/**
+	 * Returns 'Search Results' on a WordPress search page.
+	 *
+	 * @return void
+	 */
+	public function test_returns_search_results_on_search_page() {
+		global $wp_query;
+		$wp_query->is_search = true;
+
+		$this->assertEquals(
+			'Search Results',
+			$this->gtag->get_list_name()
+		);
+	}
+
+	/**
+	 * Returns 'Shop' on the WooCommerce shop page.
+	 *
+	 * @return void
+	 */
+	public function test_returns_shop_on_shop_page() {
+		$page_id = wp_insert_post(
+			[
+				'post_type'   => 'page',
+				'post_status' => 'publish',
+				'post_title'  => 'Shop',
+			]
+		);
+		update_option( 'woocommerce_shop_page_id', $page_id );
+
+		global $wp_query;
+		$wp_query->is_page           = true;
+		$wp_query->queried_object    = get_post( $page_id );
+		$wp_query->queried_object_id = $page_id;
+
+		$this->assertEquals(
+			'Shop',
+			$this->gtag->get_list_name()
+		);
+	}
+
+	/**
+	 * Returns 'Category: <name>' on a product category archive page.
+	 *
+	 * @return void
+	 */
+	public function test_returns_category_name_on_product_category_page() {
+		$term = wp_insert_term( 'Women', 'product_cat' );
+
+		global $wp_query;
+		$wp_query->is_tax            = true;
+		$wp_query->queried_object    = get_term( $term['term_id'], 'product_cat' );
+		$wp_query->queried_object_id = $term['term_id'];
+
+		$this->assertEquals(
+			'Category: Women',
+			$this->gtag->get_list_name()
+		);
+	}
+
+	/**
+	 * Returns 'Tag: <name>' on a product tag archive page.
+	 *
+	 * @return void
+	 */
+	public function test_returns_tag_name_on_product_tag_page() {
+		$term = wp_insert_term( 'Sale', 'product_tag' );
+
+		global $wp_query;
+		$wp_query->is_tax            = true;
+		$wp_query->queried_object    = get_term( $term['term_id'], 'product_tag' );
+		$wp_query->queried_object_id = $term['term_id'];
+
+		$this->assertEquals(
+			'Tag: Sale',
+			$this->gtag->get_list_name()
+		);
+	}
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #324.

All `view_item_list` GA4 events were sending hardcoded values (`engagement` / `Viewing products`) for `item_list_id` and `item_list_name` regardless of where on the site the product list appeared. This made shop pages, category archives, search results, and tag pages indistinguishable in GA4 reports.

This fix derives both fields from the list context:

- **For block-based pages**: `listName` is already passed in from WooCommerce Blocks via the `product-list-render` action. It is now used directly for `item_list_name`, with a slugified version as `item_list_id`.
- **For classic pages**: a new `get_list_name()` PHP method detects the current page context (`is_shop()`, `is_product_category()`, `is_product_tag()`, `is_search()`) and passes the resolved name to JS via `wp_head`.

**Examples of what changes:**

| Context | Before | After |
|---|---|---|
| WooCommerce shop page (classic) | `engagement` / `Viewing products` | `shop` / `Shop` |
| Product category archive | `engagement` / `Viewing products` | `category_women` / `Category: Women` |
| Search results | `engagement` / `Viewing products` | `search_results` / `Search Results` |
| Products block / Product Collection block | `engagement` / `Viewing products` | `product_list` / `Product List` |
| All Products block (legacy) | `engagement` / `Viewing products` | `woocommerce_all_products` / `woocommerce/all-products` |

### Checks:
* [x] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [x] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Detailed test instructions:

1. On a WooCommerce store with GA4 configured, visit the shop page (`/shop`)
2. Open your browser's network tab and filter for requests to `google-analytics.com` or `gtag`
3. Look for a `view_item_list` event — confirm `item_list_id` is `shop` and `item_list_name` is `Shop`
4. Repeat on a product category page — expect `category_<slug>` / `Category: <name>`
5. Repeat on a search results page — expect `search_results` / `Search Results`
6. On a page using the Products or Product Collection block, confirm `product_list` / `Product List`
7. On a page using the All Products (legacy) block, confirm `woocommerce_all_products` / `woocommerce/all-products`

QIT automated regression tests will run on this PR.

### Additional details:

One note on the e2e test assertions: the classic shop test (`classic-shop`) uses a custom WordPress page with a shortcode rather than the actual WooCommerce shop page, so `is_shop()` does not fire for it — the test correctly asserts `product_list` / `Product List` for that case. Real WooCommerce shop/category/tag/search pages will receive the specific contextual values.

### Changelog entry

> Fix - `item_list_id` and `item_list_name` in `view_item_list` GA4 events now reflect the actual page context (shop, category, tag, search) instead of hardcoded placeholder values.

---

_This PR was created during the [Woo Bug Blitz](https://woohappyp2.wordpress.com/2026/03/18/extensions-bug-blitz/) via team Ceres' [`/bug-blitz` Claude skill](https://github.com/Automattic/public-resources-squad/blob/trunk/.claude/skills/bug-blitz/skill.md). The fix was authored with Claude Code assistance by a Happiness Engineer who encounters this bug in support tickets._