### PR TITLE
Move tracking settings to instances

### DIFF
--- a/includes/class-wc-abstract-google-analytics-js.php
+++ b/includes/class-wc-abstract-google-analytics-js.php
@@ -18,7 +18,7 @@ abstract class WC_Abstract_Google_Analytics_JS {
 	protected static $instance;
 
 	/** @var array $settings Inherited Analytics settings */
-	protected static $settings;
+	protected $settings = array();
 
 	/** @var string Developer ID */
 	public const DEVELOPER_ID = 'dOGY3NW';
@@ -120,7 +120,7 @@ abstract class WC_Abstract_Google_Analytics_JS {
 		add_action(
 			'woocommerce_thankyou',
 			function ( $order_id ) {
-				if ( 'yes' === self::get( 'ga_ecommerce_tracking_enabled' ) ) {
+				if ( 'yes' === $this->get_setting( 'ga_ecommerce_tracking_enabled' ) ) {
 					$order = wc_get_order( $order_id );
 					if ( $order && $order->get_meta( '_ga_tracked' ) !== '1' ) {
 						// Check order key.
@@ -174,22 +174,24 @@ abstract class WC_Abstract_Google_Analytics_JS {
 	}
 
 	/**
-	 * Return one of our settings
+	 * Return one of our settings.
 	 *
 	 * @param string $setting Key/name for the setting.
 	 *
-	 * @return string|null Value of the setting or null if not found
+	 * @return mixed|null Value of the setting or null if not found.
 	 */
-	protected static function get( $setting ): ?string {
-		return self::$settings[ $setting ] ?? null;
+	protected function get_setting( string $setting ) {
+		return $this->settings[ $setting ] ?? null;
 	}
 
 	/**
-	 * Generic GA snippet for opt out
+	 * Generic GA snippet for opt out.
+	 *
+	 * @return void
 	 */
-	public static function load_opt_out(): void {
+	public function load_opt_out_script(): void {
 		$code = "
-			var gaProperty = '" . esc_js( self::get( 'ga_id' ) ) . "';
+			var gaProperty = '" . esc_js( $this->get_setting( 'ga_id' ) ) . "';
 			var disableStr = 'ga-disable-' + gaProperty;
 			if ( document.cookie.indexOf( disableStr + '=true' ) > -1 ) {
 				window[disableStr] = true;
@@ -205,16 +207,25 @@ abstract class WC_Abstract_Google_Analytics_JS {
 	}
 
 	/**
-	 * Get item identifier from product data
+	 * Compatibility wrapper for the formerly static opt-out loader.
+	 *
+	 * @return void
+	 */
+	public static function load_opt_out(): void {
+		static::get_compatibility_instance()->load_opt_out_script();
+	}
+
+	/**
+	 * Get item identifier from product data.
 	 *
 	 * @param WC_Product $product WC_Product Object.
 	 *
 	 * @return string
 	 */
-	public static function get_product_identifier( WC_Product $product ): string {
+	public function get_product_identifier_for_product( WC_Product $product ): string {
 		$identifier = $product->is_type( 'variation' ) ? $product->get_parent_id() : $product->get_id();
 
-		if ( 'product_sku' === self::get( 'ga_product_identifier' ) ) {
+		if ( 'product_sku' === $this->get_setting( 'ga_product_identifier' ) ) {
 			if ( ! empty( $product->get_sku() ) ) {
 				$identifier = $product->get_sku();
 			} else {
@@ -223,6 +234,17 @@ abstract class WC_Abstract_Google_Analytics_JS {
 		}
 
 		return apply_filters( 'woocommerce_ga_product_identifier', $identifier, $product );
+	}
+
+	/**
+	 * Compatibility wrapper for the formerly static product identifier formatter.
+	 *
+	 * @param WC_Product $product WC_Product Object.
+	 *
+	 * @return string
+	 */
+	public static function get_product_identifier( WC_Product $product ): string {
+		return static::get_compatibility_instance()->get_product_identifier_for_product( $product );
 	}
 
 	/**
@@ -305,7 +327,7 @@ abstract class WC_Abstract_Google_Analytics_JS {
 			),
 			'extensions' => array(
 				'woocommerce_google_analytics_integration' => array(
-					'identifier' => $this->get_product_identifier( $product ),
+					'identifier' => $this->get_product_identifier_for_product( $product ),
 				),
 			),
 		);
@@ -490,8 +512,17 @@ abstract class WC_Abstract_Google_Analytics_JS {
 		$product = is_a( $product, 'WC_Product' ) ? $product : $product['data'];
 
 		return array(
-			'identifier' => (string) $this->get_product_identifier( $product ),
+			'identifier' => (string) $this->get_product_identifier_for_product( $product ),
 		);
+	}
+
+	/**
+	 * Return the current instance for compatibility wrappers.
+	 *
+	 * @return WC_Abstract_Google_Analytics_JS
+	 */
+	protected static function get_compatibility_instance(): WC_Abstract_Google_Analytics_JS {
+		return static::$instance ?? static::get_instance();
 	}
 
 	/**

--- a/includes/class-wc-abstract-google-analytics-js.php
+++ b/includes/class-wc-abstract-google-analytics-js.php
@@ -517,12 +517,23 @@ abstract class WC_Abstract_Google_Analytics_JS {
 	}
 
 	/**
-	 * Return the current instance for compatibility wrappers.
+	 * Return an instance for the static compatibility wrappers to read settings from.
+	 *
+	 * If a tracking instance has already been bootstrapped, reuse it. Otherwise build a
+	 * lightweight, settings-only instance without invoking the constructor, so reading a
+	 * setting never registers scripts/hooks, enqueues anything, or installs a live
+	 * singleton. This mirrors the pre-refactor static helpers, which read settings with
+	 * no side effects even when the integration skipped get_tracking_instance() (e.g.
+	 * `ga_id` is unset).
 	 *
 	 * @return WC_Abstract_Google_Analytics_JS
 	 */
 	protected static function get_compatibility_instance(): WC_Abstract_Google_Analytics_JS {
-		return static::$instance ?? static::get_instance();
+		if ( static::$instance ) {
+			return static::$instance;
+		}
+
+		return ( new \ReflectionClass( static::class ) )->newInstanceWithoutConstructor();
 	}
 
 	/**

--- a/includes/class-wc-google-gtag-js.php
+++ b/includes/class-wc-google-gtag-js.php
@@ -429,6 +429,11 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 	public static function get_instance( $settings = array() ): WC_Abstract_Google_Analytics_JS {
 		if ( null === self::$instance ) {
 			self::$instance = new self( $settings );
+		} elseif ( ! empty( $settings ) ) {
+			// A static compatibility wrapper may have bootstrapped the instance with empty
+			// settings before the integration supplied the real ones. Rehydrate so later
+			// reads (e.g. enabled events, product identifier) reflect the current settings.
+			self::$instance->settings = $settings;
 		}
 
 		return self::$instance;

--- a/includes/class-wc-google-gtag-js.php
+++ b/includes/class-wc-google-gtag-js.php
@@ -46,8 +46,10 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 	 * @param array $settings Settings
 	 */
 	public function __construct( $settings = array() ) {
+		$this->settings = $settings;
+		self::$instance = $this;
+
 		parent::__construct();
-		self::$settings = $settings;
 
 		$this->map_hooks();
 
@@ -66,7 +68,7 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 	private function register_scripts(): void {
 		wp_register_script(
 			'google-tag-manager',
-			'https://www.googletagmanager.com/gtag/js?id=' . self::get( 'ga_id' ),
+			'https://www.googletagmanager.com/gtag/js?id=' . $this->get_setting( 'ga_id' ),
 			array(),
 			null,
 			array(
@@ -99,7 +101,7 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 					%2$s("js", new Date());
 					%2$s("set", "developer_id.%3$s", true);
 					%2$s("config", "%1$s", %5$s);',
-					esc_js( $this->get( 'ga_id' ) ),
+					esc_js( $this->get_setting( 'ga_id' ) ),
 					esc_js( $this->tracker_function_name() ),
 					esc_js( static::DEVELOPER_ID ),
 					wp_json_encode( $this->get_consent_modes(), JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ),
@@ -167,8 +169,8 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 				wp_json_encode(
 					array(
 						'tracker_function_name' => $this->tracker_function_name(),
-						'events'                => $this->get_enabled_events(),
-						'identifier'            => $this->get( 'ga_product_identifier' ),
+						'events'                => $this->get_enabled_events_for_settings(),
+						'identifier'            => $this->get_setting( 'ga_product_identifier' ),
 						'currency'              => array(
 							'decimalSeparator'  => wc_get_price_decimal_separator(),
 							'thousandSeparator' => wc_get_price_thousand_separator(),
@@ -281,12 +283,12 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 		return apply_filters(
 			'woocommerce_ga_gtag_config',
 			array(
-				'track_404'            => 'yes' === $this->get( 'ga_404_tracking_enabled' ),
-				'allow_google_signals' => 'yes' === $this->get( 'ga_support_display_advertising' ),
+				'track_404'            => 'yes' === $this->get_setting( 'ga_404_tracking_enabled' ),
+				'allow_google_signals' => 'yes' === $this->get_setting( 'ga_support_display_advertising' ),
 				'logged_in'            => is_user_logged_in(),
 				'linker'               => array(
 					'domains'        => $this->get_linker_domains(),
-					'allow_incoming' => 'yes' === $this->get( 'ga_linker_allow_incoming_enabled' ),
+					'allow_incoming' => 'yes' === $this->get_setting( 'ga_linker_allow_incoming_enabled' ),
 				),
 				'custom_map'           => array(
 					'dimension1' => 'logged_in',
@@ -301,7 +303,7 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 	 * @return array
 	 */
 	private function get_linker_domains(): array {
-		if ( empty( $this->get( 'ga_linker_cross_domains' ) ) ) {
+		if ( empty( $this->get_setting( 'ga_linker_cross_domains' ) ) ) {
 			return array();
 		}
 
@@ -320,7 +322,7 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 
 						return null;
 					},
-					explode( ',', $this->get( 'ga_linker_cross_domains' ) )
+					explode( ',', $this->get_setting( 'ga_linker_cross_domains' ) )
 				)
 			)
 		);
@@ -331,7 +333,7 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 	 *
 	 * @return array
 	 */
-	public static function get_enabled_events(): array {
+	public function get_enabled_events_for_settings(): array {
 		$events   = array();
 		$settings = array(
 			'purchase'          => 'ga_ecommerce_tracking_enabled',
@@ -346,12 +348,21 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 		);
 
 		foreach ( $settings as $event => $setting_name ) {
-			if ( 'yes' === self::get( $setting_name ) ) {
+			if ( 'yes' === $this->get_setting( $setting_name ) ) {
 				$events[] = $event;
 			}
 		}
 
 		return $events;
+	}
+
+	/**
+	 * Compatibility wrapper for the formerly static enabled-events formatter.
+	 *
+	 * @return array
+	 */
+	public static function get_enabled_events(): array {
+		return static::get_compatibility_instance()->get_enabled_events_for_settings();
 	}
 
 	/**

--- a/includes/class-wc-google-gtag-js.php
+++ b/includes/class-wc-google-gtag-js.php
@@ -66,6 +66,14 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 	 * @return void
 	 */
 	private function register_scripts(): void {
+		// Deregister first so this can be safely re-run when settings change after
+		// construction (see get_instance() rehydration). The `ga_id` baked into the
+		// GTM URL and the gtag `config` snippet must reflect the current settings.
+		// These are no-ops when nothing has been registered yet.
+		wp_deregister_script( 'google-tag-manager' );
+		wp_deregister_script( $this->gtag_script_handle );
+		wp_deregister_script( $this->script_handle );
+
 		wp_register_script(
 			'google-tag-manager',
 			'https://www.googletagmanager.com/gtag/js?id=' . $this->get_setting( 'ga_id' ),
@@ -430,10 +438,12 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 		if ( null === self::$instance ) {
 			self::$instance = new self( $settings );
 		} elseif ( ! empty( $settings ) ) {
-			// A static compatibility wrapper may have bootstrapped the instance with empty
+			// A direct get_instance() call may have bootstrapped the instance with empty
 			// settings before the integration supplied the real ones. Rehydrate so later
-			// reads (e.g. enabled events, product identifier) reflect the current settings.
+			// reads (e.g. enabled events, product identifier) reflect the current settings,
+			// and re-register the scripts so the baked-in ga_id / config match them too.
 			self::$instance->settings = $settings;
+			self::$instance->register_scripts();
 		}
 
 		return self::$instance;

--- a/tests/unit-tests/WCGoogleGtagJS.php
+++ b/tests/unit-tests/WCGoogleGtagJS.php
@@ -273,4 +273,72 @@ class WCGoogleGtagJS extends EventsDataTest {
 
 		$this->assertEquals( array( 'add_to_cart' ), WC_Google_Gtag_JS::get_enabled_events() );
 	}
+
+	/**
+	 * Test that a static compatibility wrapper does not bootstrap full tracking
+	 * (register/enqueue scripts, install a live singleton) when no instance exists yet.
+	 *
+	 * @return void
+	 */
+	public function test_static_wrapper_does_not_bootstrap_tracking_without_instance(): void {
+		$this->reset_gtag_instance();
+		// Clear any registration left over from earlier tests.
+		wp_deregister_script( 'google-tag-manager' );
+
+		$product = WC_Helper_Product::create_simple_product();
+
+		// Reading a setting through the static wrapper must work without side effects.
+		$this->assertEquals( $product->get_id(), WC_Google_Gtag_JS::get_product_identifier( $product ) );
+
+		// register_scripts() (run only by the constructor) would re-register this handle,
+		// and the constructor would install the singleton — neither should happen here.
+		$this->assertFalse( wp_script_is( 'google-tag-manager', 'registered' ), 'Static wrapper should not register the gtag script' );
+		$this->assertNull( $this->get_gtag_instance(), 'Static wrapper should not install a live singleton' );
+	}
+
+	/**
+	 * Test that rehydrating an existing instance with new settings re-registers the
+	 * scripts so the baked-in `ga_id` reflects the updated settings.
+	 *
+	 * @return void
+	 */
+	public function test_get_instance_rehydration_reregisters_scripts(): void {
+		$this->reset_gtag_instance();
+		wp_deregister_script( 'google-tag-manager' );
+
+		// Bootstrap with empty settings: the GTM URL carries no measurement id.
+		WC_Google_Gtag_JS::get_instance();
+		$this->assertStringNotContainsString( 'id=G-', wp_scripts()->registered['google-tag-manager']->src );
+
+		// The integration later supplies the real settings.
+		WC_Google_Gtag_JS::get_instance( array( 'ga_id' => 'G-1234567890' ) );
+
+		$this->assertStringContainsString(
+			'id=G-1234567890',
+			wp_scripts()->registered['google-tag-manager']->src,
+			'Rehydration should re-register the gtag script with the new ga_id'
+		);
+	}
+
+	/**
+	 * Reset the shared tracking singleton so a test can exercise the no-instance path.
+	 *
+	 * @return void
+	 */
+	private function reset_gtag_instance(): void {
+		$property = new \ReflectionProperty( \WC_Abstract_Google_Analytics_JS::class, 'instance' );
+		$property->setAccessible( true );
+		$property->setValue( null, null );
+	}
+
+	/**
+	 * Read the shared tracking singleton.
+	 *
+	 * @return \WC_Abstract_Google_Analytics_JS|null
+	 */
+	private function get_gtag_instance() {
+		$property = new \ReflectionProperty( \WC_Abstract_Google_Analytics_JS::class, 'instance' );
+		$property->setAccessible( true );
+		return $property->getValue();
+	}
 }

--- a/tests/unit-tests/WCGoogleGtagJS.php
+++ b/tests/unit-tests/WCGoogleGtagJS.php
@@ -44,31 +44,47 @@ class WCGoogleGtagJS extends EventsDataTest {
 	 * @return void
 	 */
 	public function test_get_product_identifier() {
-		$mock_sku = $this->getMockBuilder( WC_Google_Gtag_JS::class )
-						 ->setMethods( array( '__construct' ) )
-						 ->setConstructorArgs( array( array( 'ga_product_identifier' => 'product_sku' ) ) )
-						 ->getMock();
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_sku( 'TEST-SKU-123' );
+		$product->save();
 
-		$this->assertEquals( $this->get_product()->get_sku(), $mock_sku::get_product_identifier( $this->get_product() ) );
+		$gtag_sku = new WC_Google_Gtag_JS( array( 'ga_product_identifier' => 'product_sku' ) );
 
-		$this->get_product()->set_sku( '' );
-		$this->assertEquals( '#' . $this->get_product()->get_id(), $mock_sku::get_product_identifier( $this->get_product() ) );
+		$this->assertEquals( $product->get_sku(), $gtag_sku->get_product_identifier_for_product( $product ) );
 
-		$mock_id = $this->getMockBuilder( WC_Google_Gtag_JS::class )
-						->setMethods( array( '__construct' ) )
-						->setConstructorArgs( array( array( 'ga_product_identifier' => 'product_id' ) ) )
-						->getMock();
+		$product->set_sku( '' );
+		$product->save();
+		$this->assertEquals( '#' . $product->get_id(), $gtag_sku->get_product_identifier_for_product( $product ) );
 
-		$this->assertEquals( $this->get_product()->get_id(), $mock_id::get_product_identifier( $this->get_product() ) );
+		$gtag_id = new WC_Google_Gtag_JS( array( 'ga_product_identifier' => 'product_id' ) );
 
-		add_filter(
-			'woocommerce_ga_product_identifier',
-			function ( $product ) {
-				return 'filtered';
-			}
-		);
+		$this->assertEquals( $product->get_id(), $gtag_id->get_product_identifier_for_product( $product ) );
 
-		$this->assertEquals( 'filtered', $mock_id::get_product_identifier( $this->get_product() ) );
+		$callback = function () {
+			return 'filtered';
+		};
+		add_filter( 'woocommerce_ga_product_identifier', $callback );
+
+		try {
+			$this->assertEquals( 'filtered', $gtag_id->get_product_identifier_for_product( $product ) );
+		} finally {
+			remove_filter( 'woocommerce_ga_product_identifier', $callback );
+		}
+	}
+
+	/**
+	 * Test that the static product identifier wrapper still uses the current instance settings.
+	 *
+	 * @return void
+	 */
+	public function test_static_get_product_identifier_uses_current_instance_settings() {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_sku( 'STATIC-SKU-123' );
+		$product->save();
+
+		new WC_Google_Gtag_JS( array( 'ga_product_identifier' => 'product_sku' ) );
+
+		$this->assertEquals( 'STATIC-SKU-123', WC_Google_Gtag_JS::get_product_identifier( $product ) );
 	}
 
 	/**
@@ -243,7 +259,18 @@ class WCGoogleGtagJS extends EventsDataTest {
 
 		foreach ( $settings as $option_name => $expected_events ) {
 			$gtag = new WC_Google_Gtag_JS( array( $option_name => 'yes' ) );
-			$this->assertEquals( $expected_events, $gtag->get_enabled_events() );
+			$this->assertEquals( $expected_events, $gtag->get_enabled_events_for_settings() );
 		}
+	}
+
+	/**
+	 * Test that the static enabled-events wrapper still uses the current instance settings.
+	 *
+	 * @return void
+	 */
+	public function test_static_get_enabled_events_uses_current_instance_settings(): void {
+		new WC_Google_Gtag_JS( array( 'ga_event_tracking_enabled' => 'yes' ) );
+
+		$this->assertEquals( array( 'add_to_cart' ), WC_Google_Gtag_JS::get_enabled_events() );
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #412
Closes STORMA-41

Moves tracking settings from static storage to the gtag instance and routes internal settings-dependent logic through instance methods. The old public static methods remain as compatibility wrappers.

### Checks:
* [x] Does your code follow the WordPress coding standards?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

### Screenshots:

N/A

### Detailed test instructions:

1. Run `npm run lint:php`.
2. Run `npm run test:php`.

### Additional details:

N/A

### Changelog entry

> Dev - Store Google Analytics tracking settings on the tracking instance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Issues Found: 2

### Bugs (2)

1. GTAG loader URL may include an empty id parameter (includes/class-wc-google-gtag-js.php)
   - When ga_id is absent, concatenation into the gtag loader URL produces a URL ending with `?id=` (empty measurement id), which is undesirable.

2. Empty ga_id handling in opt-out/inline JS (includes/class-wc-abstract-google-analytics-js.php & includes/class-wc-google-gtag-js.php)
   - get_setting('ga_id') can be null and is passed through esc_js() (coerced to an empty string), resulting in JS like `var gaProperty = '';` and `ga-disable-` (trailing dash) which may cause incorrect opt-out behavior or confusing globals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->