### PR TITLE
Fix events not tracked on empty cart page with Product Collection block

### DIFF
--- a/assets/js/src/integrations/blocks.js
+++ b/assets/js/src/integrations/blocks.js
@@ -1043,15 +1043,27 @@ export const blocksTracking = ( getEventHandler ) => {
 	// cache populated above by product-list-render.
 	if ( ! viewedProductListenerAttached ) {
 		viewedProductListenerAttached = true;
-		document.body.addEventListener( 'wc-blocks_viewed_product', ( event ) => {
-			const { productId } = event.detail ?? {};
-			if ( productId ) {
-				const product = getProductFromID( productId, [], null );
-				safeTrackEvent( getEventHandler, 'select_content', {
-					product,
-				} );
+		document.body.addEventListener(
+			'wc-blocks_viewed_product',
+			( event ) => {
+				const { productId } = event.detail ?? {};
+				const productIdString = String( productId ?? '' );
+				if ( /^[1-9]\d*$/.test( productIdString ) ) {
+					const normalizedProductId = parseInt(
+						productIdString,
+						10
+					).toString();
+					const product = getProductFromID(
+						normalizedProductId,
+						[],
+						null
+					) ?? { id: normalizedProductId };
+					safeTrackEvent( getEventHandler, 'select_content', {
+						product,
+					} );
+				}
 			}
-		} );
+		);
 	}
 };
 

--- a/assets/js/src/integrations/blocks.js
+++ b/assets/js/src/integrations/blocks.js
@@ -101,7 +101,7 @@ const wasRecentlyAdded = ( product ) =>
 		recentlyAdded.has( token )
 	);
 
-let viewedProductListenerAttached = false;
+let viewedProductListener = null;
 
 /**
  * Get currency settings from our plugin's settings.
@@ -1041,30 +1041,36 @@ export const blocksTracking = ( getEventHandler ) => {
 	// product-view-link hook only fires for the All Products block; this event
 	// covers Product Collection. Product data is resolved via the block products
 	// cache populated above by product-list-render.
-	if ( ! viewedProductListenerAttached ) {
-		viewedProductListenerAttached = true;
-		document.body.addEventListener(
+	if ( viewedProductListener ) {
+		document.body.removeEventListener(
 			'wc-blocks_viewed_product',
-			( event ) => {
-				const { productId } = event.detail ?? {};
-				const productIdString = String( productId ?? '' );
-				if ( /^[1-9]\d*$/.test( productIdString ) ) {
-					const normalizedProductId = parseInt(
-						productIdString,
-						10
-					).toString();
-					const product = getProductFromID(
-						normalizedProductId,
-						[],
-						null
-					) ?? { id: normalizedProductId };
-					safeTrackEvent( getEventHandler, 'select_content', {
-						product,
-					} );
-				}
-			}
+			viewedProductListener
 		);
 	}
+
+	viewedProductListener = ( event ) => {
+		const { productId } = event.detail ?? {};
+		const productIdString = String( productId ?? '' );
+		if ( /^[1-9]\d*$/.test( productIdString ) ) {
+			const normalizedProductId = parseInt(
+				productIdString,
+				10
+			).toString();
+			const product = getProductFromID(
+				normalizedProductId,
+				[],
+				null
+			) ?? { id: normalizedProductId };
+			safeTrackEvent( getEventHandler, 'select_content', {
+				product,
+			} );
+		}
+	};
+
+	document.body.addEventListener(
+		'wc-blocks_viewed_product',
+		viewedProductListener
+	);
 };
 
 /*

--- a/assets/js/src/integrations/blocks.js
+++ b/assets/js/src/integrations/blocks.js
@@ -1,5 +1,9 @@
 import { removeAction } from '@wordpress/hooks';
-import { addUniqueAction, getProductFromID } from '../utils';
+import {
+	addUniqueAction,
+	getProductFromID,
+	cacheBlockProducts,
+} from '../utils';
 import { ACTION_PREFIX, NAMESPACE } from '../constants';
 
 const recentlyRemovedProducts = new Set();
@@ -1013,7 +1017,15 @@ export const blocksTracking = ( getEventHandler ) => {
 	addUniqueAction(
 		`${ ACTION_PREFIX }-product-list-render`,
 		NAMESPACE,
-		( data ) => safeTrackEvent( getEventHandler, 'view_item_list', data )
+		( data ) => {
+			// Cache block-rendered products so classic.js click handlers can look
+			// them up via getProductFromID when window.ga4w.data.products is empty
+			// (e.g. Product Collection block on the empty cart page).
+			if ( data?.products ) {
+				cacheBlockProducts( data.products );
+			}
+			safeTrackEvent( getEventHandler, 'view_item_list', data );
+		}
 	);
 
 	addUniqueAction(
@@ -1021,6 +1033,19 @@ export const blocksTracking = ( getEventHandler ) => {
 		NAMESPACE,
 		( data ) => safeTrackEvent( getEventHandler, 'select_content', data )
 	);
+
+	// Listen for the stable WooCommerce 9.4+ DOM event fired when a user clicks a
+	// product link inside a Product Collection block. The experimental
+	// product-view-link hook only fires for the All Products block; this event
+	// covers Product Collection. Product data is resolved via the block products
+	// cache populated above by product-list-render.
+	document.body.addEventListener( 'wc-blocks_viewed_product', ( event ) => {
+		const { productId } = event.detail ?? {};
+		if ( productId ) {
+			const product = getProductFromID( productId, [], null );
+			getEventHandler( 'select_content' )( { product } );
+		}
+	} );
 };
 
 /*

--- a/assets/js/src/integrations/blocks.js
+++ b/assets/js/src/integrations/blocks.js
@@ -101,6 +101,8 @@ const wasRecentlyAdded = ( product ) =>
 		recentlyAdded.has( token )
 	);
 
+let viewedProductListenerAttached = false;
+
 /**
  * Get currency settings from our plugin's settings.
  *
@@ -1039,13 +1041,18 @@ export const blocksTracking = ( getEventHandler ) => {
 	// product-view-link hook only fires for the All Products block; this event
 	// covers Product Collection. Product data is resolved via the block products
 	// cache populated above by product-list-render.
-	document.body.addEventListener( 'wc-blocks_viewed_product', ( event ) => {
-		const { productId } = event.detail ?? {};
-		if ( productId ) {
-			const product = getProductFromID( productId, [], null );
-			getEventHandler( 'select_content' )( { product } );
-		}
-	} );
+	if ( ! viewedProductListenerAttached ) {
+		viewedProductListenerAttached = true;
+		document.body.addEventListener( 'wc-blocks_viewed_product', ( event ) => {
+			const { productId } = event.detail ?? {};
+			if ( productId ) {
+				const product = getProductFromID( productId, [], null );
+				safeTrackEvent( getEventHandler, 'select_content', {
+					product,
+				} );
+			}
+		} );
+	}
 };
 
 /*

--- a/assets/js/src/integrations/classic.js
+++ b/assets/js/src/integrations/classic.js
@@ -350,7 +350,9 @@ export function classicTracking(
 			} );
 		} );
 
-	// Handle select_content and add_to_cart in Products (Beta) block, Product Collection (Beta) block.
+	// Handle select_content and add_to_cart in Products (Beta) block, and
+	// add_to_cart in Product Collection. Product Collection select_content is
+	// tracked through the stable wc-blocks_viewed_product DOM event.
 	// Attach click event listeners to a whole product card, as some links may not have the product_id data attribute.
 	document
 		.querySelectorAll(
@@ -395,7 +397,10 @@ export function classicTracking(
 							cart
 						),
 					} );
-				} else if ( viewLink || button || nameLink ) {
+				} else if (
+					! productCard.closest( '.wc-block-product-template' ) &&
+					( viewLink || button || nameLink )
+				) {
 					// Product image or add-to-cart-like button.
 					getEventHandler( 'select_content' )( {
 						product: getProductFromID(

--- a/assets/js/src/tracker/data-formatting.js
+++ b/assets/js/src/tracker/data-formatting.js
@@ -20,7 +20,7 @@ export const view_item_list = ( {
 	products,
 	listName = __( 'Product List', 'woocommerce-google-analytics-integration' ),
 } ) => {
-	if ( products.length === 0 ) {
+	if ( ! products?.length ) {
 		return false;
 	}
 

--- a/assets/js/src/utils/index.js
+++ b/assets/js/src/utils/index.js
@@ -3,12 +3,25 @@ import { addAction, removeAction } from '@wordpress/hooks';
 // Fallback for classic.js click handlers when window.ga4w.data.products is empty (e.g. empty cart page).
 const blockProductsCache = [];
 
+const hasMatchingProductId = ( id, search ) =>
+	id !== undefined &&
+	id !== null &&
+	search !== undefined &&
+	search !== null &&
+	String( id ) === String( search );
+
 export const cacheBlockProducts = ( products ) => {
 	if ( ! Array.isArray( products ) ) {
 		return;
 	}
 	products.forEach( ( product ) => {
-		if ( ! blockProductsCache.some( ( { id } ) => id === product.id ) ) {
+		if (
+			product?.id !== undefined &&
+			product?.id !== null &&
+			! blockProductsCache.some( ( { id } ) =>
+				hasMatchingProductId( id, product.id )
+			)
+		) {
 			blockProductsCache.push( product );
 		}
 	} );
@@ -193,8 +206,10 @@ const formatCategoryKey = ( index ) => {
  */
 export const getProductFromID = ( search, products, cart ) => {
 	return (
-		products?.find( ( { id } ) => id === search ) ??
-		cart?.items?.find( ( { id } ) => id === search ) ??
-		blockProductsCache.find( ( { id } ) => id === search )
+		products?.find( ( { id } ) => hasMatchingProductId( id, search ) ) ??
+		cart?.items?.find( ( { id } ) => hasMatchingProductId( id, search ) ) ??
+		blockProductsCache.find( ( { id } ) =>
+			hasMatchingProductId( id, search )
+		)
 	);
 };

--- a/assets/js/src/utils/index.js
+++ b/assets/js/src/utils/index.js
@@ -1,18 +1,8 @@
 import { addAction, removeAction } from '@wordpress/hooks';
 
-/**
- * Module-level cache for products rendered by WooCommerce Blocks (e.g. Product Collection block).
- * Populated by cacheBlockProducts when the product-list-render action fires.
- * Used as a fallback in getProductFromID so classic.js click handlers can track
- * events for products that weren't captured via the PHP woocommerce_loop_add_to_cart_link hook.
- */
+// Fallback for classic.js click handlers when window.ga4w.data.products is empty (e.g. empty cart page).
 const blockProductsCache = [];
 
-/**
- * Adds products to the block products cache, skipping any already present by ID.
- *
- * @param {Object[]} products Array of product objects from WooCommerce Blocks.
- */
 export const cacheBlockProducts = ( products ) => {
 	if ( ! Array.isArray( products ) ) {
 		return;

--- a/assets/js/src/utils/index.js
+++ b/assets/js/src/utils/index.js
@@ -197,11 +197,11 @@ const formatCategoryKey = ( index ) => {
 };
 
 /**
- * Searches through the global wcgaiData.products object to find a single product by its ID
+ * Searches available product sources to find a single product by ID.
  *
- * @param {number}   search   The ID of the product to search for
- * @param {Object[]} products The array of available products
- * @param {Object}   cart     The cart object
+ * @param {number|string} search   The ID of the product to search for
+ * @param {Object[]}      products The array of available products
+ * @param {Object}        cart     The cart object
  * @return {Object|undefined} The product object or undefined if not found
  */
 export const getProductFromID = ( search, products, cart ) => {

--- a/assets/js/src/utils/index.js
+++ b/assets/js/src/utils/index.js
@@ -14,6 +14,9 @@ const blockProductsCache = [];
  * @param {Object[]} products Array of product objects from WooCommerce Blocks.
  */
 export const cacheBlockProducts = ( products ) => {
+	if ( ! Array.isArray( products ) ) {
+		return;
+	}
 	products.forEach( ( product ) => {
 		if ( ! blockProductsCache.some( ( { id } ) => id === product.id ) ) {
 			blockProductsCache.push( product );

--- a/assets/js/src/utils/index.js
+++ b/assets/js/src/utils/index.js
@@ -1,6 +1,27 @@
 import { addAction, removeAction } from '@wordpress/hooks';
 
 /**
+ * Module-level cache for products rendered by WooCommerce Blocks (e.g. Product Collection block).
+ * Populated by cacheBlockProducts when the product-list-render action fires.
+ * Used as a fallback in getProductFromID so classic.js click handlers can track
+ * events for products that weren't captured via the PHP woocommerce_loop_add_to_cart_link hook.
+ */
+const blockProductsCache = [];
+
+/**
+ * Adds products to the block products cache, skipping any already present by ID.
+ *
+ * @param {Object[]} products Array of product objects from WooCommerce Blocks.
+ */
+export const cacheBlockProducts = ( products ) => {
+	products.forEach( ( product ) => {
+		if ( ! blockProductsCache.some( ( { id } ) => id === product.id ) ) {
+			blockProductsCache.push( product );
+		}
+	} );
+};
+
+/**
  * Formats data into the productFieldObject shape.
  *
  * @see https://developers.google.com/analytics/devguides/collection/gtagjs/enhanced-ecommerce#product-data
@@ -180,6 +201,7 @@ const formatCategoryKey = ( index ) => {
 export const getProductFromID = ( search, products, cart ) => {
 	return (
 		products?.find( ( { id } ) => id === search ) ??
-		cart?.items?.find( ( { id } ) => id === search )
+		cart?.items?.find( ( { id } ) => id === search ) ??
+		blockProductsCache.find( ( { id } ) => id === search )
 	);
 };

--- a/tests/e2e/specs/gtag-events/classic-pages.test.js
+++ b/tests/e2e/specs/gtag-events/classic-pages.test.js
@@ -350,6 +350,17 @@ test.describe( 'GTag events on classic pages', () => {
 			const data = getEventData( request, 'view_item_list' );
 			expect( data[ 'ep.item_list_id' ] ).toEqual( 'product_list' );
 			expect( data[ 'ep.item_list_name' ] ).toEqual( 'Product List' );
+			const products = [ data.product1, data.product2 ];
+			const simple = products.find(
+				( p ) => p?.id === simpleProductID.toString()
+			);
+			expect( simple ).toMatchObject( {
+				id: simpleProductID.toString(),
+				nm: 'Simple product',
+				ln: 'Product List',
+				ca: 'Uncategorized',
+				pr: simpleProductPrice.toString(),
+			} );
 		} );
 	} );
 

--- a/tests/e2e/specs/gtag-events/classic-pages.test.js
+++ b/tests/e2e/specs/gtag-events/classic-pages.test.js
@@ -19,6 +19,7 @@ import {
 	createClassicShopPage,
 } from '../../utils/create-page';
 import {
+	blockProductAddToCart,
 	checkout,
 	simpleProductAddToCart,
 	variableProductAddToCart,
@@ -344,7 +345,9 @@ test.describe( 'GTag events on classic pages', () => {
 		const event = trackGtagEvent( page, 'view_item_list' );
 
 		// Navigate without adding any items — cart is empty.
-		await page.goto( 'classic-empty-cart-with-products?orderby=date' );
+		await page.goto(
+			'classic-empty-cart-with-product-collection?orderby=date'
+		);
 
 		await event.then( ( request ) => {
 			const data = getEventData( request, 'view_item_list' );
@@ -372,17 +375,10 @@ test.describe( 'GTag events on classic pages', () => {
 		const event = trackGtagEvent( page, 'add_to_cart' );
 
 		// Navigate without adding any items — cart is empty.
-		await page.goto( 'classic-empty-cart-with-products?orderby=date' );
-		// Scope to `.add_to_cart_button` to avoid matching the cart table's
-		// remove link, which also carries [data-product_id] once the item is
-		// in the cart.
-		const addToCart = `.add_to_cart_button[data-product_id="${ simpleProductID }"]`;
-		const addToCartButton = await page.locator( addToCart ).first();
-		await addToCartButton.click();
-		// The cart page reloads after AJAX add-to-cart, so toHaveClass( /added/ )
-		// is unreliable here — the "added" class is gone by the time the reload
-		// settles. Wait for the navigation to finish instead.
-		await page.waitForLoadState( 'load' );
+		await page.goto(
+			'classic-empty-cart-with-product-collection?orderby=date'
+		);
+		await blockProductAddToCart( page, simpleProductID );
 
 		await event.then( ( request ) => {
 			const data = getEventData( request, 'add_to_cart' );
@@ -401,16 +397,20 @@ test.describe( 'GTag events on classic pages', () => {
 	} ) => {
 		await createClassicEmptyCartPageWithProducts();
 
-		const event = trackGtagEvent( page, 'select_content' );
+		const listEvent = trackGtagEvent( page, 'view_item_list' );
 
 		// Navigate without adding any items — cart is empty.
-		await page.goto( 'classic-empty-cart-with-products?orderby=date' );
+		await page.goto(
+			'classic-empty-cart-with-product-collection?orderby=date'
+		);
+		await listEvent;
 
-		// Click the product title/image link — wc-blocks_viewed_product fires
+		// Click the product image link — wc-blocks_viewed_product fires
 		// before the browser navigates away.
+		const event = trackGtagEvent( page, 'select_content' );
 		const productLink = page
 			.locator(
-				`li.post-${ simpleProductID } a.woocommerce-loop-product__link`
+				`li.post-${ simpleProductID } .wc-block-components-product-image a`
 			)
 			.first();
 		await Promise.all( [ event, productLink.click() ] );

--- a/tests/e2e/specs/gtag-events/classic-pages.test.js
+++ b/tests/e2e/specs/gtag-events/classic-pages.test.js
@@ -385,6 +385,34 @@ test.describe( 'GTag events on classic pages', () => {
 		} );
 	} );
 
+	test( 'Select content event is sent from empty cart page', async ( {
+		page,
+	} ) => {
+		await createClassicEmptyCartPageWithProducts();
+
+		const event = trackGtagEvent( page, 'select_content' );
+
+		// Navigate without adding any items — cart is empty.
+		await page.goto( 'classic-empty-cart-with-products?orderby=date' );
+
+		// Click the product title/image link — wc-blocks_viewed_product fires
+		// before the browser navigates away.
+		const productLink = page
+			.locator(
+				`li.post-${ simpleProductID } a.woocommerce-loop-product__link`
+			)
+			.first();
+		await Promise.all( [ event, productLink.click() ] );
+
+		await event.then( ( request ) => {
+			const data = getEventData( request, 'select_content' );
+			expect( data[ 'ep.content_type' ] ).toEqual( 'product' );
+			expect( data[ 'ep.content_id' ] ).toEqual(
+				simpleProductID.toString()
+			);
+		} );
+	} );
+
 	test( 'Purchase event is sent on order complete page', async ( {
 		page,
 	} ) => {

--- a/tests/e2e/specs/gtag-events/classic-pages.test.js
+++ b/tests/e2e/specs/gtag-events/classic-pages.test.js
@@ -15,6 +15,7 @@ import {
 import {
 	createClassicCartPage,
 	createClassicCheckoutPage,
+	createClassicEmptyCartPageWithProducts,
 	createClassicShopPage,
 } from '../../utils/create-page';
 import {
@@ -332,6 +333,49 @@ test.describe( 'GTag events on classic pages', () => {
 				simpleProductPrice.toString()
 			);
 			expect( data[ 'ep.payment_type' ] ).toBeTruthy();
+		} );
+	} );
+
+	test( 'View item list event is sent on empty cart page with products', async ( {
+		page,
+	} ) => {
+		await createClassicEmptyCartPageWithProducts();
+
+		const event = trackGtagEvent( page, 'view_item_list' );
+
+		// Navigate without adding any items — cart is empty.
+		await page.goto( 'classic-empty-cart-with-products?orderby=date' );
+
+		await event.then( ( request ) => {
+			const data = getEventData( request, 'view_item_list' );
+			expect( data[ 'ep.item_list_id' ] ).toEqual( 'engagement' );
+			expect( data[ 'ep.item_list_name' ] ).toEqual( 'Viewing products' );
+		} );
+	} );
+
+	test( 'Add to cart event is sent from empty cart page', async ( {
+		page,
+	} ) => {
+		await createClassicEmptyCartPageWithProducts();
+
+		const event = trackGtagEvent( page, 'add_to_cart' );
+
+		// Navigate without adding any items — cart is empty.
+		await page.goto( 'classic-empty-cart-with-products?orderby=date' );
+		const addToCart = `[data-product_id="${ simpleProductID }"]`;
+		const addToCartButton = await page.locator( addToCart ).first();
+		await addToCartButton.click();
+		await expect( addToCartButton ).toHaveClass( /added/ );
+
+		await event.then( ( request ) => {
+			const data = getEventData( request, 'add_to_cart' );
+			expect( data.product1 ).toEqual( {
+				id: simpleProductID.toString(),
+				nm: 'Simple product',
+				ca: 'Uncategorized',
+				qt: '1',
+				pr: simpleProductPrice.toString(),
+			} );
 		} );
 	} );
 

--- a/tests/e2e/specs/gtag-events/classic-pages.test.js
+++ b/tests/e2e/specs/gtag-events/classic-pages.test.js
@@ -36,6 +36,7 @@ test.describe( 'GTag events on classic pages', () => {
 		await setSettings();
 		variableProductID = await createVariableProduct();
 		simpleProductID = await createSimpleProduct();
+		await createClassicEmptyCartPageWithProducts();
 	} );
 
 	test.afterAll( async () => {
@@ -340,8 +341,6 @@ test.describe( 'GTag events on classic pages', () => {
 	test( 'View item list event is sent on empty cart page with products', async ( {
 		page,
 	} ) => {
-		await createClassicEmptyCartPageWithProducts();
-
 		const event = trackGtagEvent( page, 'view_item_list' );
 
 		// Navigate without adding any items — cart is empty.
@@ -370,8 +369,6 @@ test.describe( 'GTag events on classic pages', () => {
 	test( 'Add to cart event is sent from empty cart page', async ( {
 		page,
 	} ) => {
-		await createClassicEmptyCartPageWithProducts();
-
 		const event = trackGtagEvent( page, 'add_to_cart' );
 
 		// Navigate without adding any items — cart is empty.
@@ -395,8 +392,6 @@ test.describe( 'GTag events on classic pages', () => {
 	test( 'Select content event is sent from empty cart page', async ( {
 		page,
 	} ) => {
-		await createClassicEmptyCartPageWithProducts();
-
 		const listEvent = trackGtagEvent( page, 'view_item_list' );
 
 		// Navigate without adding any items — cart is empty.

--- a/tests/e2e/specs/gtag-events/classic-pages.test.js
+++ b/tests/e2e/specs/gtag-events/classic-pages.test.js
@@ -348,8 +348,8 @@ test.describe( 'GTag events on classic pages', () => {
 
 		await event.then( ( request ) => {
 			const data = getEventData( request, 'view_item_list' );
-			expect( data[ 'ep.item_list_id' ] ).toEqual( 'engagement' );
-			expect( data[ 'ep.item_list_name' ] ).toEqual( 'Viewing products' );
+			expect( data[ 'ep.item_list_id' ] ).toEqual( 'product_list' );
+			expect( data[ 'ep.item_list_name' ] ).toEqual( 'Product List' );
 		} );
 	} );
 
@@ -362,10 +362,16 @@ test.describe( 'GTag events on classic pages', () => {
 
 		// Navigate without adding any items — cart is empty.
 		await page.goto( 'classic-empty-cart-with-products?orderby=date' );
-		const addToCart = `[data-product_id="${ simpleProductID }"]`;
+		// Scope to `.add_to_cart_button` to avoid matching the cart table's
+		// remove link, which also carries [data-product_id] once the item is
+		// in the cart.
+		const addToCart = `.add_to_cart_button[data-product_id="${ simpleProductID }"]`;
 		const addToCartButton = await page.locator( addToCart ).first();
 		await addToCartButton.click();
-		await expect( addToCartButton ).toHaveClass( /added/ );
+		// The cart page reloads after AJAX add-to-cart, so toHaveClass( /added/ )
+		// is unreliable here — the "added" class is gone by the time the reload
+		// settles. Wait for the navigation to finish instead.
+		await page.waitForLoadState( 'load' );
 
 		await event.then( ( request ) => {
 			const data = getEventData( request, 'add_to_cart' );

--- a/tests/e2e/utils/create-page.js
+++ b/tests/e2e/utils/create-page.js
@@ -72,6 +72,23 @@ export async function createClassicCheckoutPage() {
 }
 
 /**
+ * Creates a classic empty-cart page that also shows a product listing via shortcode.
+ * Used to test that events (view_item_list, add_to_cart, select_content) fire correctly
+ * when the cart is empty but products are visible on the page.
+ *
+ * @return {number} Created page ID.
+ */
+export async function createClassicEmptyCartPageWithProducts() {
+	const title = 'Classic Empty Cart With Products';
+	const content = '[woocommerce_cart]\n[products]';
+
+	return (
+		( await pageExistsByTitle( title ) ) ||
+		( await createPage( title, content ) )
+	);
+}
+
+/**
  * Creates a classic shop page using shortcodes.
  *
  * @return {number} Created page ID.

--- a/tests/e2e/utils/create-page.js
+++ b/tests/e2e/utils/create-page.js
@@ -72,15 +72,18 @@ export async function createClassicCheckoutPage() {
 }
 
 /**
- * Creates a classic empty-cart page that also shows a product listing via shortcode.
+ * Creates a classic empty-cart page that also shows a Product Collection block.
  * Used to test that events (view_item_list, add_to_cart, select_content) fire correctly
  * when the cart is empty but products are visible on the page.
  *
  * @return {number} Created page ID.
  */
 export async function createClassicEmptyCartPageWithProducts() {
-	const title = 'Classic Empty Cart With Products';
-	const content = '[woocommerce_cart]\n[products]';
+	const title = 'Classic Empty Cart With Product Collection';
+	const {
+		pageContent,
+	} = require( './fixtures/product-collection.fixture.json' );
+	const content = `[woocommerce_cart]\n${ pageContent }`;
 
 	return (
 		( await pageExistsByTitle( title ) ) ||


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #389, closes STORMA-37.

When the cart is empty, `window.ga4w.data.products` is an empty array, so classic page click handlers had no way to look up product data for items rendered by a Product Collection block on the same page. This caused `view_item_list`, `add_to_cart`, and `select_content` tracking to miss item data or not fire as expected.

**Changes:**

- **Block products cache** (`assets/js/src/utils/index.js`): Adds a module-level cache for block-rendered products and lets `getProductFromID` fall back to that cache after checking page products and cart items.
- **Cache safety** (`assets/js/src/utils/index.js`): Ignores non-array cache input, skips products without an ID, and compares string/number product IDs consistently.
- **Cache population** (`assets/js/src/integrations/blocks.js`): Caches Product Collection products from the `product-list-render` action before firing `view_item_list`.
- **Product Collection clicks** (`assets/js/src/integrations/blocks.js`): Uses the WooCommerce `wc-blocks_viewed_product` DOM event to track Product Collection `select_content` clicks, with idempotent listener registration and product ID validation.
- **Classic tracking compatibility** (`assets/js/src/integrations/classic.js`): Preserves Product Collection `add_to_cart` tracking while avoiding duplicate `select_content` events.
- **E2E coverage** (`tests/e2e/`): Covers `view_item_list`, `add_to_cart`, and `select_content` on a classic empty-cart page that also renders a Product Collection block.

### Checks:
* [x] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Detailed test instructions:

1. Install the plugin on a WooCommerce store.
2. Create a page containing `[woocommerce_cart]` followed by a Product Collection block.
3. Visit the page without adding anything to the cart.
4. Confirm a `view_item_list` gtag event fires with item data for the visible products.
5. Click "Add to cart" on a Product Collection product and confirm an `add_to_cart` event fires with correct item data.
6. Click a Product Collection product image/link and confirm a single `select_content` event fires with correct `content_type` and `content_id`.

### Local verification:

- `npm run lint:js`
- `npm run dev`
- `git diff --check`
- `npm run test:e2e -- tests/e2e/specs/gtag-events/classic-pages.test.js --grep "empty cart page"`
- `npm run test:e2e -- tests/e2e/specs/gtag-events/blocks-pages.test.js --grep "product collection block shop page"`

### Changelog entry

> Fix - Track view_item_list, add_to_cart, and select_content events correctly when the cart is empty and products are rendered via a Product Collection block.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Issues Found: 2

### Bug
1. **Potential duplicate event listeners**: The `wc-blocks_viewed_product` listener in `blocksTracking()` is registered inside the function without a deduplication guard, which could cause multiple select_content events to fire if `blocksTracking()` runs more than once. (The PR appears to address this by storing a reference and removing any previously-registered listener before re-adding, but this should be verified as a critical fix.)

### Suggestion
1. **Incomplete test coverage documentation**: The docstring for `createClassicEmptyCartWithProducts` lists select_content as covered, but the PR review noted that an explicit test for the select_content event was not added in the E2E tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->