### PR TITLE
Add CodeRabbit configuration and ignore .claude/settings.local.json

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: en-US
+tone_instructions: 'Keep reviews concise. No filler praise or emoji. Focus on real issues only; if no issues, say so briefly.'
+
+reviews:
+  profile: chill
+  path_filters:
+    - 'includes/**/*.php'
+    - 'tests/**/*.php'
+    - 'assets/js/src/**/*.{js,jsx,ts,tsx}'
+    - 'woocommerce-google-analytics-integration.php'
+  path_instructions:
+    - path: '**/*.{php,html,js,jsx,ts,tsx}'
+      instructions: |
+        - Consider full file context before commenting; do not rely only on the diff.
+        - Use line numbers from the actual file, not from the diff.
+        - Only report issues you are certain about; if unsure, say so explicitly.
+        - Do not flag standard WordPress/WooCommerce patterns (e.g. $wpdb->posts interpolation, get_posts() with posts_per_page => -1 for bounded queries).
+        - Focus on real bugs, logic errors, security vulnerabilities, and missing edge cases — not stylistic preferences.
+        - Categorize each finding as: Bug, Security, Performance, or Suggestion.
+        - For each finding: give file path, line number, brief explanation of why it is a problem, and a concrete fix.
+        - If there are no real issues, say "No issues found"; do not invent problems to fill the review.
+  poem: false
+  in_progress_fortune: false
+  high_level_summary_instructions: "Write a brief summary listing the number of issues found and their categories (Bug, Security, Performance, Suggestion). If no issues, state 'No issues found.'"
+
+knowledge_base:
+  code_guidelines:
+    enabled: true
+    filePatterns:
+      - 'CLAUDE.md'
+      - 'AGENTS.md'

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ tests/e2e/test-results
 dist
 
 woocommerce-google-analytics-integration.zip
+.claude/settings.local.json


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds a `.coderabbit.yaml` configuration file to enable CodeRabbit for code reviews in this repository, mirroring the setup used in the MailPoet project. It also updates `.gitignore` to ignore `.claude/settings.local.json`.

Closes # .

### Checks:
* [x] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Screenshots:

_N/A_

### Detailed test instructions:

1. Verify `.coderabbit.yaml` exists in the root.
2. Verify `.claude/settings.local.json` is listed in `.gitignore`.
3. Check if CodeRabbit picks up the configuration on a new PR.

### Additional details:

_N/A_

### Changelog entry

> Dev - Add CodeRabbit configuration and ignore .claude/settings.local.json
