### PR TITLE
Persist add_to_cart event across cart redirect

### DIFF
--- a/includes/class-wc-abstract-google-analytics-js.php
+++ b/includes/class-wc-abstract-google-analytics-js.php
@@ -85,9 +85,10 @@ abstract class WC_Abstract_Google_Analytics_JS {
 
 		add_action( 'woocommerce_add_to_cart', array( $this, 'capture_added_to_cart' ), 10, 5 );
 
-		// When WC redirects after a successful classic add-to-cart, in-memory script data is lost before render.
+		// When WC redirects after a successful add-to-cart, in-memory script data is lost before render.
 		// Stash the formatted product in the WC session so the next request can re-emit it. Issue #427 / STORMA-42.
 		add_filter( 'woocommerce_add_to_cart_redirect', array( $this, 'persist_added_to_cart_for_redirect' ) );
+		add_action( 'woocommerce_ajax_added_to_cart', array( $this, 'persist_added_to_cart_for_ajax_redirect' ) );
 
 		// On the redirected page, restore the captured event data and mark add_to_cart for firing.
 		add_action( 'wp_head', array( $this, 'restore_added_to_cart_from_session' ), 1 );
@@ -356,19 +357,44 @@ abstract class WC_Abstract_Google_Analytics_JS {
 	}
 
 	/**
-	 * Persist the captured `added_to_cart` payload into the WC session immediately
-	 * before WC issues an add-to-cart redirect. The next page request will pick it
-	 * up via `restore_added_to_cart_from_session()` and fire the event.
+	 * Persist the captured `added_to_cart` payload into the WC session when a
+	 * classic add-to-cart request is going to redirect. The next page request
+	 * will pick it up via `restore_added_to_cart_from_session()` and fire the
+	 * event.
 	 *
-	 * @param string $url Redirect URL (returned unchanged).
+	 * @param string|false $url Redirect URL (returned unchanged).
 	 *
-	 * @return string
+	 * @return string|false
 	 */
 	public function persist_added_to_cart_for_redirect( $url ) {
+		if ( $url || 'yes' === get_option( 'woocommerce_cart_redirect_after_add' ) ) {
+			$this->persist_pending_added_to_cart();
+		}
+		return $url;
+	}
+
+	/**
+	 * Persist the captured `added_to_cart` payload when WooCommerce's legacy
+	 * AJAX add-to-cart handler will redirect the browser before it fires the
+	 * `added_to_cart` JavaScript event.
+	 *
+	 * @return void
+	 */
+	public function persist_added_to_cart_for_ajax_redirect(): void {
+		if ( 'yes' === get_option( 'woocommerce_cart_redirect_after_add' ) ) {
+			$this->persist_pending_added_to_cart();
+		}
+	}
+
+	/**
+	 * Persist the pending add-to-cart payload into the WC session.
+	 *
+	 * @return void
+	 */
+	private function persist_pending_added_to_cart(): void {
 		if ( $this->pending_added_to_cart && WC()->session ) {
 			WC()->session->set( self::PENDING_ADDED_TO_CART_SESSION_KEY, $this->pending_added_to_cart );
 		}
-		return $url;
 	}
 
 	/**

--- a/includes/class-wc-abstract-google-analytics-js.php
+++ b/includes/class-wc-abstract-google-analytics-js.php
@@ -23,6 +23,12 @@ abstract class WC_Abstract_Google_Analytics_JS {
 	/** @var string Developer ID */
 	public const DEVELOPER_ID = 'dOGY3NW';
 
+	/** @var string WC session key used to carry add_to_cart event data across an add-to-cart redirect. */
+	protected const PENDING_ADDED_TO_CART_SESSION_KEY = '_ga_pending_added_to_cart';
+
+	/** @var array|null Formatted product data captured during the current request's woocommerce_add_to_cart action. */
+	protected $pending_added_to_cart = null;
+
 	/**
 	 * Constructor
 	 * To be called from child classes to setup event data
@@ -77,14 +83,14 @@ abstract class WC_Abstract_Google_Analytics_JS {
 			}
 		);
 
-		add_action(
-			'woocommerce_add_to_cart',
-			function ( $cart_item_key, $product_id, $quantity, $variation_id, $variation ) {
-				$this->set_script_data( 'added_to_cart', $this->get_formatted_product( wc_get_product( $product_id ), $variation_id, $variation, $quantity ) );
-			},
-			10,
-			5
-		);
+		add_action( 'woocommerce_add_to_cart', array( $this, 'capture_added_to_cart' ), 10, 5 );
+
+		// When WC redirects after a successful classic add-to-cart, in-memory script data is lost before render.
+		// Stash the formatted product in the WC session so the next request can re-emit it. Issue #427 / STORMA-42.
+		add_filter( 'woocommerce_add_to_cart_redirect', array( $this, 'persist_added_to_cart_for_redirect' ) );
+
+		// On the redirected page, restore the captured event data and mark add_to_cart for firing.
+		add_action( 'wp_head', array( $this, 'restore_added_to_cart_from_session' ), 1 );
 
 		add_action(
 			'wp_head',
@@ -329,6 +335,60 @@ abstract class WC_Abstract_Google_Analytics_JS {
 		}
 
 		return $formatted;
+	}
+
+	/**
+	 * Capture the product added to the cart so it can either be rendered now
+	 * (no redirect) or persisted into the WC session (if WC will redirect).
+	 *
+	 * @param string     $cart_item_key Cart item key.
+	 * @param int        $product_id    Product ID being added.
+	 * @param int|string $quantity      Quantity added.
+	 * @param int        $variation_id  Variation ID (0 if not a variation).
+	 * @param array      $variation     Variation attributes.
+	 *
+	 * @return void
+	 */
+	public function capture_added_to_cart( $cart_item_key, $product_id, $quantity, $variation_id, $variation ): void {
+		$formatted = $this->get_formatted_product( wc_get_product( $product_id ), $variation_id, $variation, $quantity );
+		$this->set_script_data( 'added_to_cart', $formatted );
+		$this->pending_added_to_cart = $formatted;
+	}
+
+	/**
+	 * Persist the captured `added_to_cart` payload into the WC session immediately
+	 * before WC issues an add-to-cart redirect. The next page request will pick it
+	 * up via `restore_added_to_cart_from_session()` and fire the event.
+	 *
+	 * @param string $url Redirect URL (returned unchanged).
+	 *
+	 * @return string
+	 */
+	public function persist_added_to_cart_for_redirect( $url ) {
+		if ( $this->pending_added_to_cart && WC()->session ) {
+			WC()->session->set( self::PENDING_ADDED_TO_CART_SESSION_KEY, $this->pending_added_to_cart );
+		}
+		return $url;
+	}
+
+	/**
+	 * Restore an `added_to_cart` payload that was stashed before a redirect,
+	 * append `add_to_cart` to the events array, and consume the session key
+	 * so the event only fires once.
+	 *
+	 * @return void
+	 */
+	public function restore_added_to_cart_from_session(): void {
+		if ( ! WC()->session ) {
+			return;
+		}
+		$pending = WC()->session->get( self::PENDING_ADDED_TO_CART_SESSION_KEY );
+		if ( ! $pending ) {
+			return;
+		}
+		$this->set_script_data( 'added_to_cart', $pending );
+		$this->append_script_data( 'events', 'add_to_cart' );
+		WC()->session->__unset( self::PENDING_ADDED_TO_CART_SESSION_KEY );
 	}
 
 	/**

--- a/tests/unit-tests/AddToCartRedirectSurvival.php
+++ b/tests/unit-tests/AddToCartRedirectSurvival.php
@@ -23,6 +23,9 @@ class AddToCartRedirectSurvival extends EventsDataTest {
 	/** @var WC_Google_Gtag_JS */
 	private $gtag;
 
+	/** @var string */
+	private $cart_redirect_after_add;
+
 	/**
 	 * Set up the gtag instance and ensure a clean WC session for each test.
 	 *
@@ -30,7 +33,8 @@ class AddToCartRedirectSurvival extends EventsDataTest {
 	 */
 	public function set_up() {
 		parent::set_up();
-		$this->gtag = new WC_Google_Gtag_JS( [ 'ga_product_identifier' => 'product_id' ] );
+		$this->gtag                    = new WC_Google_Gtag_JS( [ 'ga_product_identifier' => 'product_id' ] );
+		$this->cart_redirect_after_add = get_option( 'woocommerce_cart_redirect_after_add', 'no' );
 
 		if ( WC()->session === null && class_exists( 'WC_Session_Handler' ) ) {
 			WC()->initialize_session();
@@ -49,6 +53,7 @@ class AddToCartRedirectSurvival extends EventsDataTest {
 		if ( WC()->session ) {
 			WC()->session->__unset( '_ga_pending_added_to_cart' );
 		}
+		update_option( 'woocommerce_cart_redirect_after_add', $this->cart_redirect_after_add );
 		parent::tear_down();
 	}
 
@@ -79,9 +84,69 @@ class AddToCartRedirectSurvival extends EventsDataTest {
 	}
 
 	/**
-	 * Without the redirect filter firing (e.g. AJAX or Store API add), nothing
-	 * is persisted to session — otherwise a subsequent unrelated page load
-	 * would over-fire add_to_cart.
+	 * If WC applies the redirect filter but does not actually redirect, nothing
+	 * is persisted to session — otherwise the same page load would over-fire
+	 * add_to_cart.
+	 *
+	 * @return void
+	 */
+	public function test_redirect_filter_does_not_persist_without_redirect_destination_or_option() {
+		update_option( 'woocommerce_cart_redirect_after_add', 'no' );
+
+		$product = WC_Helper_Product::create_simple_product();
+		$this->gtag->capture_added_to_cart( 'mock-key', $product->get_id(), 1, 0, [] );
+		$this->gtag->append_script_data( 'events', 'add_to_cart' );
+		$this->gtag->persist_added_to_cart_for_redirect( false );
+		$this->gtag->restore_added_to_cart_from_session();
+
+		$data = $this->script_data();
+
+		$this->assertEmpty( WC()->session->get( '_ga_pending_added_to_cart' ) );
+		$this->assertEquals( [ 'add_to_cart' ], $data['events'] );
+	}
+
+	/**
+	 * When WC redirects via the global cart redirect option, the redirect filter
+	 * receives an empty URL before WC checks the option. The pending product
+	 * still needs to survive to the redirected cart page.
+	 *
+	 * @return void
+	 */
+	public function test_redirect_filter_persists_when_wc_redirect_option_enabled() {
+		update_option( 'woocommerce_cart_redirect_after_add', 'yes' );
+
+		$product = WC_Helper_Product::create_simple_product();
+		$this->gtag->capture_added_to_cart( 'mock-key', $product->get_id(), 1, 0, [] );
+		$this->gtag->persist_added_to_cart_for_redirect( false );
+
+		$pending = WC()->session->get( '_ga_pending_added_to_cart' );
+		$this->assertIsArray( $pending );
+		$this->assertSame( $product->get_id(), $pending['id'] );
+	}
+
+	/**
+	 * AJAX adds with WC's redirect-after-add option enabled redirect in
+	 * WooCommerce's frontend JS before the `added_to_cart` event fires, so they
+	 * need the same one-shot session handoff.
+	 *
+	 * @return void
+	 */
+	public function test_ajax_redirect_persists_when_wc_redirect_option_enabled() {
+		update_option( 'woocommerce_cart_redirect_after_add', 'yes' );
+
+		$product = WC_Helper_Product::create_simple_product();
+		$this->gtag->capture_added_to_cart( 'mock-key', $product->get_id(), 1, 0, [] );
+		$this->gtag->persist_added_to_cart_for_ajax_redirect();
+
+		$pending = WC()->session->get( '_ga_pending_added_to_cart' );
+		$this->assertIsArray( $pending );
+		$this->assertSame( $product->get_id(), $pending['id'] );
+	}
+
+	/**
+	 * Without a redirecting path (e.g. Store API add), nothing is persisted to
+	 * session — otherwise a subsequent unrelated page load would over-fire
+	 * add_to_cart.
 	 *
 	 * @return void
 	 */

--- a/tests/unit-tests/AddToCartRedirectSurvival.php
+++ b/tests/unit-tests/AddToCartRedirectSurvival.php
@@ -23,6 +23,11 @@ class AddToCartRedirectSurvival extends EventsDataTest {
 	/** @var WC_Google_Gtag_JS */
 	private $gtag;
 
+	/**
+	 * Set up the gtag instance and ensure a clean WC session for each test.
+	 *
+	 * @return void
+	 */
 	public function set_up() {
 		parent::set_up();
 		$this->gtag = new WC_Google_Gtag_JS( [ 'ga_product_identifier' => 'product_id' ] );
@@ -35,6 +40,11 @@ class AddToCartRedirectSurvival extends EventsDataTest {
 		}
 	}
 
+	/**
+	 * Drop any pending session entry so it doesn't leak into the next test.
+	 *
+	 * @return void
+	 */
 	public function tear_down() {
 		if ( WC()->session ) {
 			WC()->session->__unset( '_ga_pending_added_to_cart' );
@@ -96,7 +106,10 @@ class AddToCartRedirectSurvival extends EventsDataTest {
 			'id'         => 999,
 			'name'       => 'Test Product',
 			'categories' => [],
-			'prices'     => [ 'price' => 1999, 'currency_minor_unit' => 2 ],
+			'prices'     => [
+				'price'               => 1999,
+				'currency_minor_unit' => 2,
+			],
 			'extensions' => [],
 			'quantity'   => 1,
 		];

--- a/tests/unit-tests/AddToCartRedirectSurvival.php
+++ b/tests/unit-tests/AddToCartRedirectSurvival.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace GoogleAnalyticsIntegration\Tests;
+
+use WC_Google_Gtag_JS;
+use WC_Helper_Product;
+
+/**
+ * Unit tests for the redirect-survival of the add_to_cart event.
+ *
+ * Covers STORMA-42 / #427: when "Redirect to the cart page after successful addition"
+ * is enabled, in-memory script data is lost before render. The fix persists the
+ * formatted product through the WC session and restores it on the next request.
+ *
+ * Tests exercise the named handler methods directly rather than firing
+ * `do_action()`, to avoid coupling assertions to global-state side-effects from
+ * other tests' gtag instances.
+ *
+ * @package GoogleAnalyticsIntegration\Tests
+ */
+class AddToCartRedirectSurvival extends EventsDataTest {
+
+	/** @var WC_Google_Gtag_JS */
+	private $gtag;
+
+	public function set_up() {
+		parent::set_up();
+		$this->gtag = new WC_Google_Gtag_JS( [ 'ga_product_identifier' => 'product_id' ] );
+
+		if ( WC()->session === null && class_exists( 'WC_Session_Handler' ) ) {
+			WC()->initialize_session();
+		}
+		if ( WC()->session ) {
+			WC()->session->__unset( '_ga_pending_added_to_cart' );
+		}
+	}
+
+	public function tear_down() {
+		if ( WC()->session ) {
+			WC()->session->__unset( '_ga_pending_added_to_cart' );
+		}
+		parent::tear_down();
+	}
+
+	/**
+	 * Helper: decode the gtag instance's current script_data JSON.
+	 *
+	 * @return array
+	 */
+	private function script_data(): array {
+		return json_decode( $this->gtag->get_script_data(), true );
+	}
+
+	/**
+	 * The redirect filter stashes the formatted product into WC session,
+	 * so the next request can restore it after the redirect.
+	 *
+	 * @return void
+	 */
+	public function test_redirect_filter_persists_added_to_cart_to_session() {
+		$product = WC_Helper_Product::create_simple_product();
+		$this->gtag->capture_added_to_cart( 'mock-key', $product->get_id(), 1, 0, [] );
+		$this->gtag->persist_added_to_cart_for_redirect( 'http://example.test/cart' );
+
+		$pending = WC()->session->get( '_ga_pending_added_to_cart' );
+		$this->assertIsArray( $pending );
+		$this->assertSame( $product->get_id(), $pending['id'] );
+		$this->assertSame( $product->get_title(), $pending['name'] );
+	}
+
+	/**
+	 * Without the redirect filter firing (e.g. AJAX or Store API add), nothing
+	 * is persisted to session — otherwise a subsequent unrelated page load
+	 * would over-fire add_to_cart.
+	 *
+	 * @return void
+	 */
+	public function test_no_session_stash_when_redirect_filter_does_not_fire() {
+		$product = WC_Helper_Product::create_simple_product();
+		$this->gtag->capture_added_to_cart( 'mock-key', $product->get_id(), 1, 0, [] );
+		// Intentionally skip persist_added_to_cart_for_redirect().
+
+		$pending = WC()->session->get( '_ga_pending_added_to_cart' );
+		$this->assertEmpty( $pending, 'No session entry should be created when WC does not redirect.' );
+	}
+
+	/**
+	 * On the redirected page, the restore method restores the formatted product
+	 * as `added_to_cart` script data, appends `add_to_cart` to the events list,
+	 * and clears the session key so it only fires once.
+	 *
+	 * @return void
+	 */
+	public function test_restore_from_session_populates_script_data_and_clears() {
+		$fake_product = [
+			'id'         => 999,
+			'name'       => 'Test Product',
+			'categories' => [],
+			'prices'     => [ 'price' => 1999, 'currency_minor_unit' => 2 ],
+			'extensions' => [],
+			'quantity'   => 1,
+		];
+		WC()->session->set( '_ga_pending_added_to_cart', $fake_product );
+
+		$this->gtag->restore_added_to_cart_from_session();
+
+		$data = $this->script_data();
+
+		$this->assertArrayHasKey( 'added_to_cart', $data );
+		$this->assertEquals( $fake_product, $data['added_to_cart'] );
+
+		$this->assertArrayHasKey( 'events', $data );
+		$this->assertContains( 'add_to_cart', $data['events'] );
+
+		$this->assertEmpty(
+			WC()->session->get( '_ga_pending_added_to_cart' ),
+			'Session key should be cleared after consumption (one-shot).'
+		);
+	}
+
+	/**
+	 * If no session entry exists, the restore method is a no-op.
+	 *
+	 * @return void
+	 */
+	public function test_restore_is_noop_without_session_entry() {
+		$this->gtag->restore_added_to_cart_from_session();
+
+		$data = $this->script_data();
+
+		$this->assertArrayNotHasKey( 'added_to_cart', $data );
+		$events = $data['events'] ?? [];
+		$this->assertNotContains( 'add_to_cart', $events );
+	}
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #427. Closes https://linear.app/a8c/issue/STORMA-42.
Also closes #394 / https://linear.app/a8c/issue/STORMA-38 — same bug, same code path, filed independently two months earlier.

When **WooCommerce > Settings > Products > "Redirect to the cart page after successful addition"** is enabled, the GA4 `add_to_cart` event is never fired after a classic (non-AJAX) add. WC issues a `wp_safe_redirect` after the `woocommerce_add_to_cart` action; the in-memory `script_data['added_to_cart']` and the `add_to_cart` entry in `script_data['events']` set during that POST are thrown away before any page renders, so neither of the JS firing paths in `assets/js/src/integrations/classic.js` has data to work with.

**Approach (post-2024 #427-thread):** persist the formatted product into the WC session inside the `woocommerce_add_to_cart_redirect` filter — which WC calls **only** from `WC_Form_Handler::add_to_cart_action()` when a classic add is about to redirect. The next request consumes the session entry on `wp_head` (priority 1), restores `added_to_cart` script data, appends `add_to_cart` to the events array, then unsets the session key. The event therefore fires on the redirected destination exactly once.

**Why this won't false-positive or over-fire:**

- `woocommerce_add_to_cart` only fires after a successful add (no false positive on `adding_to_cart`, addressing tomalec's option-1 concern in #427).
- Only the `woocommerce_add_to_cart_redirect` filter path stashes to session. AJAX adds (`WC_AJAX::add_to_cart`) and Store API adds don't hit that filter, so they create no session entry — `classic.js`'s existing `added_to_cart` event handler continues to fire those as before.
- Session key is one-shot (`__unset` after consume), so subsequent navigation never re-fires.

The hooks were refactored from inline closures to named public methods (`capture_added_to_cart`, `persist_added_to_cart_for_redirect`, `restore_added_to_cart_from_session`) so unit tests can exercise the behavior directly without depending on global `do_action()` ordering.

### Checks:
* [x] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Detailed test instructions:

**Unit tests (run locally):**

```
npm run wp-env:up
npm run test:php:setup
npm run test:php
```

Full suite: `OK (61 tests, 174 assertions)`. New tests live in `tests/unit-tests/AddToCartRedirectSurvival.php` and cover:

- `test_redirect_filter_persists_added_to_cart_to_session` — captured product lands in WC session when the redirect filter fires.
- `test_no_session_stash_when_redirect_filter_does_not_fire` — no session entry when WC doesn't redirect (AJAX/Store API parity).
- `test_restore_from_session_populates_script_data_and_clears` — session payload is rehydrated and key is unset.
- `test_restore_is_noop_without_session_entry` — empty session is a no-op (no over-fire on unrelated page loads).

**Manual reproduction & verification (classic shortcode + classic theme, the path with 100% repro per #427):**

1. WC > Settings > Products > General: enable "Redirect to the cart page after successful addition".
2. Activate a classic theme (e.g. Twenty Twenty-Two / Storefront) — block themes use different add-to-cart paths.
3. Open DevTools → Network → filter for `collect` (or use Google Tag Assistant).
4. On a product or shop page, click "Add to cart". WC redirects to the cart page.
5. **Before this PR:** no GA4 `purchase`-family `add_to_cart` event fires on the redirected cart page.
6. **After this PR:** an `add_to_cart` event fires on the redirected cart page with the correct product payload.

Equally verifiable via raw HTTP — on the redirected cart page, `window.ga4w.data` now contains `added_to_cart: {...}` and `events: ["add_to_cart", ...]`, where previously both were missing.

**Regression check (no over-fire):**

7. Disable redirect-after-add.
8. Add a product via Ajax (default classic / block flows). `add_to_cart` should fire **exactly once** — via `classic.js`'s `added_to_cart` event handler, not via a session-rehydrated event. (Confirmed by `test_no_session_stash_when_redirect_filter_does_not_fire`.)

### Additional details:

> Fix - GA4 `add_to_cart` event is now sent when "Redirect to the cart page after successful addition" is enabled. The formatted product is persisted via the WC session through the redirect, then emitted on the destination page.

### Changelog entry

> Fix - Persist add_to_cart event across cart redirect.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Issues Found

**1 Bug**

- **GA4 add_to_cart event lost on WooCommerce redirect after add-to-cart**: When WooCommerce is configured to "Redirect to the cart page after successful addition," the GA4 `add_to_cart` event was not fired because the in-memory script data set during the POST request was lost before rendering the redirected page. This affected classic (non-AJAX) add-to-cart flows but not AJAX or Store API additions.

This PR fixes the issue by capturing and persisting the formatted product data to the WooCommerce session during `woocommerce_add_to_cart_redirect`, then restoring it on the subsequent request at `wp_head` priority 1 to ensure the event fires exactly once on the redirected destination. The fix includes comprehensive unit tests covering persistence, restoration, and edge cases (no session, AJAX redirects, redirects that don't occur).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->