### PR TITLE
Track Interactivity API add-to-cart events

### DIFF
--- a/assets/js/src/integrations/blocks.js
+++ b/assets/js/src/integrations/blocks.js
@@ -4,6 +4,97 @@ import { ACTION_PREFIX, NAMESPACE } from '../constants';
 
 const recentlyRemovedProducts = new Set();
 
+/*
+ * Track recently dispatched add_to_cart events so the cart-add-item hook and
+ * the fetch interceptor don't both fire for the same Store API add. Entries
+ * auto-expire after 50ms, which is long enough for the second code path to
+ * short-circuit but short enough that a deliberate second add of the same
+ * product is not swallowed.
+ */
+const recentlyAdded = new Set();
+const DEDUP_WINDOW = 50;
+let addItemStoreApiTrackingStarted = false;
+let addItemEventHandler = null;
+
+/*
+ * Last quantity observed for each cart line item (keyed by Store API line item
+ * key), recorded from every Store API cart response the interceptor sees. A
+ * follow-up update-item is reported as the added delta against this value, which
+ * stays correct across repeated adds of the same product on a single page load —
+ * the cart data exposed to the page (wc/store/cart, or the static window.ga4w
+ * cart) reflects page-load state and would otherwise go stale.
+ */
+const lastSeenCartQuantities = new Map();
+
+const rememberCartQuantities = ( cart ) => {
+	if ( ! Array.isArray( cart?.items ) ) {
+		return;
+	}
+
+	cart.items.forEach( ( item ) => {
+		if ( item?.key !== undefined && item?.key !== null ) {
+			lastSeenCartQuantities.set( item.key, item.quantity );
+		}
+	} );
+};
+
+const warnTrackingError = ( message, error ) => {
+	// eslint-disable-next-line no-console
+	console.warn( `Google Analytics for WooCommerce: ${ message }`, error );
+};
+
+// Dispatch an event through its gtag handler without letting a tracking error
+// propagate back into the caller (a WooCommerce hook or the fetch interceptor).
+const safeTrackEvent = ( getEventHandler, eventName, data ) => {
+	try {
+		getEventHandler( eventName )( data );
+	} catch ( error ) {
+		warnTrackingError( `could not track the ${ eventName } event.`, error );
+	}
+};
+
+/*
+ * How long to wait before the batch interceptor dispatches its add_to_cart
+ * event. The All Products Block bundles its add into a Store API batch request
+ * and fires the cart-add-item hook ~2ms after the batch response resolves, so
+ * the interceptor must give the hook time to claim the add (via recentlyAdded)
+ * before falling back to firing the event itself. Comfortably larger than the
+ * hook latency yet well within the 50ms de-dup window above.
+ */
+const BATCH_ADD_TRACK_DELAY = 25;
+
+// The cart-add-item hook and the fetch interceptor receive differently-shaped
+// product objects for the same add, so we match on whichever identifiers are
+// available: the Store API line item `key` (most precise — distinguishes
+// variations of the same parent product) and an `id|name` token (the common
+// ground when one path lacks a key, e.g. the hook payload). Marking/checking
+// every available token means a match on any one of them dedupes the add.
+const getAddDedupTokens = ( product ) => {
+	const tokens = [];
+
+	if ( product?.key !== undefined && product?.key !== null ) {
+		tokens.push( `key:${ product.key }` );
+	}
+
+	if ( product?.id || product?.name ) {
+		tokens.push( `id:${ product?.id ?? '' }|${ product?.name ?? '' }` );
+	}
+
+	return tokens;
+};
+
+const markRecentlyAdded = ( product ) => {
+	getAddDedupTokens( product ).forEach( ( token ) => {
+		recentlyAdded.add( token );
+		setTimeout( () => recentlyAdded.delete( token ), DEDUP_WINDOW );
+	} );
+};
+
+const wasRecentlyAdded = ( product ) =>
+	getAddDedupTokens( product ).some( ( token ) =>
+		recentlyAdded.has( token )
+	);
+
 /**
  * Get currency settings from our plugin's settings.
  *
@@ -18,18 +109,23 @@ const getCurrencySettings = () => window.ga4w?.settings?.currency;
  * @return {Object|null} Cart object with items array, or null if unavailable.
  */
 const getCartData = () => {
-	// Try to get fresh cart data from WooCommerce Blocks store
-	if ( window.wp?.data?.select?.( 'wc/store/cart' ) ) {
-		const storeCart = window.wp.data
-			.select( 'wc/store/cart' )
-			.getCartData();
-		if ( storeCart?.items?.length > 0 ) {
-			return storeCart;
+	try {
+		// Try to get fresh cart data from WooCommerce Blocks store.
+		if ( window.wp?.data?.select?.( 'wc/store/cart' ) ) {
+			const storeCart = window.wp.data
+				.select( 'wc/store/cart' )
+				.getCartData();
+			if ( storeCart?.items?.length > 0 ) {
+				return storeCart;
+			}
 		}
-	}
 
-	// Fallback to static cart data from page load
-	return window.ga4w?.data?.cart;
+		// Fallback to static cart data from page load.
+		return window.ga4w?.data?.cart ?? null;
+	} catch ( error ) {
+		warnTrackingError( 'could not read cart data.', error );
+		return null;
+	}
 };
 
 const getProductDedupKey = ( product ) =>
@@ -55,7 +151,7 @@ const parsePriceFromDOM = ( priceText ) => {
 	const { decimalSeparator = '.', thousandSeparator = ',' } = currency;
 
 	// Use WooCommerce's accounting.js library if available (most reliable)
-	if ( window.accounting?.unformat ) {
+	if ( typeof window.accounting?.unformat === 'function' ) {
 		return window.accounting.unformat( priceText, decimalSeparator );
 	}
 
@@ -139,6 +235,478 @@ const getProductFromDOM = ( cartItem ) => {
 	};
 };
 
+const STORE_API_ADD_ITEM_PATH = /\/wc\/store(?:\/v\d+)?\/cart\/add-item/;
+const STORE_API_UPDATE_ITEM_PATH = /\/wc\/store(?:\/v\d+)?\/cart\/update-item/;
+const STORE_API_BATCH_PATH = /\/wc\/store(?:\/v\d+)?\/batch/;
+
+/**
+ * Resolve the method and pathname of a same-origin fetch call.
+ *
+ * @param {Request|string|URL} input Fetch input.
+ * @param {Object}             init  Fetch options.
+ * @return {{ method: string, pathname: string }|null} Request info, or null when
+ *                                                      cross-origin or unparseable.
+ */
+const getStoreApiRequestInfo = ( input, init = {} ) => {
+	let requestUrl;
+	try {
+		requestUrl = new URL(
+			input?.url ?? input?.toString?.(),
+			window.location.origin
+		);
+	} catch {
+		return null;
+	}
+
+	if ( requestUrl.origin !== window.location.origin ) {
+		return null;
+	}
+
+	const method = ( init?.method ?? input?.method ?? 'GET' ).toUpperCase();
+
+	// On plain-permalink installs the Store API route lives in the `rest_route`
+	// query parameter (e.g. /?rest_route=/wc/store/v1/cart/add-item) and the
+	// pathname is just "/", so prefer it when present.
+	const restRoute = requestUrl.searchParams.get( 'rest_route' );
+
+	return { method, pathname: restRoute ?? requestUrl.pathname };
+};
+
+/**
+ * Check whether a fetch call is adding an item through the Store API.
+ *
+ * @param {Request|string|URL} input Fetch input.
+ * @param {Object}             init  Fetch options.
+ * @return {boolean} Whether the request is a Store API cart add item request.
+ */
+const isStoreApiAddItemRequest = ( input, init = {} ) => {
+	const info = getStoreApiRequestInfo( input, init );
+
+	return (
+		!! info &&
+		info.method === 'POST' &&
+		STORE_API_ADD_ITEM_PATH.test( info.pathname )
+	);
+};
+
+/**
+ * Check whether a fetch call is a Store API batch request, which Interactivity
+ * API powered add-to-cart blocks use to bundle their cart mutations.
+ *
+ * @param {Request|string|URL} input Fetch input.
+ * @param {Object}             init  Fetch options.
+ * @return {boolean} Whether the request is a Store API batch request.
+ */
+const isStoreApiBatchRequest = ( input, init = {} ) => {
+	const info = getStoreApiRequestInfo( input, init );
+
+	return (
+		!! info &&
+		info.method === 'POST' &&
+		STORE_API_BATCH_PATH.test( info.pathname )
+	);
+};
+
+/**
+ * Get the request body without consuming the original Request object.
+ *
+ * @param {Request|string|URL} input Fetch input.
+ * @param {Object}             init  Fetch options.
+ * @return {Promise<*>} Request body.
+ */
+const getRequestBody = async ( input, init = {} ) => {
+	if ( init?.body ) {
+		return init.body;
+	}
+
+	if ( typeof input?.clone === 'function' ) {
+		return await input.clone().text();
+	}
+
+	return null;
+};
+
+/**
+ * Coerce a fetch request body (JSON string, form data, or object) into a plain
+ * object of its fields.
+ *
+ * @param {*} body Request body.
+ * @return {Object} Body fields.
+ */
+const coerceRequestBodyData = ( body ) => {
+	if ( body instanceof FormData || body instanceof URLSearchParams ) {
+		return Object.fromEntries( body.entries() );
+	}
+
+	if ( typeof body === 'string' ) {
+		try {
+			return JSON.parse( body );
+		} catch {
+			return Object.fromEntries( new URLSearchParams( body ).entries() );
+		}
+	}
+
+	return body && typeof body === 'object' ? body : {};
+};
+
+const toPositiveInteger = ( value, fallback = null ) => {
+	const parsed = parseInt( value, 10 );
+
+	return Number.isFinite( parsed ) && parsed > 0 ? parsed : fallback;
+};
+
+/**
+ * Parse the product and quantity from a Store API add item request body.
+ *
+ * @param {*} body Request body.
+ * @return {{ productId: number|null, quantity: number }} Parsed body data.
+ */
+const parseAddItemRequestBody = ( body ) => {
+	const data = coerceRequestBodyData( body );
+
+	return {
+		productId: toPositiveInteger( data.id ),
+		quantity: toPositiveInteger( data.quantity, 1 ),
+	};
+};
+
+/**
+ * Parse the cart line item key from a Store API update item request body.
+ *
+ * @param {*} body Request body.
+ * @return {string|null} Cart line item key, or null when absent.
+ */
+const parseUpdateItemRequestKey = ( body ) =>
+	coerceRequestBodyData( body )?.key ?? null;
+
+/**
+ * Get a stable key for comparing Store API cart items.
+ *
+ * @param {Object} item Store API cart item.
+ * @return {string|number|undefined} Cart item key.
+ */
+const getCartItemKey = ( item ) => item?.key ?? item?.id;
+
+/**
+ * Find the item that was added in the Store API response.
+ *
+ * Prefers the line that actually changed — a newly added line, or an existing
+ * line whose quantity grew — so a repeated add of a product already in the cart
+ * resolves to the correct line instead of the first line that happens to share
+ * the requested id. Falls back to matching the requested product id when no
+ * change is visible (e.g. cart-before data was unavailable).
+ *
+ * @param {Object} cartAfter        Cart data after the request.
+ * @param {Object} cartBefore       Cart data before the request.
+ * @param {number} requestProductId Product ID from the request body.
+ * @return {Object|undefined} Added cart item.
+ */
+const getAddedCartItem = ( cartAfter, cartBefore, requestProductId ) => {
+	if ( ! Array.isArray( cartAfter?.items ) || ! cartAfter.items.length ) {
+		return undefined;
+	}
+
+	if ( Array.isArray( cartBefore?.items ) ) {
+		const changedItem = cartAfter.items.find( ( item ) => {
+			const previousItem = cartBefore.items.find(
+				( beforeItem ) =>
+					getCartItemKey( beforeItem ) === getCartItemKey( item )
+			);
+
+			return ! previousItem || item.quantity > previousItem.quantity;
+		} );
+
+		if ( changedItem ) {
+			return changedItem;
+		}
+	}
+
+	return requestProductId
+		? cartAfter.items.find(
+				( item ) => parseInt( item.id, 10 ) === requestProductId
+		  )
+		: undefined;
+};
+
+/**
+ * Scale a cart line item's line total down to a subset of its quantity.
+ *
+ * A Store API cart line's `line_total` covers its full quantity. When only part
+ * of that quantity is reported as an add — a repeated add of a product already
+ * in the cart, or a quantity increase — the line total must be scaled to the
+ * added units so the reported price stays in step with the reported quantity.
+ *
+ * @param {Object} item          Store API cart item.
+ * @param {number} addedQuantity Quantity being reported as added.
+ * @return {Object} The item, with `totals.line_total` scaled to the added units.
+ */
+const scaleLineTotalToAddedQuantity = ( item, addedQuantity ) => {
+	const newQuantity = parseInt( item?.quantity, 10 );
+	const lineTotal = parseInt( item?.totals?.line_total, 10 );
+
+	if (
+		! Number.isFinite( lineTotal ) ||
+		! Number.isFinite( newQuantity ) ||
+		! Number.isFinite( addedQuantity ) ||
+		! newQuantity ||
+		addedQuantity >= newQuantity
+	) {
+		return item;
+	}
+
+	return {
+		...item,
+		totals: {
+			...item.totals,
+			line_total: String(
+				Math.round( ( lineTotal * addedQuantity ) / newQuantity )
+			),
+		},
+	};
+};
+
+/**
+ * Resolve the added product and quantity for a single Store API add-item call.
+ *
+ * @param {*}      requestBody Add-item request body.
+ * @param {Object} cartAfter   Cart data returned by the add-item response.
+ * @param {Object} cartBefore  Cart data before the add-item call.
+ * @return {{ product: Object, quantity: number }|null} Added product, or null when none matched.
+ */
+const getAddItemFromResponse = ( requestBody, cartAfter, cartBefore ) => {
+	const { productId, quantity } = parseAddItemRequestBody( requestBody );
+	const product = getAddedCartItem( cartAfter, cartBefore, productId );
+
+	return product
+		? {
+				product: scaleLineTotalToAddedQuantity( product, quantity ),
+				quantity,
+		  }
+		: null;
+};
+
+/**
+ * Resolve the added product and quantity for a single Store API update-item
+ * call. Updating an item that is already in the cart to a higher quantity (e.g.
+ * clicking add-to-cart again, or raising the quantity) is treated as an
+ * add_to_cart for the increase, so the quantity reported is the delta between
+ * the new and previous quantity — not the new total.
+ *
+ * @param {*}      requestBody Update-item request body.
+ * @param {Object} cartAfter   Cart data returned by the update-item response.
+ * @param {Object} cartBefore  Cart data before the update-item call.
+ * @return {{ product: Object, quantity: number }|null} Added product, or null when the quantity did not increase.
+ */
+const getUpdateItemFromResponse = ( requestBody, cartAfter, cartBefore ) => {
+	const key = parseUpdateItemRequestKey( requestBody );
+
+	if ( ! key ) {
+		return null;
+	}
+
+	const updatedItem = Array.isArray( cartAfter?.items )
+		? cartAfter.items.find( ( item ) => item.key === key )
+		: null;
+
+	if ( ! updatedItem ) {
+		return null;
+	}
+
+	let previousQuantity = 0;
+	if ( lastSeenCartQuantities.has( key ) ) {
+		previousQuantity = lastSeenCartQuantities.get( key );
+	} else if ( Array.isArray( cartBefore?.items ) ) {
+		previousQuantity =
+			cartBefore.items.find( ( item ) => item.key === key )?.quantity ??
+			0;
+	}
+	const addedQuantity =
+		parseInt( updatedItem.quantity, 10 ) - parseInt( previousQuantity, 10 );
+
+	if ( ! Number.isFinite( addedQuantity ) || addedQuantity <= 0 ) {
+		return null;
+	}
+
+	return {
+		product: scaleLineTotalToAddedQuantity( updatedItem, addedQuantity ),
+		quantity: addedQuantity,
+	};
+};
+
+/**
+ * Parse a Store API batch request body into an object.
+ *
+ * @param {*} body Request body (JSON string or already-parsed object).
+ * @return {Object|null} Parsed body, or null when it cannot be parsed.
+ */
+const parseBatchRequestBody = ( body ) => {
+	if ( typeof body === 'string' ) {
+		try {
+			return JSON.parse( body );
+		} catch {
+			return null;
+		}
+	}
+
+	return body && typeof body === 'object' ? body : null;
+};
+
+/**
+ * Resolve every add_to_cart from a Store API batch request/response pair.
+ *
+ * A batch bundles sub-requests under `requests` and returns their results, in
+ * the same order, under `responses`. Each cart sub-response body is the full
+ * cart at that point, matched against the previous cart state to pick out the
+ * change. Both add-item (new line) and update-item (quantity increase of an
+ * existing line) sub-requests are reported as add_to_cart.
+ *
+ * @param {*}      requestBody  Batch request body.
+ * @param {Object} responseJson Batch response JSON.
+ * @param {Object} cartBefore   Cart data before the batch request.
+ * @return {Array<{ product: Object, quantity: number }>} Added products.
+ */
+const getBatchAddToCartItems = ( requestBody, responseJson, cartBefore ) => {
+	const requests = parseBatchRequestBody( requestBody )?.requests;
+	const responses = responseJson?.responses;
+
+	if ( ! Array.isArray( requests ) || ! Array.isArray( responses ) ) {
+		return [];
+	}
+
+	const adds = [];
+	let previousCart = cartBefore;
+
+	requests.forEach( ( request, index ) => {
+		const path = request?.path ?? '';
+		const isAddItem = STORE_API_ADD_ITEM_PATH.test( path );
+		const isUpdateItem = STORE_API_UPDATE_ITEM_PATH.test( path );
+
+		if ( ! isAddItem && ! isUpdateItem ) {
+			return;
+		}
+
+		const subResponse = responses[ index ];
+		const status = subResponse?.status;
+
+		if ( ! subResponse || status < 200 || status >= 300 ) {
+			return;
+		}
+
+		const cartAfter = subResponse.body;
+		const add = isAddItem
+			? getAddItemFromResponse( request.body, cartAfter, previousCart )
+			: getUpdateItemFromResponse(
+					request.body,
+					cartAfter,
+					previousCart
+			  );
+
+		if ( add ) {
+			adds.push( add );
+		}
+
+		// Record quantities after reading the delta so a later update-item (in
+		// this batch or a subsequent request) compares against the new state.
+		rememberCartQuantities( cartAfter );
+		previousCart = cartAfter;
+	} );
+
+	return adds;
+};
+
+/**
+ * Track successful Store API add item requests.
+ *
+ * Interactivity API powered add-to-cart blocks do not fire the legacy jQuery
+ * event or the WooCommerce Blocks cart-add-item hook in every WooCommerce version.
+ *
+ * @param {Function} getEventHandler - Function to get the event handler for a given event name.
+ */
+const trackStoreApiAddToCart = ( getEventHandler ) => {
+	addItemEventHandler = ( data ) =>
+		safeTrackEvent( getEventHandler, 'add_to_cart', data );
+
+	if (
+		addItemStoreApiTrackingStarted ||
+		typeof window.fetch !== 'function'
+	) {
+		return;
+	}
+
+	addItemStoreApiTrackingStarted = true;
+	const originalFetch = window.fetch;
+
+	window.fetch = async function trackAddItemFetch( ...args ) {
+		const [ input, init ] = args;
+		const isAddItemRequest = isStoreApiAddItemRequest( input, init );
+		const isBatchRequest =
+			! isAddItemRequest && isStoreApiBatchRequest( input, init );
+		const shouldTrack = isAddItemRequest || isBatchRequest;
+		const cartBefore = shouldTrack ? getCartData() : null;
+		const bodyPromise = shouldTrack ? getRequestBody( input, init ) : null;
+		const response = await originalFetch.apply( this, args );
+
+		if ( ! shouldTrack || ! response?.ok ) {
+			return response;
+		}
+
+		try {
+			const requestBody = await bodyPromise;
+			const responseJson = await response.clone().json();
+			let adds;
+			if ( isBatchRequest ) {
+				adds = getBatchAddToCartItems(
+					requestBody,
+					responseJson,
+					cartBefore
+				);
+			} else {
+				adds = [
+					getAddItemFromResponse(
+						requestBody,
+						responseJson,
+						cartBefore
+					),
+				].filter( Boolean );
+				// responseJson is the cart for a direct add-item; record it so a
+				// later update-item compares against the new state.
+				rememberCartQuantities( responseJson );
+			}
+
+			// Give the cart-add-item hook a chance to mark these products as
+			// already handled first, so blocks that fire both the hook and a
+			// Store API request (e.g. the All Products Block) are tracked once,
+			// from the hook. A batch add resolves the hook a couple of
+			// milliseconds after its response, so it needs a longer wait than a
+			// direct add-item (where deferring a single task is enough).
+			const trackDelay = isBatchRequest ? BATCH_ADD_TRACK_DELAY : 0;
+
+			adds.forEach( ( { product, quantity } ) => {
+				setTimeout( () => {
+					if ( wasRecentlyAdded( product ) ) {
+						return;
+					}
+
+					markRecentlyAdded( product );
+					addItemEventHandler( {
+						product: { ...product, quantity },
+					} );
+				}, trackDelay );
+			} );
+		} catch ( error ) {
+			// Tracking must never break the cart. Swallow the error but warn so
+			// an unexpected Store API response shape can be diagnosed.
+			warnTrackingError(
+				'could not parse the Store API add-item response for add_to_cart tracking.',
+				error
+			);
+			return response;
+		}
+
+		return response;
+	};
+};
+
 /**
  * Track when an item is removed from the Interactivity API-powered Mini Cart.
  * The new Mini Cart (WooCommerce 10.4+) doesn't fire the experimental__woocommerce_blocks
@@ -151,96 +719,115 @@ const getProductFromDOM = ( cartItem ) => {
  */
 const trackMiniCartRemoval = ( getEventHandler ) => {
 	document.body.addEventListener( 'click', ( event ) => {
-		const removeButton = event.target.closest(
-			'.wc-block-cart-item__remove-link'
-		);
+		try {
+			const removeButton = event.target?.closest?.(
+				'.wc-block-cart-item__remove-link'
+			);
 
-		if ( ! removeButton ) {
-			return;
-		}
-
-		// Find the cart item container to get product information
-		const cartItem = removeButton.closest( '.wc-block-cart-items__row' );
-		if ( ! cartItem ) {
-			return;
-		}
-
-		let product = null;
-
-		/*
-		 * Try to find product data from available sources:
-		 * 1. WooCommerce Blocks store (wc/store/cart) - real-time cart state
-		 * 2. Static cart data from server (window.ga4w.data.cart) - initial page load
-		 * 3. DOM extraction - last resort when store data is unavailable
-		 */
-		const productLink = cartItem.querySelector(
-			'.wc-block-components-product-name'
-		);
-		const productHref = productLink?.getAttribute( 'href' );
-		const productName = productLink?.textContent?.trim();
-
-		// Extract product ID from URL (e.g., ?p=123)
-		let productId = null;
-		if ( productHref ) {
-			const paramMatch = productHref.match( /[?&]p=(\d+)/ );
-			if ( paramMatch ) {
-				productId = parseInt( paramMatch[ 1 ], 10 );
+			if ( ! removeButton ) {
+				return;
 			}
-		}
 
-		// Try WooCommerce store or static cart data
-		const cart = getCartData();
-		if ( cart?.items ) {
-			if ( productId ) {
-				product = getProductFromID( productId, [], cart );
-			} else if ( productName ) {
-				product = cart.items.find(
-					( item ) => item.name === productName
-				);
+			// Find the cart item container to get product information
+			const cartItem = removeButton.closest(
+				'.wc-block-cart-items__row'
+			);
+			if ( ! cartItem ) {
+				return;
 			}
-		}
 
-		// Fallback: extract from DOM when cart data lookup fails
-		// This can happen if the cart store hasn't synced yet or product matching fails
-		if ( ! product ) {
-			product = getProductFromDOM( cartItem );
-		}
+			let product = null;
 
-		if ( product ) {
-			const dedupKey = getProductDedupKey( product );
+			/*
+			 * Try to find product data from available sources:
+			 * 1. WooCommerce Blocks store (wc/store/cart) - real-time cart state
+			 * 2. Static cart data from server (window.ga4w.data.cart) - initial page load
+			 * 3. DOM extraction - last resort when store data is unavailable
+			 */
+			const productLink = cartItem.querySelector(
+				'.wc-block-components-product-name'
+			);
+			const productHref = productLink?.getAttribute( 'href' );
+			const productName = productLink?.textContent?.trim();
 
-			setTimeout( () => {
-				if ( ! dedupKey || ! recentlyRemovedProducts.has( dedupKey ) ) {
-					getEventHandler( 'remove_from_cart' )( { product } );
+			// Extract product ID from URL (e.g., ?p=123)
+			let productId = null;
+			if ( productHref ) {
+				const paramMatch = productHref.match( /[?&]p=(\d+)/ );
+				if ( paramMatch ) {
+					productId = parseInt( paramMatch[ 1 ], 10 );
 				}
-			}, 0 );
+			}
+
+			// Try WooCommerce store or static cart data
+			const cart = getCartData();
+			if ( Array.isArray( cart?.items ) ) {
+				if ( productId ) {
+					product = getProductFromID( productId, [], cart );
+				} else if ( productName ) {
+					product = cart.items.find(
+						( item ) => item.name === productName
+					);
+				}
+			}
+
+			// Fallback: extract from DOM when cart data lookup fails
+			// This can happen if the cart store hasn't synced yet or product matching fails
+			if ( ! product ) {
+				product = getProductFromDOM( cartItem );
+			}
+
+			if ( product ) {
+				const dedupKey = getProductDedupKey( product );
+
+				setTimeout( () => {
+					if (
+						! dedupKey ||
+						! recentlyRemovedProducts.has( dedupKey )
+					) {
+						safeTrackEvent( getEventHandler, 'remove_from_cart', {
+							product,
+						} );
+					}
+				}, 0 );
+			}
+		} catch ( error ) {
+			warnTrackingError(
+				'could not read mini-cart remove_from_cart data.',
+				error
+			);
 		}
 	} );
 };
 
 // We add actions asynchronosly, to make sure handlers will have the config available.
 export const blocksTracking = ( getEventHandler ) => {
-	addUniqueAction(
-		`${ ACTION_PREFIX }-product-render`,
-		NAMESPACE,
-		getEventHandler( 'view_item' )
+	addUniqueAction( `${ ACTION_PREFIX }-product-render`, NAMESPACE, ( data ) =>
+		safeTrackEvent( getEventHandler, 'view_item', data )
 	);
 
 	addUniqueAction(
 		`${ ACTION_PREFIX }-cart-remove-item`,
 		NAMESPACE,
 		( data ) => {
-			const dedupKey = getProductDedupKey( data?.product );
+			try {
+				const dedupKey = getProductDedupKey( data?.product );
 
-			if ( dedupKey ) {
-				recentlyRemovedProducts.add( dedupKey );
-				setTimeout(
-					() => recentlyRemovedProducts.delete( dedupKey ),
-					50
+				if ( dedupKey ) {
+					recentlyRemovedProducts.add( dedupKey );
+					setTimeout(
+						() => recentlyRemovedProducts.delete( dedupKey ),
+						DEDUP_WINDOW
+					);
+				}
+
+				safeTrackEvent( getEventHandler, 'remove_from_cart', data );
+			} catch ( error ) {
+				warnTrackingError(
+					'could not process Blocks remove_from_cart tracking.',
+					error
 				);
 			}
-
-			getEventHandler( 'remove_from_cart' )( data );
 		}
 	);
 
@@ -251,19 +838,28 @@ export const blocksTracking = ( getEventHandler ) => {
 		`${ ACTION_PREFIX }-checkout-render-checkout-form`,
 		NAMESPACE,
 		( data ) => {
-			/*
-			 * WooCommerce 10.4+ may fire this event before cart data is fully loaded.
-			 * If storeCart is empty or missing items, fall back to the cart data
-			 * provided by the server via window.ga4w.data.cart.
-			 */
-			const storeCart = data?.storeCart;
-			const cartData =
-				storeCart?.items?.length > 0
-					? storeCart
-					: window.ga4w?.data?.cart;
+			try {
+				/*
+				 * WooCommerce 10.4+ may fire this event before cart data is fully loaded.
+				 * If storeCart is empty or missing items, fall back to the cart data
+				 * provided by the server via window.ga4w.data.cart.
+				 */
+				const storeCart = data?.storeCart;
+				const cartData =
+					storeCart?.items?.length > 0
+						? storeCart
+						: window.ga4w?.data?.cart;
 
-			if ( cartData ) {
-				getEventHandler( 'begin_checkout' )( { storeCart: cartData } );
+				if ( cartData ) {
+					safeTrackEvent( getEventHandler, 'begin_checkout', {
+						storeCart: cartData,
+					} );
+				}
+			} catch ( error ) {
+				warnTrackingError(
+					'could not process begin_checkout tracking.',
+					error
+				);
 			}
 		}
 	);
@@ -272,21 +868,37 @@ export const blocksTracking = ( getEventHandler ) => {
 	addUniqueAction(
 		`${ ACTION_PREFIX }-cart-add-item`,
 		NAMESPACE,
-		( { product } ) => {
-			getEventHandler( 'add_to_cart' )( { product } );
+		( data ) => {
+			try {
+				const product = data?.product;
+
+				if ( wasRecentlyAdded( product ) ) {
+					return;
+				}
+
+				markRecentlyAdded( product );
+				safeTrackEvent( getEventHandler, 'add_to_cart', { product } );
+			} catch ( error ) {
+				warnTrackingError(
+					'could not process Blocks add_to_cart tracking.',
+					error
+				);
+			}
 		}
 	);
+
+	trackStoreApiAddToCart( getEventHandler );
 
 	addUniqueAction(
 		`${ ACTION_PREFIX }-product-list-render`,
 		NAMESPACE,
-		getEventHandler( 'view_item_list' )
+		( data ) => safeTrackEvent( getEventHandler, 'view_item_list', data )
 	);
 
 	addUniqueAction(
 		`${ ACTION_PREFIX }-product-view-link`,
 		NAMESPACE,
-		getEventHandler( 'select_content' )
+		( data ) => safeTrackEvent( getEventHandler, 'select_content', data )
 	);
 };
 

--- a/tests/e2e/specs/gtag-events/blocks-pages.test.js
+++ b/tests/e2e/specs/gtag-events/blocks-pages.test.js
@@ -15,6 +15,10 @@ import {
 	blockProductAddToCart,
 	relatedProductAddToCart,
 	simpleProductAddToCart,
+	storeApiAddToCart,
+	storeApiBatchAddToCart,
+	storeApiBatchIncreaseCartQuantity,
+	waitForStoreApiInterceptor,
 } from '../../utils/customer';
 import {
 	createAllProductsBlockShopPage,
@@ -58,6 +62,310 @@ test.describe( 'GTag events on block pages', () => {
 				pr: simpleProductPrice.toString(),
 			} );
 		} );
+	} );
+
+	test( 'Add to cart event is sent after a Store API add item request', async ( {
+		page,
+	} ) => {
+		await page.goto( 'shop?orderby=date' );
+
+		const event = trackGtagEvent( page, 'add_to_cart' );
+		await storeApiAddToCart( page, simpleProductID );
+
+		await event.then( ( request ) => {
+			const data = getEventData( request, 'add_to_cart' );
+			// The interceptor reports the item from the Store API add-item
+			// response, which carries id/name/quantity/price. Categories are
+			// not part of that cart item payload, so they are not asserted.
+			expect( data.product1 ).toMatchObject( {
+				id: simpleProductID.toString(),
+				nm: 'Simple product',
+				qt: '1',
+				pr: simpleProductPrice.toString(),
+			} );
+		} );
+	} );
+
+	test( 'Add to cart event is sent after a Store API batch add item request', async ( {
+		page,
+	} ) => {
+		await page.goto( 'shop?orderby=date' );
+
+		const event = trackGtagEvent( page, 'add_to_cart' );
+		await storeApiBatchAddToCart( page, simpleProductID );
+
+		await event.then( ( request ) => {
+			const data = getEventData( request, 'add_to_cart' );
+			// The interceptor reports the item from the batched Store API
+			// add-item response, which carries id/name/quantity/price.
+			// Categories are not part of that cart item payload, so they are
+			// not asserted.
+			expect( data.product1 ).toMatchObject( {
+				id: simpleProductID.toString(),
+				nm: 'Simple product',
+				qt: '1',
+				pr: simpleProductPrice.toString(),
+			} );
+		} );
+	} );
+
+	test( 'Add to cart event is sent when a Store API batch update-item increases the quantity', async ( {
+		page,
+	} ) => {
+		// Use a dedicated product so a polluted cart can't break the seeding
+		// click below (which expects the product to go from 0 to "1 in cart").
+		const updateProductID = await createSimpleProduct();
+		await page.goto( 'shop?orderby=date' );
+
+		// Seed through the block so the cart store the interceptor reads
+		// (wc/store/cart) holds the current quantity — the same source the real
+		// Interactivity API add-to-cart flow keeps in sync. Wait for the seed's
+		// own add_to_cart to flush so the assertion below tracks the update, not
+		// the seed (and so the de-dup window has passed before the update).
+		const seedEvent = trackGtagEvent( page, 'add_to_cart' );
+		await blockProductAddToCart( page, updateProductID );
+		await seedEvent;
+
+		const event = trackGtagEvent( page, 'add_to_cart' );
+		// Raise the quantity by 2 via update-item; the event must report the
+		// added delta (2), not the new total quantity.
+		await storeApiBatchIncreaseCartQuantity( page, updateProductID, 2 );
+
+		await event.then( ( request ) => {
+			const data = getEventData( request, 'add_to_cart' );
+			expect( data.product1 ).toMatchObject( {
+				id: updateProductID.toString(),
+				nm: 'Simple product',
+				qt: '2',
+				// Price reflects the two added units (the scaled line total).
+				pr: ( simpleProductPrice * 2 ).toString(),
+			} );
+		} );
+	} );
+
+	test( 'Add to cart event fires exactly once when both cart-add-item hook and Store API add fire for the same product', async ( {
+		page,
+	} ) => {
+		await page.goto( 'shop?orderby=date' );
+		await waitForStoreApiInterceptor( page );
+
+		// Count add_to_cart events. GA4 sends a single event in the query string
+		// (`en=add_to_cart`) but batches multiple events into the POST body
+		// (newline-separated), so we inspect both to count reliably.
+		const addToCartEvents = [];
+		page.on( 'request', ( request ) => {
+			const url = request.url();
+			if ( ! url.includes( 'google-analytics.com/g/collect' ) ) {
+				return;
+			}
+
+			if ( new URL( url ).searchParams.get( 'en' ) === 'add_to_cart' ) {
+				addToCartEvents.push( url );
+				return;
+			}
+
+			( request.postData() || '' ).split( /\r?\n/ ).forEach( ( line ) => {
+				if (
+					new URLSearchParams( line ).get( 'en' ) === 'add_to_cart'
+				) {
+					addToCartEvents.push( line );
+				}
+			} );
+		} );
+
+		// Resolves once the first add_to_cart event has actually been sent to
+		// GA4, which also tells us gtag has flushed (it can load after the page).
+		const firstAddToCart = trackGtagEvent( page, 'add_to_cart' );
+
+		// Drive both code paths for the same product: the cart-add-item hook
+		// (All Products Block path) and a real Store API add (Interactivity API
+		// path). The nonce is fetched up front so the hook and the add-item
+		// request fall within the de-dup window.
+		await page.evaluate( async ( productID ) => {
+			const cartResponse = await window.fetch(
+				'/wp-json/wc/store/v1/cart'
+			);
+			const nonce =
+				cartResponse.headers.get( 'Nonce' ) ||
+				cartResponse.headers.get( 'X-WC-Store-API-Nonce' );
+
+			window.wp.hooks.doAction(
+				'experimental__woocommerce_blocks-cart-add-item',
+				{
+					product: {
+						id: productID,
+						name: 'Simple product',
+						categories: [ { name: 'Uncategorized' } ],
+						quantity: 1,
+						prices: { price: 0, currency_minor_unit: 2 },
+					},
+				}
+			);
+
+			const response = await window.fetch(
+				'/wp-json/wc/store/v1/cart/add-item',
+				{
+					method: 'POST',
+					headers: {
+						'Content-Type': 'application/json',
+						...( nonce ? { Nonce: nonce } : {} ),
+					},
+					body: JSON.stringify( { id: productID, quantity: 1 } ),
+				}
+			);
+
+			if ( ! response.ok ) {
+				throw new Error( await response.text() );
+			}
+		}, simpleProductID );
+
+		// Wait for the first add_to_cart event to be sent, then allow time for a
+		// (de-duplicated) second one from the fetch interceptor's setTimeout(0).
+		await firstAddToCart;
+		await page.waitForTimeout( 1000 );
+
+		expect( addToCartEvents.length ).toBe( 1 );
+	} );
+
+	test( 'Store API add item request succeeds when tracking cart data is corrupted', async ( {
+		page,
+	} ) => {
+		const safetyProductID = await createSimpleProduct();
+		await page.goto( 'shop?orderby=date' );
+		await waitForStoreApiInterceptor( page );
+
+		const pageErrors = [];
+		page.on( 'pageerror', ( error ) => pageErrors.push( error.message ) );
+
+		const responseOk = await page.evaluate( async ( productID ) => {
+			const cartResponse = await window.fetch(
+				'/wp-json/wc/store/v1/cart'
+			);
+			const nonce =
+				cartResponse.headers.get( 'Nonce' ) ||
+				cartResponse.headers.get( 'X-WC-Store-API-Nonce' );
+			const originalSelect = window.wp?.data?.select;
+
+			if ( window.wp?.data ) {
+				window.wp.data.select = () => {
+					throw new Error( 'Corrupted cart store' );
+				};
+			}
+
+			const originalGa4wDataDescriptor = Object.getOwnPropertyDescriptor(
+				window.ga4w,
+				'data'
+			);
+			Object.defineProperty( window.ga4w, 'data', {
+				configurable: true,
+				get() {
+					throw new Error( 'Corrupted tracking data' );
+				},
+			} );
+
+			let addResponseOk;
+			let addedItemKey;
+			try {
+				const response = await window.fetch(
+					'/wp-json/wc/store/v1/cart/add-item',
+					{
+						method: 'POST',
+						headers: {
+							'Content-Type': 'application/json',
+							...( nonce ? { Nonce: nonce } : {} ),
+						},
+						body: JSON.stringify( {
+							id: productID,
+							quantity: 1,
+						} ),
+					}
+				);
+
+				addResponseOk = response.ok;
+				if ( response.ok ) {
+					const cart = await response.clone().json();
+					addedItemKey = cart.items.find(
+						( item ) => parseInt( item.id, 10 ) === productID
+					)?.key;
+				}
+			} finally {
+				if ( window.wp?.data && originalSelect ) {
+					window.wp.data.select = originalSelect;
+				}
+
+				Object.defineProperty(
+					window.ga4w,
+					'data',
+					originalGa4wDataDescriptor
+				);
+			}
+
+			if ( addedItemKey ) {
+				await window.fetch( '/wp-json/wc/store/v1/cart/remove-item', {
+					method: 'POST',
+					headers: {
+						'Content-Type': 'application/json',
+						...( nonce ? { Nonce: nonce } : {} ),
+					},
+					body: JSON.stringify( { key: addedItemKey } ),
+				} );
+			}
+
+			return addResponseOk;
+		}, safetyProductID );
+
+		await page.waitForTimeout( 100 );
+
+		expect( responseOk ).toBe( true );
+		expect( pageErrors ).toEqual( [] );
+	} );
+
+	test( 'Blocks add and checkout hooks tolerate malformed tracking payloads', async ( {
+		page,
+	} ) => {
+		await page.goto( 'shop?orderby=date' );
+
+		const pageErrors = [];
+		page.on( 'pageerror', ( error ) => pageErrors.push( error.message ) );
+
+		const hooksReturned = await page.evaluate( () => {
+			const product = {};
+			Object.defineProperties( product, {
+				id: {
+					get() {
+						throw new Error( 'Corrupted product ID' );
+					},
+				},
+				name: {
+					get() {
+						throw new Error( 'Corrupted product name' );
+					},
+				},
+			} );
+
+			const checkoutData = {};
+			Object.defineProperty( checkoutData, 'storeCart', {
+				get() {
+					throw new Error( 'Corrupted checkout cart' );
+				},
+			} );
+
+			window.wp.hooks.doAction(
+				'experimental__woocommerce_blocks-cart-add-item',
+				{ product }
+			);
+			window.wp.hooks.doAction(
+				'experimental__woocommerce_blocks-checkout-render-checkout-form',
+				checkoutData
+			);
+
+			return true;
+		} );
+
+		await page.waitForTimeout( 100 );
+
+		expect( hooksReturned ).toBe( true );
+		expect( pageErrors ).toEqual( [] );
 	} );
 
 	test( 'View item list event is sent from the shop page', async ( {

--- a/tests/e2e/utils/customer.js
+++ b/tests/e2e/utils/customer.js
@@ -92,6 +92,181 @@ export async function blockProductAddToCart( page, productID ) {
 }
 
 /**
+ * Waits for the plugin's Store API fetch interceptor to be installed.
+ *
+ * The interceptor wraps `window.fetch` from within `blocksTracking()`, which
+ * runs once `window.ga4w` is ready. We detect the wrap without relying on the
+ * function name (which a production build may minify) by checking that
+ * `window.fetch` is no longer the browser's native implementation.
+ *
+ * @param {Page} page
+ */
+export async function waitForStoreApiInterceptor( page ) {
+	await page.waitForFunction(
+		() =>
+			!! window.ga4w &&
+			! window.fetch.toString().includes( 'native code' )
+	);
+}
+
+/**
+ * Adds a product to the cart through the Store API, mirroring how the
+ * Interactivity API powered add-to-cart blocks (WooCommerce 10.4+) add items.
+ *
+ * Waits for the fetch interceptor first, and authenticates the request with a
+ * Store API nonce read from a GET /cart response header — the nonce is not
+ * reliably exposed on the page (e.g. `wcSettings.storeApiNonce`) for all page
+ * types, so reading it from the response header is the robust approach.
+ *
+ * @param {Page}   page
+ * @param {number} productID
+ * @param {number} [quantity=1]
+ */
+export async function storeApiAddToCart( page, productID, quantity = 1 ) {
+	await waitForStoreApiInterceptor( page );
+
+	await page.evaluate(
+		async ( { id, qty } ) => {
+			const cartResponse = await window.fetch(
+				'/wp-json/wc/store/v1/cart'
+			);
+			const nonce =
+				cartResponse.headers.get( 'Nonce' ) ||
+				cartResponse.headers.get( 'X-WC-Store-API-Nonce' );
+
+			const response = await window.fetch(
+				'/wp-json/wc/store/v1/cart/add-item',
+				{
+					method: 'POST',
+					headers: {
+						'Content-Type': 'application/json',
+						...( nonce ? { Nonce: nonce } : {} ),
+					},
+					body: JSON.stringify( { id, quantity: qty } ),
+				}
+			);
+
+			if ( ! response.ok ) {
+				throw new Error( await response.text() );
+			}
+		},
+		{ id: productID, qty: quantity }
+	);
+}
+
+/**
+ * Adds a product to the cart through the Store API batch endpoint, mirroring how
+ * the Interactivity API powered add-to-cart blocks (WooCommerce 10.4+) bundle
+ * their cart mutations into a single `/wc/store/v1/batch` request.
+ *
+ * @param {Page}   page
+ * @param {number} productID
+ * @param {number} [quantity=1]
+ */
+export async function storeApiBatchAddToCart( page, productID, quantity = 1 ) {
+	await waitForStoreApiInterceptor( page );
+
+	await page.evaluate(
+		async ( { id, qty } ) => {
+			const cartResponse = await window.fetch(
+				'/wp-json/wc/store/v1/cart'
+			);
+			const nonce =
+				cartResponse.headers.get( 'Nonce' ) ||
+				cartResponse.headers.get( 'X-WC-Store-API-Nonce' );
+
+			const response = await window.fetch( '/wp-json/wc/store/v1/batch', {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+					...( nonce ? { Nonce: nonce } : {} ),
+				},
+				body: JSON.stringify( {
+					requests: [
+						{
+							method: 'POST',
+							path: '/wc/store/v1/cart/add-item',
+							// Store API verifies the nonce per sub-request, so it
+							// must be repeated here, not only on the batch request.
+							headers: nonce ? { Nonce: nonce } : {},
+							body: { id, quantity: qty },
+						},
+					],
+				} ),
+			} );
+
+			if ( ! response.ok ) {
+				throw new Error( await response.text() );
+			}
+		},
+		{ id: productID, qty: quantity }
+	);
+}
+
+/**
+ * Raises the quantity of a cart item through the Store API batch endpoint,
+ * mirroring how the Interactivity API powered add-to-cart blocks increase the
+ * quantity of a product that is already in the cart (a `cart/update-item`
+ * request carrying the new total quantity).
+ *
+ * @param {Page}   page
+ * @param {number} productID
+ * @param {number} increaseBy How many units to add on top of the current quantity.
+ */
+export async function storeApiBatchIncreaseCartQuantity(
+	page,
+	productID,
+	increaseBy = 1
+) {
+	await waitForStoreApiInterceptor( page );
+
+	await page.evaluate(
+		async ( { id, delta } ) => {
+			const cartResponse = await window.fetch(
+				'/wp-json/wc/store/v1/cart'
+			);
+			const nonce =
+				cartResponse.headers.get( 'Nonce' ) ||
+				cartResponse.headers.get( 'X-WC-Store-API-Nonce' );
+			const cart = await cartResponse.json();
+			const item = cart.items.find(
+				( cartItem ) => parseInt( cartItem.id, 10 ) === id
+			);
+
+			if ( ! item ) {
+				throw new Error( `Product ${ id } is not in the cart` );
+			}
+
+			const response = await window.fetch( '/wp-json/wc/store/v1/batch', {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+					...( nonce ? { Nonce: nonce } : {} ),
+				},
+				body: JSON.stringify( {
+					requests: [
+						{
+							method: 'POST',
+							path: '/wc/store/v1/cart/update-item',
+							headers: nonce ? { Nonce: nonce } : {},
+							body: {
+								key: item.key,
+								quantity: item.quantity + delta,
+							},
+						},
+					],
+				} ),
+			} );
+
+			if ( ! response.ok ) {
+				throw new Error( await response.text() );
+			}
+		},
+		{ id: productID, delta: increaseBy }
+	);
+}
+
+/**
  * Perform checkout steps to purchase a product.
  *
  * @param {Page} page


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes STORMA-162

Tracks successful Store API add-item requests and avoids duplicate events when other cart hooks also fire.

### Checks:
* [x] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Screenshots:

N/A

### Detailed test instructions:

1. Enable GA4 tracking.
2. Add a product to cart through an Interactivity API add-to-cart flow.
3. Confirm one `add_to_cart` event is sent with the expected product and quantity.

### Additional details:

N/A

### Changelog entry

> Fix - Track Store API add-to-cart events without duplicate analytics events.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Code Review Summary

**2 issues found:**

**Bugs (2):**
- Incomplete request body handling remains: getRequestBody can return a raw Blob/ReadableStream (or other non-parsed bodies). parseAddItemRequestBody may then misinterpret the body (productId null / default quantity); code currently falls back to cart-diff matching but the raw-body path is still present.
- Product deduplication gaps remain: getAddDedupTokens returns [] for products without id/name/key, making wasRecentlyAdded/markRecentlyAdded no-ops and allowing duplicate add_to_cart events for such items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
