### PR TITLE
Declare WordPress 7 compatibility

### DIFF
--- a/woocommerce-google-analytics-integration.php
+++ b/woocommerce-google-analytics-integration.php
@@ -8,9 +8,9 @@
  * Version: 2.1.23
  * WC requires at least: 10.6
  * WC tested up to: 10.7
- * Requires at least: 6.8
+ * Requires at least: 6.9
  * Requires Plugins: woocommerce
- * Tested up to: 6.9
+ * Tested up to: 7.0
  * Requires PHP: 7.4
  * License: GPLv3
  * License URI: https://www.gnu.org/licenses/gpl-3.0.html


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Declare Google Analytics for WooCommerce compatibility with WordPress 7.0 while keeping the minimum supported WordPress version at 6.9.

### Checks:
<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [x] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Screenshots:

_N/A_

### Detailed test instructions:

1. Open `woocommerce-google-analytics-integration.php`.
2. Confirm the plugin header includes `Requires at least: 6.9` and `Tested up to: 7.0`.
3. Open `readme.txt`.
4. Confirm the readme metadata includes `Requires at least: 6.9` and `Tested up to: 7.0`.

### Additional details:

_N/A_

### Changelog entry

> Update - Declare compatibility with WordPress 7.0 while requiring WordPress 6.9 or newer.
