### PR TITLE
Add checkout journey events

### DIFF
--- a/assets/js/src/integrations/blocks.js
+++ b/assets/js/src/integrations/blocks.js
@@ -3,6 +3,8 @@ import { addUniqueAction, getProductFromID } from '../utils';
 import { ACTION_PREFIX, NAMESPACE } from '../constants';
 
 const recentlyRemovedProducts = new Set();
+let addShippingInfoTracked = false;
+let addPaymentInfoTracked = false;
 
 /*
  * Track recently dispatched add_to_cart events so the cart-add-item hook and
@@ -130,6 +132,45 @@ const getCartData = () => {
 
 const getProductDedupKey = ( product ) =>
 	product?.key ?? product?.id ?? product?.name;
+
+const getCheckoutCartData = ( storeCart ) =>
+	storeCart?.items?.length > 0 ? storeCart : window.ga4w?.data?.cart;
+
+const getActivePaymentMethod = () =>
+	window.wp?.data?.select?.( 'wc/store/payment' )?.getActivePaymentMethod?.();
+
+const getAllShippingRates = ( storeCart ) =>
+	storeCart?.shipping_rates?.flatMap(
+		( shippingPackage ) => shippingPackage.shipping_rates ?? []
+	) ?? [];
+
+const findShippingRateName = ( storeCart, rateId ) =>
+	getAllShippingRates( storeCart ).find(
+		( shippingRate ) => shippingRate.rate_id === rateId
+	)?.name;
+
+// Returns the human-readable name of the selected shipping rate when available
+// (GA4's `shipping_tier` is meant to be the user-facing tier label, e.g. "Free
+// Shipping" — not the machine rate id "free_shipping:1"). Falls back to the
+// rate id if no name is available.
+const getSelectedShippingRate = ( storeCart ) => {
+	const selected = getAllShippingRates( storeCart ).find(
+		( shippingRate ) => shippingRate.selected
+	);
+
+	return selected?.name ?? selected?.rate_id;
+};
+
+const trackCheckoutEvent = ( eventName, getEventHandler, data = {} ) => {
+	const storeCart = getCheckoutCartData( data.storeCart );
+
+	if ( ! storeCart?.items?.length ) {
+		return false;
+	}
+
+	safeTrackEvent( getEventHandler, eventName, { ...data, storeCart } );
+	return true;
+};
 
 /**
  * Parse a price string into a numeric value using currency settings.
@@ -838,29 +879,76 @@ export const blocksTracking = ( getEventHandler ) => {
 		`${ ACTION_PREFIX }-checkout-render-checkout-form`,
 		NAMESPACE,
 		( data ) => {
-			try {
-				/*
-				 * WooCommerce 10.4+ may fire this event before cart data is fully loaded.
-				 * If storeCart is empty or missing items, fall back to the cart data
-				 * provided by the server via window.ga4w.data.cart.
-				 */
-				const storeCart = data?.storeCart;
-				const cartData =
-					storeCart?.items?.length > 0
-						? storeCart
-						: window.ga4w?.data?.cart;
+			addShippingInfoTracked = false;
+			addPaymentInfoTracked = false;
+			trackCheckoutEvent( 'begin_checkout', getEventHandler, data );
+		}
+	);
 
-				if ( cartData ) {
-					safeTrackEvent( getEventHandler, 'begin_checkout', {
-						storeCart: cartData,
-					} );
+	addUniqueAction(
+		`${ ACTION_PREFIX }-checkout-set-selected-shipping-rate`,
+		NAMESPACE,
+		( data ) => {
+			const storeCart = getCheckoutCartData( data.storeCart );
+			addShippingInfoTracked = trackCheckoutEvent(
+				'add_shipping_info',
+				getEventHandler,
+				{
+					...data,
+					shippingTier:
+						findShippingRateName(
+							storeCart,
+							data.shippingRateId
+						) ?? data.shippingRateId,
 				}
-			} catch ( error ) {
-				warnTrackingError(
-					'could not process begin_checkout tracking.',
-					error
+			);
+		}
+	);
+
+	addUniqueAction(
+		`${ ACTION_PREFIX }-checkout-set-active-payment-method`,
+		NAMESPACE,
+		( data ) => {
+			addPaymentInfoTracked = trackCheckoutEvent(
+				'add_payment_info',
+				getEventHandler,
+				{
+					...data,
+					paymentType: data.paymentMethodSlug,
+				}
+			);
+		}
+	);
+
+	addUniqueAction(
+		`${ ACTION_PREFIX }-checkout-submit`,
+		NAMESPACE,
+		( data ) => {
+			const shippingTier = getSelectedShippingRate( data.storeCart );
+
+			if ( ! addShippingInfoTracked && shippingTier ) {
+				addShippingInfoTracked = trackCheckoutEvent(
+					'add_shipping_info',
+					getEventHandler,
+					{
+						...data,
+						shippingTier,
+					}
 				);
 			}
+
+			if ( addPaymentInfoTracked ) {
+				return;
+			}
+
+			addPaymentInfoTracked = trackCheckoutEvent(
+				'add_payment_info',
+				getEventHandler,
+				{
+					...data,
+					paymentType: getActivePaymentMethod(),
+				}
+			);
 		}
 	);
 

--- a/assets/js/src/integrations/blocks.js
+++ b/assets/js/src/integrations/blocks.js
@@ -139,10 +139,41 @@ const getCheckoutCartData = ( storeCart ) =>
 const getActivePaymentMethod = () =>
 	window.wp?.data?.select?.( 'wc/store/payment' )?.getActivePaymentMethod?.();
 
-const getAllShippingRates = ( storeCart ) =>
-	storeCart?.shipping_rates?.flatMap(
+// The live cart from the Blocks data store. This is the source of truth for the
+// available shipping rates (with their human-readable names) — the set-selected
+// shipping-rate hook only carries the rate id, and the static server cart has no
+// rates at all, which is why we previously leaked the machine rate id as
+// shipping_tier.
+const getStoreCartData = () =>
+	window.wp?.data?.select?.( 'wc/store/cart' )?.getCartData?.();
+
+// The Blocks data store exposes the shipping packages under the camelCased
+// `shippingRates`, while hook payloads and the static server cart use the
+// snake_cased `shipping_rates`. Each package's inner rate array (and the rate
+// fields rate_id / name / selected) is snake_cased in both. Normalise so we can
+// read the rates from whichever source actually has them.
+const getShippingPackages = ( cart ) =>
+	cart?.shippingRates ?? cart?.shipping_rates ?? [];
+
+// Resolve the user-facing payment method title (e.g. "Cash on delivery") from
+// the server-provided gateway data, keyed by the payment method slug. This is
+// the same `WC_Payment_Gateway::get_title()` value the classic checkout renders
+// in its radio labels, so both checkout types report a consistent payment_type.
+// Falls back to the slug if the title is unavailable.
+const getPaymentTypeLabel = ( slug ) =>
+	window.wc?.wcSettings?.getSetting?.( 'paymentMethodData' )?.[ slug ]
+		?.title || slug;
+
+const getAllShippingRates = ( storeCart ) => {
+	const livePackages = getShippingPackages( getStoreCartData() );
+	const packages = livePackages.length
+		? livePackages
+		: getShippingPackages( storeCart );
+
+	return packages.flatMap(
 		( shippingPackage ) => shippingPackage.shipping_rates ?? []
-	) ?? [];
+	);
+};
 
 const findShippingRateName = ( storeCart, rateId ) =>
 	getAllShippingRates( storeCart ).find(
@@ -914,7 +945,7 @@ export const blocksTracking = ( getEventHandler ) => {
 				getEventHandler,
 				{
 					...data,
-					paymentType: data.paymentMethodSlug,
+					paymentType: getPaymentTypeLabel( data.paymentMethodSlug ),
 				}
 			);
 		}
@@ -946,7 +977,9 @@ export const blocksTracking = ( getEventHandler ) => {
 				getEventHandler,
 				{
 					...data,
-					paymentType: getActivePaymentMethod(),
+					paymentType: getPaymentTypeLabel(
+						getActivePaymentMethod()
+					),
 				}
 			);
 		}

--- a/assets/js/src/integrations/classic.js
+++ b/assets/js/src/integrations/classic.js
@@ -29,6 +29,36 @@ const getCheckoutOptionLabel = ( element ) => {
 	return label?.textContent?.trim() || element.value;
 };
 
+// Return the shipping tier name without the price suffix. WooCommerce renders
+// shipping labels as "Flat rate: $4.00", with the cost wrapped in a
+// `.woocommerce-Price-amount` element. GA4's `shipping_tier` is the tier name
+// (e.g. "Flat rate"), not the price — and dropping the cost also keeps it
+// consistent with the block checkout, which reports the Store API rate name.
+const getShippingTierLabel = ( element ) => {
+	if ( ! element ) {
+		return undefined;
+	}
+
+	const label = element.labels?.[ 0 ] || element.closest( 'label' );
+
+	if ( label ) {
+		const clone = label.cloneNode( true );
+		clone
+			.querySelectorAll( '.woocommerce-Price-amount' )
+			.forEach( ( node ) => node.remove() );
+
+		// With the price removed we are left with "Flat rate:" — drop the
+		// trailing separator and whitespace.
+		const tier = clone.textContent.replace( /[\s:]+$/, '' ).trim();
+
+		if ( tier ) {
+			return tier;
+		}
+	}
+
+	return getCheckoutOptionLabel( element );
+};
+
 /**
  * The Google Analytics integration for classic WooCommerce pages
  * triggers events using three different methods.
@@ -112,7 +142,7 @@ export function classicTracking(
 		}
 
 		if ( event.target.matches( checkoutShippingMethodSelector ) ) {
-			trackShippingInfo( getCheckoutOptionLabel( event.target ) );
+			trackShippingInfo( getShippingTierLabel( event.target ) );
 		}
 
 		if ( event.target.matches( checkoutPaymentMethodSelector ) ) {
@@ -134,7 +164,7 @@ export function classicTracking(
 
 				if ( shippingElement ) {
 					trackShippingInfo(
-						getCheckoutOptionLabel( shippingElement )
+						getShippingTierLabel( shippingElement )
 					);
 				}
 			}

--- a/assets/js/src/integrations/classic.js
+++ b/assets/js/src/integrations/classic.js
@@ -1,5 +1,34 @@
 import { getProductFromID } from '../utils';
 
+const checkoutPaymentMethodSelector = 'input[name="payment_method"]';
+const checkoutShippingMethodSelector =
+	'input[name^="shipping_method"], select[name^="shipping_method"]';
+
+const getSelectedCheckoutOption = ( selector ) =>
+	Array.from( document.querySelectorAll( selector ) ).find(
+		( element ) => element.checked || element.tagName === 'SELECT'
+	);
+
+// Return the user-facing label for a shipping or payment input. For radios,
+// WooCommerce renders the human label as the text content of the associated
+// <label for="..."> element. For selects we fall back to the selected option's
+// text. The raw `value` (e.g. "free_shipping:1") is kept as a last resort so we
+// never emit an empty `shipping_tier`/`payment_type`.
+const getCheckoutOptionLabel = ( element ) => {
+	if ( ! element ) {
+		return undefined;
+	}
+
+	if ( element.tagName === 'SELECT' ) {
+		const selectedOption = element.options[ element.selectedIndex ];
+		return selectedOption?.text?.trim() || element.value;
+	}
+
+	const label = element.labels?.[ 0 ] || element.closest( 'label' );
+
+	return label?.textContent?.trim() || element.value;
+};
+
 /**
  * The Google Analytics integration for classic WooCommerce pages
  * triggers events using three different methods.
@@ -34,6 +63,25 @@ export function classicTracking(
 		list_name: listName,
 	}
 ) {
+	let shippingInfoTracked = false;
+	let paymentInfoTracked = false;
+
+	const trackShippingInfo = ( shippingTier ) => {
+		shippingInfoTracked = true;
+		getEventHandler( 'add_shipping_info' )( {
+			storeCart: cart,
+			shippingTier,
+		} );
+	};
+
+	const trackPaymentInfo = ( paymentType ) => {
+		paymentInfoTracked = true;
+		getEventHandler( 'add_payment_info' )( {
+			storeCart: cart,
+			paymentType,
+		} );
+	};
+
 	// Instantly track the events listed in the `events` object.
 	Object.values( events ?? {} ).forEach( ( eventName ) => {
 		if ( eventName === 'add_to_cart' ) {
@@ -48,6 +96,59 @@ export function classicTracking(
 			} );
 		}
 	} );
+
+	document.body.addEventListener( 'change', ( event ) => {
+		if ( ! cart?.items?.length ) {
+			return;
+		}
+
+		// Only react to changes inside the classic checkout form. The cart page
+		// shipping calculator uses the same `shipping_method[*]` input names, so
+		// without this scope a shipping change on the cart page would emit a
+		// spurious add_shipping_info event. This mirrors the submit handler,
+		// which also only operates on `form.checkout`.
+		if ( ! event.target.closest?.( 'form.checkout' ) ) {
+			return;
+		}
+
+		if ( event.target.matches( checkoutShippingMethodSelector ) ) {
+			trackShippingInfo( getCheckoutOptionLabel( event.target ) );
+		}
+
+		if ( event.target.matches( checkoutPaymentMethodSelector ) ) {
+			trackPaymentInfo( getCheckoutOptionLabel( event.target ) );
+		}
+	} );
+
+	document
+		.querySelector( 'form.checkout' )
+		?.addEventListener( 'submit', () => {
+			if ( ! cart?.items?.length ) {
+				return;
+			}
+
+			if ( ! shippingInfoTracked ) {
+				const shippingElement = getSelectedCheckoutOption(
+					checkoutShippingMethodSelector
+				);
+
+				if ( shippingElement ) {
+					trackShippingInfo(
+						getCheckoutOptionLabel( shippingElement )
+					);
+				}
+			}
+
+			if ( ! paymentInfoTracked ) {
+				trackPaymentInfo(
+					getCheckoutOptionLabel(
+						getSelectedCheckoutOption(
+							checkoutPaymentMethodSelector
+						)
+					)
+				);
+			}
+		} );
 
 	/**
 	 * Track the custom add to cart event dispatched by WooCommerce Core

--- a/assets/js/src/tracker/data-formatting.js
+++ b/assets/js/src/tracker/data-formatting.js
@@ -63,13 +63,11 @@ export const remove_from_cart = ( { product, quantity = 1 } ) => {
 	};
 };
 
-/**
- * Formats data for the begin_checkout event
- *
- * @param {Object} params           The function params
- * @param {Object} params.storeCart The cart object
- */
-export const begin_checkout = ( { storeCart } ) => {
+const getCheckoutData = ( storeCart ) => {
+	if ( ! storeCart?.items?.length ) {
+		return false;
+	}
+
 	return {
 		currency: storeCart.totals.currency_code,
 		value: formatPrice(
@@ -79,6 +77,52 @@ export const begin_checkout = ( { storeCart } ) => {
 		...getCartCoupon( storeCart ),
 		items: storeCart.items.map( getProductFieldObject ),
 	};
+};
+
+/**
+ * Formats data for the begin_checkout event
+ *
+ * @param {Object} params           The function params
+ * @param {Object} params.storeCart The cart object
+ */
+export const begin_checkout = ( { storeCart } ) => {
+	return getCheckoutData( storeCart );
+};
+
+/**
+ * Formats data for the add_shipping_info event
+ *
+ * @param {Object} params              The function params
+ * @param {Object} params.storeCart    The cart object
+ * @param {string} params.shippingTier The selected shipping tier.
+ */
+export const add_shipping_info = ( { storeCart, shippingTier } ) => {
+	const checkoutData = getCheckoutData( storeCart );
+
+	return checkoutData
+		? {
+				...checkoutData,
+				...( shippingTier ? { shipping_tier: shippingTier } : {} ),
+		  }
+		: false;
+};
+
+/**
+ * Formats data for the add_payment_info event
+ *
+ * @param {Object} params             The function params
+ * @param {Object} params.storeCart   The cart object
+ * @param {string} params.paymentType The selected payment type.
+ */
+export const add_payment_info = ( { storeCart, paymentType } ) => {
+	const checkoutData = getCheckoutData( storeCart );
+
+	return checkoutData
+		? {
+				...checkoutData,
+				...( paymentType ? { payment_type: paymentType } : {} ),
+		  }
+		: false;
 };
 
 /**

--- a/assets/js/src/tracker/data-formatting.js
+++ b/assets/js/src/tracker/data-formatting.js
@@ -68,12 +68,34 @@ const getCheckoutData = ( storeCart ) => {
 		return false;
 	}
 
+	const totals = storeCart.totals;
+
+	/*
+	 * Per the GA4 spec, `value` is the sum of (price × quantity) for all items
+	 * and must NOT include shipping or tax. WooCommerce's `total_price` bundles
+	 * shipping and tax, so summing the per-line totals instead keeps `value`
+	 * stable across the whole checkout funnel (begin_checkout vs
+	 * add_shipping_info / add_payment_info) and between the block and classic
+	 * checkouts — which otherwise read carts in different states (live vs
+	 * page-load) and shapes.
+	 *
+	 * Each line total is already net of discounts and tax. The live cart exposes
+	 * it as `item.totals.line_total` (with `prices.price` being the unit price),
+	 * while the static server cart has no `totals` and stores the line total
+	 * directly in `prices.price` — both in minor units, summed as integers to
+	 * avoid floating-point drift.
+	 * https://developers.google.com/analytics/devguides/collection/ga4/reference/events#add_shipping_info
+	 */
+	const value = storeCart.items.reduce(
+		( total, item ) =>
+			total +
+			parseInt( item.totals?.line_total ?? item.prices.price, 10 ),
+		0
+	);
+
 	return {
-		currency: storeCart.totals.currency_code,
-		value: formatPrice(
-			storeCart.totals.total_price,
-			storeCart.totals.currency_minor_unit
-		),
+		currency: totals.currency_code,
+		value: formatPrice( value, totals.currency_minor_unit ),
 		...getCartCoupon( storeCart ),
 		items: storeCart.items.map( getProductFieldObject ),
 	};

--- a/includes/class-wc-google-gtag-js.php
+++ b/includes/class-wc-google-gtag-js.php
@@ -334,13 +334,15 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 	public static function get_enabled_events(): array {
 		$events   = array();
 		$settings = array(
-			'purchase'         => 'ga_ecommerce_tracking_enabled',
-			'add_to_cart'      => 'ga_event_tracking_enabled',
-			'remove_from_cart' => 'ga_enhanced_remove_from_cart_enabled',
-			'view_item_list'   => 'ga_enhanced_product_impression_enabled',
-			'select_content'   => 'ga_enhanced_product_click_enabled',
-			'view_item'        => 'ga_enhanced_product_detail_view_enabled',
-			'begin_checkout'   => 'ga_enhanced_checkout_process_enabled',
+			'purchase'          => 'ga_ecommerce_tracking_enabled',
+			'add_to_cart'       => 'ga_event_tracking_enabled',
+			'remove_from_cart'  => 'ga_enhanced_remove_from_cart_enabled',
+			'view_item_list'    => 'ga_enhanced_product_impression_enabled',
+			'select_content'    => 'ga_enhanced_product_click_enabled',
+			'view_item'         => 'ga_enhanced_product_detail_view_enabled',
+			'begin_checkout'    => 'ga_enhanced_checkout_process_enabled',
+			'add_shipping_info' => 'ga_enhanced_checkout_process_enabled',
+			'add_payment_info'  => 'ga_enhanced_checkout_process_enabled',
 		);
 
 		foreach ( $settings as $event => $setting_name ) {

--- a/tests/e2e/specs/gtag-events/blocks-pages.test.js
+++ b/tests/e2e/specs/gtag-events/blocks-pages.test.js
@@ -578,7 +578,9 @@ test.describe( 'GTag events on block pages', () => {
 				qt: '1',
 				pr: simpleProductPrice.toString(),
 			} );
-			expect( data[ 'ep.payment_type' ] ).toEqual( 'cod' );
+			// The slug 'cod' is resolved to the gateway's human-readable title,
+			// matching the label the classic checkout reports.
+			expect( data[ 'ep.payment_type' ] ).toEqual( 'Cash on delivery' );
 			expect( data.cu ).toEqual( 'USD' );
 			expect( data[ 'epn.value' ] ).toEqual(
 				simpleProductPrice.toString()

--- a/tests/e2e/specs/gtag-events/blocks-pages.test.js
+++ b/tests/e2e/specs/gtag-events/blocks-pages.test.js
@@ -520,6 +520,72 @@ test.describe( 'GTag events on block pages', () => {
 		} );
 	} );
 
+	test( 'Add shipping info event is sent from a checkout page', async ( {
+		page,
+	} ) => {
+		await simpleProductAddToCart( page, simpleProductID );
+		await page.goto( 'checkout' );
+
+		const event = trackGtagEvent( page, 'add_shipping_info' );
+		await page.evaluate( () => {
+			window.wp.hooks.doAction(
+				'experimental__woocommerce_blocks-checkout-set-selected-shipping-rate',
+				{
+					shippingRateId: 'free_shipping:1',
+					storeCart: window.ga4w.data.cart,
+				}
+			);
+		} );
+
+		await event.then( ( request ) => {
+			const data = getEventData( request, 'add_shipping_info' );
+			expect( data.product1 ).toMatchObject( {
+				id: simpleProductID.toString(),
+				nm: 'Simple product',
+				qt: '1',
+				pr: simpleProductPrice.toString(),
+			} );
+			expect( data[ 'ep.shipping_tier' ] ).toEqual( 'free_shipping:1' );
+			expect( data.cu ).toEqual( 'USD' );
+			expect( data[ 'epn.value' ] ).toEqual(
+				simpleProductPrice.toString()
+			);
+		} );
+	} );
+
+	test( 'Add payment info event is sent from a checkout page', async ( {
+		page,
+	} ) => {
+		await simpleProductAddToCart( page, simpleProductID );
+		await page.goto( 'checkout' );
+
+		const event = trackGtagEvent( page, 'add_payment_info' );
+		await page.evaluate( () => {
+			window.wp.hooks.doAction(
+				'experimental__woocommerce_blocks-checkout-set-active-payment-method',
+				{
+					paymentMethodSlug: 'cod',
+					storeCart: window.ga4w.data.cart,
+				}
+			);
+		} );
+
+		await event.then( ( request ) => {
+			const data = getEventData( request, 'add_payment_info' );
+			expect( data.product1 ).toMatchObject( {
+				id: simpleProductID.toString(),
+				nm: 'Simple product',
+				qt: '1',
+				pr: simpleProductPrice.toString(),
+			} );
+			expect( data[ 'ep.payment_type' ] ).toEqual( 'cod' );
+			expect( data.cu ).toEqual( 'USD' );
+			expect( data[ 'epn.value' ] ).toEqual(
+				simpleProductPrice.toString()
+			);
+		} );
+	} );
+
 	test( 'Add to cart event is sent from a product collection block shop page', async ( {
 		page,
 	} ) => {

--- a/tests/e2e/specs/gtag-events/classic-pages.test.js
+++ b/tests/e2e/specs/gtag-events/classic-pages.test.js
@@ -303,6 +303,38 @@ test.describe( 'GTag events on classic pages', () => {
 		} );
 	} );
 
+	test( 'Add payment info event is sent when changing payment method on classic checkout', async ( {
+		page,
+	} ) => {
+		await createClassicCheckoutPage();
+		await simpleProductAddToCart( page, simpleProductID );
+
+		const event = trackGtagEvent( page, 'add_payment_info' );
+		await page.goto( 'classic-checkout' );
+
+		// Simulate a user changing the payment method radio. We don't depend
+		// on the exact set of enabled gateways — just trigger a `change` on the
+		// first available payment_method input.
+		await page.evaluate( () => {
+			const input = document.querySelector(
+				'input[name="payment_method"]'
+			);
+			if ( input ) {
+				input.checked = true;
+				input.dispatchEvent( new Event( 'change', { bubbles: true } ) );
+			}
+		} );
+
+		await event.then( ( request ) => {
+			const data = getEventData( request, 'add_payment_info' );
+			expect( data.cu ).toEqual( 'USD' );
+			expect( data[ 'epn.value' ] ).toEqual(
+				simpleProductPrice.toString()
+			);
+			expect( data[ 'ep.payment_type' ] ).toBeTruthy();
+		} );
+	} );
+
 	test( 'Purchase event is sent on order complete page', async ( {
 		page,
 	} ) => {

--- a/tests/unit-tests/WCGoogleGtagJS.php
+++ b/tests/unit-tests/WCGoogleGtagJS.php
@@ -232,18 +232,18 @@ class WCGoogleGtagJS extends EventsDataTest {
 	 */
 	public function test_get_enabled_events(): void {
 		$settings = array(
-			'purchase'         => 'ga_ecommerce_tracking_enabled',
-			'add_to_cart'      => 'ga_event_tracking_enabled',
-			'remove_from_cart' => 'ga_enhanced_remove_from_cart_enabled',
-			'view_item_list'   => 'ga_enhanced_product_impression_enabled',
-			'select_content'   => 'ga_enhanced_product_click_enabled',
-			'view_item'        => 'ga_enhanced_product_detail_view_enabled',
-			'begin_checkout'   => 'ga_enhanced_checkout_process_enabled',
+			'ga_ecommerce_tracking_enabled'           => array( 'purchase' ),
+			'ga_event_tracking_enabled'               => array( 'add_to_cart' ),
+			'ga_enhanced_remove_from_cart_enabled'    => array( 'remove_from_cart' ),
+			'ga_enhanced_product_impression_enabled'  => array( 'view_item_list' ),
+			'ga_enhanced_product_click_enabled'       => array( 'select_content' ),
+			'ga_enhanced_product_detail_view_enabled' => array( 'view_item' ),
+			'ga_enhanced_checkout_process_enabled'    => array( 'begin_checkout', 'add_shipping_info', 'add_payment_info' ),
 		);
 
-		foreach ( $settings as $event => $option_name ) {
+		foreach ( $settings as $option_name => $expected_events ) {
 			$gtag = new WC_Google_Gtag_JS( array( $option_name => 'yes' ) );
-			$this->assertEquals( $gtag->get_enabled_events(), array( $event ) );
+			$this->assertEquals( $expected_events, $gtag->get_enabled_events() );
 		}
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes STORMA-161

Send `add_shipping_info` and `add_payment_info` events for block and classic checkout flows.

### Checks:
* [x] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Screenshots:

First two are from classic, the other two from block checkout:

<img width="584" height="544" alt="Screenshot 2026-06-04 at 15 50 35" src="https://github.com/user-attachments/assets/4c0dabb1-6d0d-4eca-8fd5-5e5c5c976846" />

### Detailed test instructions:

1. Enable GA4 tracking and enhanced checkout events.
2. In block checkout, select shipping and payment options and confirm the matching GA4 events are sent.
3. Repeat in classic checkout and confirm the same event types are sent.

### Additional details:

_N/A_

### Changelog entry

> Add - Track checkout shipping and payment info events.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
4 issues found.

- Bug (2)
  1. Duplicate events in block checkout: re-render handler resets deduplication flags causing add_shipping_info/add_payment_info to fire twice.
  2. Classic flow race: shippingInfoTracked is set before the tracking call and can remain true if the call throws.

- Suggestion (2)
  1. Add E2E/unit test covering Blocks runtime path by stubbing wp.data.select('wc/store/cart').getCartData to exercise shipping-rate name resolution.
  2. Changelog clarity: note that begin_checkout `value` now excludes shipping (GA4-correct) as it may affect historical funnel analyses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
