### PR TITLE
Add product formatter coverage

### DIFF
--- a/tests/unit-tests/DataFormatting.php
+++ b/tests/unit-tests/DataFormatting.php
@@ -6,6 +6,7 @@ use WC_Google_Gtag_JS;
 use WC_Helper_Product;
 use WC_Helper_Customer;
 use WC_Helper_Order;
+use WC_Product_Simple;
 
 /**
  * Unit tests for data formatting methods on WC_Abstract_Google_Analytics_JS
@@ -149,7 +150,30 @@ class DataFormatting extends EventsDataTest {
 		$formatted = $this->gtag->get_formatted_product( $variation_product, $variation_id );
 
 		$expected_price = $this->gtag->get_formatted_price( $variation->get_price() );
+		$this->assertEquals( $variation_product->get_id(), $formatted['id'] );
 		$this->assertEquals( $expected_price, $formatted['prices']['price'] );
+	}
+
+	/**
+	 * Test that bundle products use their minimum bundle price when Product Bundles exposes it.
+	 *
+	 * @return void
+	 */
+	public function test_get_formatted_product_bundle_uses_minimum_bundle_price() {
+		$product = WC_Helper_Product::create_simple_product();
+		$bundle  = $this->getMockBuilder( WC_Product_Simple::class )
+			->setConstructorArgs( [ $product->get_id() ] )
+			->onlyMethods( [ 'get_type' ] )
+			->addMethods( [ 'get_bundle_price' ] )
+			->getMock();
+		$bundle->method( 'get_type' )->willReturn( 'bundle' );
+		$bundle->method( 'get_bundle_price' )->with( 'min' )->willReturn( '12.34' );
+
+		$formatted = $this->gtag->get_formatted_product( $bundle );
+
+		$this->assertEquals( $product->get_id(), $formatted['id'] );
+		$this->assertEquals( $product->get_title(), $formatted['name'] );
+		$this->assertEquals( 1234, $formatted['prices']['price'] );
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #442
Closes STORMA-43

Adds focused unit coverage for product formatting across simple, variation, and bundle-like products.

### Checks:
* [x] Does your code follow the WordPress coding standards?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

### Screenshots:

N/A

### Detailed test instructions:

1. Run `npm run lint:php`.
2. Run `npm run test:php`.

### Additional details:

N/A

### Changelog entry

> Dev - Add product formatter unit coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

The PR adds comprehensive unit test coverage for product formatting functionality in the DataFormatting test class. The new tests properly validate:

- Price formatting across various scenarios (standard, zero, strings, rounding, negative values)
- Simple product structure and identifier configuration
- Variation product handling with correct price and ID mapping
- Bundle product support using minimum bundle price via mocking
- Variation attributes formatting
- Category limiting (max 5)
- Order and cart formatting
- Filter hook compatibility

The test implementations follow PHPUnit conventions appropriately, including proper use of mocking for bundle products with partial method overrides, correct test isolation with setup/teardown methods, and comprehensive assertions on returned data structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->