### PR TITLE
Update WC tested up to 10.8

### DIFF
--- a/woocommerce-google-analytics-integration.php
+++ b/woocommerce-google-analytics-integration.php
@@ -7,7 +7,7 @@
  * Author URI: https://woocommerce.com
  * Version: 2.1.23
  * WC requires at least: 10.6
- * WC tested up to: 10.7
+ * WC tested up to: 10.8
  * Requires at least: 6.9
  * Requires Plugins: woocommerce
  * Tested up to: 7.0

--- a/woocommerce-google-analytics-integration.php
+++ b/woocommerce-google-analytics-integration.php
@@ -27,7 +27,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 if ( ! class_exists( 'WC_Google_Analytics_Integration' ) ) {
 
 	define( 'WC_GOOGLE_ANALYTICS_INTEGRATION_VERSION', '2.1.23' ); // WRCS: DEFINED_VERSION.
-	define( 'WC_GOOGLE_ANALYTICS_INTEGRATION_MIN_WC_VER', '10.6' );
+	define( 'WC_GOOGLE_ANALYTICS_INTEGRATION_MIN_WC_VER', '10.7' );
 
 	// Maybe show the GA Pro notice on plugin activation.
 	register_activation_hook(

--- a/woocommerce-google-analytics-integration.php
+++ b/woocommerce-google-analytics-integration.php
@@ -6,7 +6,7 @@
  * Author: WooCommerce
  * Author URI: https://woocommerce.com
  * Version: 2.1.23
- * WC requires at least: 10.6
+ * WC requires at least: 10.7
  * WC tested up to: 10.8
  * Requires at least: 6.9
  * Requires Plugins: woocommerce


### PR DESCRIPTION
Bumps the plugin compatibility for WooCommerce 10.8:

- `WC tested up to`: 10.7 → 10.8
- `WC requires at least`: 10.6 → 10.7
- `WC_GOOGLE_ANALYTICS_INTEGRATION_MIN_WC_VER`: 10.6 → 10.7

### Changelog entry

> Update - Require WooCommerce 10.7+.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->