### PR TITLE
Update readme WordPress compatibility

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,8 +1,8 @@
 === Google Analytics for WooCommerce ===
 Contributors: woocommerce, automattic, claudiosanches, bor0, royho, laurendavissmith001, cshultz88, mmjones, tomalec
 Tags: woocommerce, google analytics
-Requires at least: 6.8
-Tested up to: 6.9
+Requires at least: 6.9
+Tested up to: 7.0
 Stable tag: 2.1.23
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Align the readme metadata with the WordPress compatibility values declared in the plugin header by keeping the minimum supported WordPress version at 6.9 and marking the integration as tested through 7.0.

### Checks:
<!-- Mark completed items with an [x] -->
* [ ] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [x] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Screenshots:

_N/A_

### Detailed test instructions:

1. Open `readme.txt`.
2. Confirm the readme metadata includes `Requires at least: 6.9` and `Tested up to: 7.0`.
3. Confirm no other files changed.

### Additional details:

_N/A_

### Changelog entry

> _N/A_
