### PR TITLE
Improve tracking robustness

### DIFF
--- a/assets/js/src/integrations/blocks.js
+++ b/assets/js/src/integrations/blocks.js
@@ -2,11 +2,7 @@ import { removeAction } from '@wordpress/hooks';
 import { addUniqueAction, getProductFromID } from '../utils';
 import { ACTION_PREFIX, NAMESPACE } from '../constants';
 
-/*
- * Track whether the cart-remove-item hook fired recently.
- * Used to prevent duplicate remove_from_cart events.
- */
-let hookFiredRecently = false;
+const recentlyRemovedProducts = new Set();
 
 /**
  * Get currency settings from our plugin's settings.
@@ -35,6 +31,9 @@ const getCartData = () => {
 	// Fallback to static cart data from page load
 	return window.ga4w?.data?.cart;
 };
+
+const getProductDedupKey = ( product ) =>
+	product?.key ?? product?.id ?? product?.name;
 
 /**
  * Parse a price string into a numeric value using currency settings.
@@ -208,17 +207,12 @@ const trackMiniCartRemoval = ( getEventHandler ) => {
 		}
 
 		if ( product ) {
-			/*
-			 * Use setTimeout to allow the hook to fire first (if it's going to).
-			 * The hook sets hookFiredRecently=true synchronously, so by the time
-			 * this callback runs, we'll know if the hook handled it.
-			 */
+			const dedupKey = getProductDedupKey( product );
+
 			setTimeout( () => {
-				if ( ! hookFiredRecently ) {
+				if ( ! dedupKey || ! recentlyRemovedProducts.has( dedupKey ) ) {
 					getEventHandler( 'remove_from_cart' )( { product } );
 				}
-				// Reset the flag for the next removal
-				hookFiredRecently = false;
 			}, 0 );
 		}
 	} );
@@ -236,8 +230,16 @@ export const blocksTracking = ( getEventHandler ) => {
 		`${ ACTION_PREFIX }-cart-remove-item`,
 		NAMESPACE,
 		( data ) => {
-			// Mark that the hook fired to prevent duplicate events from click listener
-			hookFiredRecently = true;
+			const dedupKey = getProductDedupKey( data?.product );
+
+			if ( dedupKey ) {
+				recentlyRemovedProducts.add( dedupKey );
+				setTimeout(
+					() => recentlyRemovedProducts.delete( dedupKey ),
+					50
+				);
+			}
+
 			getEventHandler( 'remove_from_cart' )( data );
 		}
 	);

--- a/assets/js/src/integrations/classic.js
+++ b/assets/js/src/integrations/classic.js
@@ -49,8 +49,6 @@ export function classicTracking(
 		}
 	} );
 
-	// Handle runtime cart events.
-	const oldAddedToCart = document.body.onadded_to_cart;
 	/**
 	 * Track the custom add to cart event dispatched by WooCommerce Core
 	 *
@@ -59,18 +57,12 @@ export function classicTracking(
 	 * @param {string}        cartHash  - A string representing the hash of the cart after the update.
 	 * @param {HTMLElement[]} button    - An array of HTML elements representing the add to cart button.
 	 */
-	document.body.onadded_to_cart = function (
-		e,
-		fragments,
-		cartHash,
-		button
-	) {
-		if ( typeof oldAddedToCart === 'function' ) {
-			oldAddedToCart.apply( this, arguments );
-		}
+	function handleAddedToCart( e, fragments, cartHash, button ) {
+		const buttonElement = button?.[ 0 ] ?? button;
+
 		// Get product ID from data attribute (archive pages) or value (single product pages).
 		const productID = parseInt(
-			button?.[ 0 ]?.dataset.product_id || button?.[ 0 ]?.value
+			buttonElement?.dataset.product_id || buttonElement?.value
 		);
 
 		if ( Number.isNaN( productID ) ) {
@@ -93,7 +85,20 @@ export function classicTracking(
 		}
 
 		getEventHandler( 'add_to_cart' )( { product: productToHandle } );
-	};
+	}
+
+	document.body.addEventListener( 'added_to_cart', ( event ) => {
+		const detail = Array.isArray( event.detail )
+			? event.detail
+			: [
+					event.detail?.fragments,
+					event.detail?.cartHash,
+					event.detail?.button,
+			  ];
+
+		handleAddedToCart( event, ...detail );
+	} );
+	window.jQuery?.( document.body ).on( 'added_to_cart', handleAddedToCart );
 
 	/**
 	 * Attaches click event listeners to all remove from cart links

--- a/assets/js/src/integrations/classic.js
+++ b/assets/js/src/integrations/classic.js
@@ -87,6 +87,11 @@ export function classicTracking(
 		getEventHandler( 'add_to_cart' )( { product: productToHandle } );
 	}
 
+	// Behavior change vs. older versions: we no longer assign `document.body.onadded_to_cart`
+	// because that override pattern stomps on any handler set by another plugin (and is
+	// stomped by anything that runs after us). Sites that previously hooked in via
+	// `document.body.onadded_to_cart = ...` should migrate to `addEventListener` or jQuery
+	// `.on('added_to_cart', ...)` to coexist with this plugin.
 	document.body.addEventListener( 'added_to_cart', ( event ) => {
 		const detail = Array.isArray( event.detail )
 			? event.detail

--- a/assets/js/src/integrations/classic.js
+++ b/assets/js/src/integrations/classic.js
@@ -103,7 +103,7 @@ export function classicTracking(
 
 		handleAddedToCart( event, ...detail );
 	} );
-	window.jQuery?.( document.body ).on( 'added_to_cart', handleAddedToCart );
+	window.jQuery?.( document.body )?.on( 'added_to_cart', handleAddedToCart );
 
 	/**
 	 * Attaches click event listeners to all remove from cart links

--- a/includes/class-wc-abstract-google-analytics-js.php
+++ b/includes/class-wc-abstract-google-analytics-js.php
@@ -93,10 +93,18 @@ abstract class WC_Abstract_Google_Analytics_JS {
 			}
 		);
 
+		$product_list_items = 0;
+
 		add_filter(
 			'woocommerce_loop_add_to_cart_link',
-			function ( $button, $product ) {
-				$this->append_script_data( 'products', $this->get_formatted_product( $product ) );
+			function ( $button, $product ) use ( &$product_list_items ) {
+				$max_product_list_items = absint( apply_filters( 'woocommerce_ga_max_product_list_items', 50 ) );
+
+				if ( $product_list_items < $max_product_list_items ) {
+					$this->append_script_data( 'products', $this->get_formatted_product( $product ) );
+					++$product_list_items;
+				}
+
 				return $button;
 			},
 			10,

--- a/includes/class-wc-abstract-google-analytics-js.php
+++ b/includes/class-wc-abstract-google-analytics-js.php
@@ -93,13 +93,12 @@ abstract class WC_Abstract_Google_Analytics_JS {
 			}
 		);
 
-		$product_list_items = 0;
+		$product_list_items     = 0;
+		$max_product_list_items = absint( apply_filters( 'woocommerce_ga_max_product_list_items', 50 ) );
 
 		add_filter(
 			'woocommerce_loop_add_to_cart_link',
-			function ( $button, $product ) use ( &$product_list_items ) {
-				$max_product_list_items = absint( apply_filters( 'woocommerce_ga_max_product_list_items', 50 ) );
-
+			function ( $button, $product ) use ( &$product_list_items, $max_product_list_items ) {
 				if ( $product_list_items < $max_product_list_items ) {
 					$this->append_script_data( 'products', $this->get_formatted_product( $product ) );
 					++$product_list_items;

--- a/includes/class-wc-google-analytics.php
+++ b/includes/class-wc-google-analytics.php
@@ -214,6 +214,8 @@ class WC_Google_Analytics extends WC_Integration {
 	public function show_options_info() {
 		$this->method_description .= "<div class='notice notice-info'><p>" . __( 'Please allow Google Analytics 24 hours to start displaying results.', 'woocommerce-google-analytics-integration' ) . '</p></div>';
 
+		// Nonce verification is handled by WC_Integration::process_admin_options().
+		// This callback runs on woocommerce_update_options_integration_google_analytics, which is already nonce-protected.
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		if ( isset( $_REQUEST['woocommerce_google_analytics_ga_ecommerce_tracking_enabled'] ) && true === (bool) $_REQUEST['woocommerce_google_analytics_ga_ecommerce_tracking_enabled'] ) {
 			$this->method_description .= "<div class='notice notice-info'><p>" . __( 'Please note, for transaction tracking to work properly, you will need to use a payment gateway that redirects the customer back to a WooCommerce order received/thank you page.', 'woocommerce-google-analytics-integration' ) . '</div>';

--- a/includes/class-wc-google-gtag-js.php
+++ b/includes/class-wc-google-gtag-js.php
@@ -285,13 +285,41 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 				'allow_google_signals' => 'yes' === $this->get( 'ga_support_display_advertising' ),
 				'logged_in'            => is_user_logged_in(),
 				'linker'               => array(
-					'domains'        => ! empty( $this->get( 'ga_linker_cross_domains' ) ) ? array_map( 'esc_js', explode( ',', $this->get( 'ga_linker_cross_domains' ) ) ) : array(),
+					'domains'        => $this->get_linker_domains(),
 					'allow_incoming' => 'yes' === $this->get( 'ga_linker_allow_incoming_enabled' ),
 				),
 				'custom_map'           => array(
 					'dimension1' => 'logged_in',
 				),
 			),
+		);
+	}
+
+	/**
+	 * Get validated cross-domain linker domains.
+	 *
+	 * @return array
+	 */
+	private function get_linker_domains(): array {
+		if ( empty( $this->get( 'ga_linker_cross_domains' ) ) ) {
+			return array();
+		}
+
+		return array_values(
+			array_filter(
+				array_map(
+					function ( string $domain ) {
+						$domain = trim( $domain );
+
+						if ( preg_match( '/^(?=.{1,253}$)(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,63}$/i', $domain ) ) {
+							return esc_js( $domain );
+						}
+
+						return null;
+					},
+					explode( ',', $this->get( 'ga_linker_cross_domains' ) )
+				)
+			)
 		);
 	}
 

--- a/includes/class-wc-google-gtag-js.php
+++ b/includes/class-wc-google-gtag-js.php
@@ -311,6 +311,9 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 					function ( string $domain ) {
 						$domain = trim( $domain );
 
+						// Validate the domain as ASCII RFC 1035 / RFC 1123 style. The lookahead caps the total length
+						// at the 253-character DNS limit; each label is 1-63 chars and starts/ends with alphanumerics;
+						// the TLD is 2-63 letters. Invalid entries (including XSS attempts) are silently dropped.
 						if ( preg_match( '/^(?=.{1,253}$)(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,63}$/i', $domain ) ) {
 							return esc_js( $domain );
 						}

--- a/includes/class-wc-google-gtag-js.php
+++ b/includes/class-wc-google-gtag-js.php
@@ -313,8 +313,8 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 
 						// Validate the domain as ASCII RFC 1035 / RFC 1123 style. The lookahead caps the total length
 						// at the 253-character DNS limit; each label is 1-63 chars and starts/ends with alphanumerics;
-						// the TLD is 2-63 letters. Invalid entries (including XSS attempts) are silently dropped.
-						if ( preg_match( '/^(?=.{1,253}$)(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,63}$/i', $domain ) ) {
+						// the TLD is 2-63 ASCII chars to allow punycode domains. Invalid entries are silently dropped.
+						if ( preg_match( '/^(?=.{1,253}$)(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])$/i', $domain ) ) {
 							return esc_js( $domain );
 						}
 

--- a/tests/unit-tests/Configuration.php
+++ b/tests/unit-tests/Configuration.php
@@ -108,10 +108,10 @@ class Configuration extends EventsDataTest {
 	 * @return void
 	 */
 	public function test_get_site_tag_config_linker_domains_rejects_invalid_domains() {
-		$gtag   = new WC_Google_Gtag_JS( [ 'ga_linker_cross_domains' => 'example.com, bad domain, https://example.net, sub.example.org, example, -bad.com, ok-store.co.uk' ] );
+		$gtag   = new WC_Google_Gtag_JS( [ 'ga_linker_cross_domains' => 'example.com, bad domain, https://example.net, sub.example.org, example, -bad.com, ok-store.co.uk, shop.xn--p1ai' ] );
 		$config = $gtag->get_site_tag_config();
 
-		$this->assertEquals( [ 'example.com', 'sub.example.org', 'ok-store.co.uk' ], $config['linker']['domains'] );
+		$this->assertEquals( [ 'example.com', 'sub.example.org', 'ok-store.co.uk', 'shop.xn--p1ai' ], $config['linker']['domains'] );
 	}
 
 	/**

--- a/tests/unit-tests/Configuration.php
+++ b/tests/unit-tests/Configuration.php
@@ -91,7 +91,7 @@ class Configuration extends EventsDataTest {
 	}
 
 	/**
-	 * Test that whitespace in linker domains is preserved (documents current behavior).
+	 * Test that whitespace in linker domains is trimmed.
 	 *
 	 * @return void
 	 */
@@ -99,7 +99,19 @@ class Configuration extends EventsDataTest {
 		$gtag   = new WC_Google_Gtag_JS( [ 'ga_linker_cross_domains' => 'example.com, example.net' ] );
 		$config = $gtag->get_site_tag_config();
 
-		$this->assertEquals( [ 'example.com', ' example.net' ], $config['linker']['domains'] );
+		$this->assertEquals( [ 'example.com', 'example.net' ], $config['linker']['domains'] );
+	}
+
+	/**
+	 * Test that invalid linker domains are ignored.
+	 *
+	 * @return void
+	 */
+	public function test_get_site_tag_config_linker_domains_rejects_invalid_domains() {
+		$gtag   = new WC_Google_Gtag_JS( [ 'ga_linker_cross_domains' => 'example.com, bad domain, https://example.net, sub.example.org, example, -bad.com, ok-store.co.uk' ] );
+		$config = $gtag->get_site_tag_config();
+
+		$this->assertEquals( [ 'example.com', 'sub.example.org', 'ok-store.co.uk' ], $config['linker']['domains'] );
 	}
 
 	/**

--- a/tests/unit-tests/WCGoogleGtagJS.php
+++ b/tests/unit-tests/WCGoogleGtagJS.php
@@ -141,6 +141,55 @@ class WCGoogleGtagJS extends EventsDataTest {
 	}
 
 	/**
+	 * Test that product list data is capped to avoid oversized inline payloads.
+	 *
+	 * @return void
+	 */
+	public function test_product_list_data_is_limited(): void {
+		remove_all_filters( 'woocommerce_loop_add_to_cart_link' );
+
+		$gtag    = new WC_Google_Gtag_JS();
+		$product = WC_Helper_Product::create_simple_product();
+
+		for ( $i = 0; $i < 51; $i++ ) {
+			apply_filters( 'woocommerce_loop_add_to_cart_link', '', $product );
+		}
+
+		$script_data = json_decode( $gtag->get_script_data(), true );
+
+		$this->assertCount( 50, $script_data['products'] );
+	}
+
+	/**
+	 * Test that the product list data cap can be customized.
+	 *
+	 * @return void
+	 */
+	public function test_product_list_data_limit_is_filterable(): void {
+		remove_all_filters( 'woocommerce_loop_add_to_cart_link' );
+
+		add_filter(
+			'woocommerce_ga_max_product_list_items',
+			function () {
+				return 2;
+			}
+		);
+
+		$gtag    = new WC_Google_Gtag_JS();
+		$product = WC_Helper_Product::create_simple_product();
+
+		for ( $i = 0; $i < 3; $i++ ) {
+			apply_filters( 'woocommerce_loop_add_to_cart_link', '', $product );
+		}
+
+		remove_all_filters( 'woocommerce_ga_max_product_list_items' );
+
+		$script_data = json_decode( $gtag->get_script_data(), true );
+
+		$this->assertCount( 2, $script_data['products'] );
+	}
+
+	/**
 	 * Test the tracker_var filter `woocommerce_gtag_tracker_variable`
 	 *
 	 * @return void


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Linear: [STORMA-160](https://linear.app/a8c/issue/STORMA-160)

Issue: Several tracking paths needed better limits, safer event binding, and stricter settings handling.
Fix: Caps product-list payloads, hardens cart event handling, and validates linker domains.

### Checks:
* [x] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [x] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Screenshots:

N/A

### Detailed test instructions:

1. Load product listing pages and confirm analytics payloads are limited as expected.
2. Add and remove cart items and confirm tracking events still fire once.
3. Save linker domain settings and confirm invalid domains are ignored.

### Additional details:

Local lint/build checks passed.

### Changelog entry

> Tweak - Improve tracking payload limits, cart event binding, and linker domain validation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
**3 issues found:**

1. **Bug** - Cart event deduplication: Duplicate `remove_from_cart` events were firing when products were removed from the cart. Fixed by refactoring deduplication to use a `recentlyRemovedProducts` Set with stable dedup keys and timed removal.

2. **Performance** - Excessive analytics payloads on product listing pages: Product list tracking appended data for every loop item with no limit. Fixed by adding a configurable cap (`woocommerce_ga_max_product_list_items`, default 50).

3. **Bug** - Invalid linker domain configuration handling: Cross-domain linker entries were not validated. Fixed by adding domain validation (RFC-style checks, trimming/escaping) and ignoring invalid entries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/woocommerce/woocommerce-google-analytics-integration/pull/596?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->