### PR TITLE
Bump minimum WooCommerce to 10.6, tested up to 10.7

### DIFF
--- a/woocommerce-google-analytics-integration.php
+++ b/woocommerce-google-analytics-integration.php
@@ -6,8 +6,8 @@
  * Author: WooCommerce
  * Author URI: https://woocommerce.com
  * Version: 2.1.22
- * WC requires at least: 10.5
- * WC tested up to: 10.6
+ * WC requires at least: 10.6
+ * WC tested up to: 10.7
  * Requires at least: 6.8
  * Requires Plugins: woocommerce
  * Tested up to: 6.9
@@ -27,7 +27,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 if ( ! class_exists( 'WC_Google_Analytics_Integration' ) ) {
 
 	define( 'WC_GOOGLE_ANALYTICS_INTEGRATION_VERSION', '2.1.22' ); // WRCS: DEFINED_VERSION.
-	define( 'WC_GOOGLE_ANALYTICS_INTEGRATION_MIN_WC_VER', '10.5' );
+	define( 'WC_GOOGLE_ANALYTICS_INTEGRATION_MIN_WC_VER', '10.6' );
 
 	// Maybe show the GA Pro notice on plugin activation.
 	register_activation_hook(


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR bumps the minimum required WooCommerce to 10.6 to align with the L-1 of the released WooCommerce 10.7.

### Changelog entry


Made with [Cursor](https://cursor.com)