### PR TITLE
Use get_order_number() for GA4 transaction_id

### DIFF
--- a/includes/class-wc-abstract-google-analytics-js.php
+++ b/includes/class-wc-abstract-google-analytics-js.php
@@ -339,8 +339,19 @@ abstract class WC_Abstract_Google_Analytics_JS {
 	 * @return array
 	 */
 	public function get_formatted_order( $order ): array {
+		/**
+		 * Filter the order identifier sent to Google Analytics as `transaction_id`.
+		 *
+		 * Defaults to `WC_Abstract_Order::get_order_number()`, which honors sequential
+		 * and custom order number plugins via the `woocommerce_order_number` filter.
+		 *
+		 * @param string            $order_id Order identifier sent to GA.
+		 * @param WC_Abstract_Order $order    Order being formatted.
+		 */
+		$order_id = apply_filters( 'woocommerce_ga_order_id', $order->get_order_number(), $order );
+
 		return array(
-			'id'          => $order->get_id(),
+			'id'          => $order_id,
 			'affiliation' => get_bloginfo( 'name' ),
 			'totals'      => array(
 				'currency_code'       => $order->get_currency(),

--- a/tests/unit-tests/DataFormatting.php
+++ b/tests/unit-tests/DataFormatting.php
@@ -248,16 +248,61 @@ class DataFormatting extends EventsDataTest {
 	}
 
 	/**
-	 * Test that order ID and blog name affiliation are returned.
+	 * Test that the WooCommerce order number and blog name affiliation are returned.
 	 *
 	 * @return void
 	 */
-	public function test_get_formatted_order_returns_id_and_affiliation() {
+	public function test_get_formatted_order_returns_order_number_and_affiliation() {
 		$order     = $this->create_order_with_product();
 		$formatted = $this->gtag->get_formatted_order( $order );
 
-		$this->assertEquals( $order->get_id(), $formatted['id'] );
+		$this->assertEquals( $order->get_order_number(), $formatted['id'] );
 		$this->assertEquals( get_bloginfo( 'name' ), $formatted['affiliation'] );
+	}
+
+	/**
+	 * Test that a custom order number (e.g., from a sequential order numbers plugin)
+	 * is honored via the woocommerce_order_number filter.
+	 *
+	 * @return void
+	 */
+	public function test_get_formatted_order_honors_woocommerce_order_number_filter() {
+		$order  = $this->create_order_with_product();
+		$custom = 'CUSTOM-' . $order->get_id();
+
+		$callback = function ( $order_number, $passed_order ) use ( $order, $custom ) {
+			return $passed_order->get_id() === $order->get_id() ? $custom : $order_number;
+		};
+		add_filter( 'woocommerce_order_number', $callback, 10, 2 );
+
+		try {
+			$formatted = $this->gtag->get_formatted_order( $order );
+			$this->assertEquals( $custom, $formatted['id'] );
+		} finally {
+			remove_filter( 'woocommerce_order_number', $callback, 10 );
+		}
+	}
+
+	/**
+	 * Test that the woocommerce_ga_order_id filter overrides the order identifier
+	 * sent to GA without affecting WooCommerce's order number elsewhere.
+	 *
+	 * @return void
+	 */
+	public function test_get_formatted_order_honors_woocommerce_ga_order_id_filter() {
+		$order = $this->create_order_with_product();
+
+		$callback = function () {
+			return 'GA-OVERRIDE';
+		};
+		add_filter( 'woocommerce_ga_order_id', $callback );
+
+		try {
+			$formatted = $this->gtag->get_formatted_order( $order );
+			$this->assertEquals( 'GA-OVERRIDE', $formatted['id'] );
+		} finally {
+			remove_filter( 'woocommerce_ga_order_id', $callback );
+		}
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #592. Closes https://linear.app/a8c/issue/STORMA-164.

The plugin currently sends `$order->get_id()` (the internal DB ID) to GA4 as `transaction_id`. For stores using sequential or custom order number plugins, the value in GA4 diverges from the order number the merchant and customer see everywhere else.

This PR swaps `get_id()` for `get_order_number()` in `WC_Abstract_Google_Analytics_JS::get_formatted_order()`, and wraps the value in a new `woocommerce_ga_order_id` filter for extensibility — mirroring the existing `woocommerce_ga_product_identifier` pattern used for products.

On stock WooCommerce, `get_order_number()` returns `(string) $order->get_id()`, so behavior is unchanged for default setups. Sequential/custom order number plugins (and anyone who hooks `woocommerce_order_number`) now flow through to GA4 as expected. HPOS-compatible by virtue of using the public order API.

### Checks:
* [x] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Detailed test instructions:

**Unit tests (run locally):**

```
npm run wp-env:up
npm run test:php:setup
npm run test:php -- --filter DataFormatting
```

Should output `OK (22 tests, 60 assertions)`. The relevant tests are:
- `test_get_formatted_order_returns_order_number_and_affiliation`
- `test_get_formatted_order_honors_woocommerce_order_number_filter`
- `test_get_formatted_order_honors_woocommerce_ga_order_id_filter`

**Manual:**

1. Install a sequential order numbers plugin, or drop a temporary mu-plugin filtering `woocommerce_order_number` to return a custom value (e.g. `STORMA-164-{\$order_number}`).
2. Place a test order with GA tracking enabled.
3. On the thank-you page, inspect the GA `purchase` event payload (DevTools → Network → `collect` request) — `transaction_id` should be the custom order number, not the internal DB ID.

### Additional details:

> Fix - GA4 \`transaction_id\` now uses \`WC_Abstract_Order::get_order_number()\` so sequential and custom order number plugins are reflected in Google Analytics reports. Add \`woocommerce_ga_order_id\` filter for further customization.

### Changelog entry

> Update - Use get_order_number() for transaction_id.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

The implementation correctly uses the public WooCommerce order API (`get_order_number()`), includes proper filter documentation and parameters, maintains backward compatibility, and includes comprehensive test coverage with proper resource cleanup via try/finally blocks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/woocommerce/woocommerce-google-analytics-integration/pull/597?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->