### PR TITLE
Format product categories by hierarchy

### DIFF
--- a/includes/class-wc-abstract-google-analytics-js.php
+++ b/includes/class-wc-abstract-google-analytics-js.php
@@ -390,7 +390,9 @@ abstract class WC_Abstract_Google_Analytics_JS {
 
 				$path[] = $term;
 
-				return $path;
+				// GA4 supports at most 5 category levels. When the path is deeper, keep the
+				// most specific terms (including the assigned leaf) instead of the topmost ancestors.
+				return array_slice( $path, -5 );
 			},
 			$assigned_terms
 		);

--- a/includes/class-wc-abstract-google-analytics-js.php
+++ b/includes/class-wc-abstract-google-analytics-js.php
@@ -318,10 +318,7 @@ abstract class WC_Abstract_Google_Analytics_JS {
 		$formatted = array(
 			'id'         => $product_id,
 			'name'       => $product->get_title(),
-			'categories' => array_map(
-				fn( $category ) => array( 'name' => $category->name ),
-				wc_get_product_terms( $product_id, 'product_cat', array( 'number' => 5 ) )
-			),
+			'categories' => $this->get_formatted_product_categories( $product_id ),
 			'prices'     => array(
 				'price'               => $this->get_formatted_price( $price ),
 				'currency_minor_unit' => wc_get_price_decimals(),
@@ -359,6 +356,74 @@ abstract class WC_Abstract_Google_Analytics_JS {
 		}
 
 		return $formatted;
+	}
+
+	/**
+	 * Return product categories with assigned terms expanded into parent-first hierarchy order.
+	 *
+	 * @param int $product_id Product ID.
+	 *
+	 * @return array
+	 */
+	private function get_formatted_product_categories( int $product_id ): array {
+		$assigned_terms = wc_get_product_terms(
+			$product_id,
+			'product_cat',
+			array(
+				'orderby' => 'name',
+				'order'   => 'ASC',
+			)
+		);
+
+		$category_paths = array_map(
+			function ( $term ) {
+				$ancestors = array_reverse( get_ancestors( $term->term_id, 'product_cat', 'taxonomy' ) );
+				$path      = array();
+
+				foreach ( $ancestors as $ancestor_id ) {
+					$ancestor = get_term( $ancestor_id, 'product_cat' );
+
+					if ( $ancestor && ! is_wp_error( $ancestor ) ) {
+						$path[] = $ancestor;
+					}
+				}
+
+				$path[] = $term;
+
+				return $path;
+			},
+			$assigned_terms
+		);
+
+		usort(
+			$category_paths,
+			function ( $left, $right ) {
+				return strnatcasecmp(
+					implode( '/', wp_list_pluck( $left, 'name' ) ),
+					implode( '/', wp_list_pluck( $right, 'name' ) )
+				);
+			}
+		);
+
+		$categories = array();
+		$seen_terms = array();
+
+		foreach ( $category_paths as $path ) {
+			foreach ( $path as $category ) {
+				if ( isset( $seen_terms[ $category->term_id ] ) ) {
+					continue;
+				}
+
+				$categories[]                     = array( 'name' => $category->name );
+				$seen_terms[ $category->term_id ] = true;
+
+				if ( 5 === count( $categories ) ) {
+					break 2;
+				}
+			}
+		}
+
+		return $categories;
 	}
 
 	/**

--- a/includes/class-wc-abstract-google-analytics-js.php
+++ b/includes/class-wc-abstract-google-analytics-js.php
@@ -375,6 +375,10 @@ abstract class WC_Abstract_Google_Analytics_JS {
 			)
 		);
 
+		if ( ! is_array( $assigned_terms ) ) {
+			return array();
+		}
+
 		$category_paths = array_map(
 			function ( $term ) {
 				$ancestors = array_reverse( get_ancestors( $term->term_id, 'product_cat', 'taxonomy' ) );

--- a/tests/unit-tests/DataFormatting.php
+++ b/tests/unit-tests/DataFormatting.php
@@ -261,6 +261,80 @@ class DataFormatting extends EventsDataTest {
 	}
 
 	/**
+	 * Test that a child category includes its parent before the child term.
+	 *
+	 * @return void
+	 */
+	public function test_get_formatted_product_categories_include_parent_names() {
+		$product = WC_Helper_Product::create_simple_product();
+		$parent  = wp_insert_term( 'Parent_' . uniqid(), 'product_cat' );
+		$child   = wp_insert_term(
+			'Child_' . uniqid(),
+			'product_cat',
+			[
+				'parent' => $parent['term_id'],
+			]
+		);
+
+		wp_set_object_terms( $product->get_id(), [ $child['term_id'] ], 'product_cat' );
+		clean_object_term_cache( $product->get_id(), 'product' );
+
+		$formatted = $this->gtag->get_formatted_product( $product );
+
+		$this->assertEquals(
+			[ $parent['term_id'], $child['term_id'] ],
+			array_map(
+				function ( $category ) {
+					return get_term_by( 'name', $category['name'], 'product_cat' )->term_id;
+				},
+				$formatted['categories']
+			)
+		);
+	}
+
+	/**
+	 * Test that multiple category trees are flattened deterministically without duplicate parents.
+	 *
+	 * @return void
+	 */
+	public function test_get_formatted_product_categories_flatten_multiple_trees() {
+		$product      = WC_Helper_Product::create_simple_product();
+		$clothing     = wp_insert_term( 'Clothing_' . uniqid(), 'product_cat' );
+		$hoodies      = wp_insert_term(
+			'Hoodies_' . uniqid(),
+			'product_cat',
+			[
+				'parent' => $clothing['term_id'],
+			]
+		);
+		$fan_gear     = wp_insert_term( 'Fan Gear_' . uniqid(), 'product_cat' );
+		$real_madrid  = wp_insert_term(
+			'Real Madrid_' . uniqid(),
+			'product_cat',
+			[
+				'parent' => $fan_gear['term_id'],
+			]
+		);
+		$category_ids = [ $real_madrid['term_id'], $hoodies['term_id'] ];
+		$expected_ids = [ $clothing['term_id'], $hoodies['term_id'], $fan_gear['term_id'], $real_madrid['term_id'] ];
+
+		wp_set_object_terms( $product->get_id(), $category_ids, 'product_cat' );
+		clean_object_term_cache( $product->get_id(), 'product' );
+
+		$formatted = $this->gtag->get_formatted_product( $product );
+
+		$this->assertEquals(
+			$expected_ids,
+			array_map(
+				function ( $category ) {
+					return get_term_by( 'name', $category['name'], 'product_cat' )->term_id;
+				},
+				$formatted['categories']
+			)
+		);
+	}
+
+	/**
 	 * Create a fresh order with its own product and customer for test isolation.
 	 *
 	 * @return \WC_Order

--- a/tests/unit-tests/DataFormatting.php
+++ b/tests/unit-tests/DataFormatting.php
@@ -335,6 +335,47 @@ class DataFormatting extends EventsDataTest {
 	}
 
 	/**
+	 * Test that the assigned leaf term is kept when its category path is deeper than five levels.
+	 *
+	 * @return void
+	 */
+	public function test_get_formatted_product_categories_deep_path_keeps_leaf() {
+		$product   = WC_Helper_Product::create_simple_product();
+		$parent_id = 0;
+		$level_ids = [];
+
+		// Build a single chain six levels deep (root -> ... -> leaf).
+		for ( $i = 0; $i < 6; $i++ ) {
+			$term        = wp_insert_term(
+				"Level{$i}_" . uniqid(),
+				'product_cat',
+				$parent_id ? [ 'parent' => $parent_id ] : []
+			);
+			$parent_id   = $term['term_id'];
+			$level_ids[] = $term['term_id'];
+		}
+
+		$leaf_id = end( $level_ids );
+
+		wp_set_object_terms( $product->get_id(), [ $leaf_id ], 'product_cat' );
+		clean_object_term_cache( $product->get_id(), 'product' );
+
+		$formatted = $this->gtag->get_formatted_product( $product );
+
+		$category_ids = array_map(
+			function ( $category ) {
+				return get_term_by( 'name', $category['name'], 'product_cat' )->term_id;
+			},
+			$formatted['categories']
+		);
+
+		// GA4 supports five levels: the five most specific terms, ending with the assigned leaf.
+		$this->assertEquals( array_slice( $level_ids, -5 ), $category_ids );
+		$this->assertContains( $leaf_id, $category_ids );
+		$this->assertSame( $leaf_id, end( $category_ids ) );
+	}
+
+	/**
 	 * Create a fresh order with its own product and customer for test isolation.
 	 *
 	 * @return \WC_Order


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #198
Closes STORMA-33

Expands assigned product categories into parent-first hierarchy order before sending them in the existing GA product category shape. Multiple trees are flattened deterministically and still capped at five categories.

### Checks:
* [x] Does your code follow the WordPress coding standards?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

### Screenshots:

N/A

### Detailed test instructions:

1. Run `npm run lint:php`.
2. Run `npm run test:php`.

### Additional details:

N/A

### Changelog entry

> Update - Format product categories in parent-first hierarchy order.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
No issues found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->