### PR TITLE
Expose tracking helpers globally

### DIFF
--- a/assets/js/src/index.js
+++ b/assets/js/src/index.js
@@ -31,11 +31,6 @@ const publicApi = {
 	},
 };
 
-window.wcGoogleAnalyticsIntegration = {
-	...( window.wcGoogleAnalyticsIntegration ?? {} ),
-	...publicApi,
-};
-
 // Wait for 'ga4w:ready' event if `window.ga4w` is not there yet.
 if ( window.ga4w ) {
 	initializeTracking();
@@ -51,6 +46,13 @@ if ( window.ga4w ) {
 }
 
 function initializeTracking() {
+	// Expose the public API once window.ga4w (settings + data) is ready, so
+	// helpers such as getProductId resolve the configured identifier correctly
+	// instead of falling back to the numeric product ID.
+	window.wcGoogleAnalyticsIntegration = {
+		...( window.wcGoogleAnalyticsIntegration ?? {} ),
+		...publicApi,
+	};
 	Object.assign( window.ga4w, publicApi );
 
 	setCurrentConsentState( window.ga4w.settings );

--- a/assets/js/src/index.js
+++ b/assets/js/src/index.js
@@ -1,10 +1,19 @@
 import { setupEventHandlers } from './tracker';
+import * as formatters from './tracker/data-formatting';
+import * as utils from './utils';
 import { classicTracking } from './integrations/classic';
 import { blocksTracking } from './integrations/blocks';
 import {
 	setCurrentConsentState,
 	addConsentStateChangeEventListener,
 } from './integrations/wp-consent-api';
+
+const publicApi = { formatters, utils };
+
+window.wcGoogleAnalyticsIntegration = {
+	...( window.wcGoogleAnalyticsIntegration ?? {} ),
+	...publicApi,
+};
 
 // Wait for 'ga4w:ready' event if `window.ga4w` is not there yet.
 if ( window.ga4w ) {
@@ -21,6 +30,8 @@ if ( window.ga4w ) {
 }
 
 function initializeTracking() {
+	Object.assign( window.ga4w, publicApi );
+
 	setCurrentConsentState( window.ga4w.settings );
 	addConsentStateChangeEventListener( window.ga4w.settings );
 

--- a/assets/js/src/index.js
+++ b/assets/js/src/index.js
@@ -8,7 +8,28 @@ import {
 	addConsentStateChangeEventListener,
 } from './integrations/wp-consent-api';
 
-const publicApi = { formatters, utils };
+/*
+ * Public JavaScript API, exposed on `window.wcGoogleAnalyticsIntegration` and
+ * mirrored onto `window.ga4w`. This is the supported extension surface:
+ *
+ * - `formatters`: the GA4 event formatters (`add_to_cart`, `view_item`,
+ *   `purchase`, …) used to build event payloads.
+ * - `utils`: the product/cart formatting helpers used to shape that data.
+ *
+ * Only the helpers below are part of the contract. Internal plumbing (e.g.
+ * `addUniqueAction`, `cacheBlockProducts`) is intentionally not exposed so it
+ * can change without breaking integrations.
+ */
+const publicApi = {
+	formatters,
+	utils: {
+		getProductFieldObject: utils.getProductFieldObject,
+		getProductImpressionObject: utils.getProductImpressionObject,
+		formatPrice: utils.formatPrice,
+		getProductId: utils.getProductId,
+		getCartCoupon: utils.getCartCoupon,
+	},
+};
 
 window.wcGoogleAnalyticsIntegration = {
 	...( window.wcGoogleAnalyticsIntegration ?? {} ),

--- a/tests/e2e/specs/js-scripts/inline-data.test.js
+++ b/tests/e2e/specs/js-scripts/inline-data.test.js
@@ -43,4 +43,26 @@ test.describe( '`woocommerce-google-analytics-integration`', () => {
 			page.locator( '#woocommerce-google-analytics-integration-js-after' )
 		).toHaveJSProperty( '__test__inlineSnippet', 'works' );
 	} );
+
+	test( 'Exposes formatters and utilities globally', async ( { page } ) => {
+		await page.goto( 'shop' );
+
+		const exposedApi = await page.evaluate( () => ( {
+			globalFormatter:
+				typeof window.wcGoogleAnalyticsIntegration?.formatters
+					?.add_to_cart,
+			globalUtility:
+				typeof window.wcGoogleAnalyticsIntegration?.utils
+					?.getProductFieldObject,
+			ga4wFormatter: typeof window.ga4w?.formatters?.add_to_cart,
+			ga4wUtility: typeof window.ga4w?.utils?.getProductFieldObject,
+		} ) );
+
+		expect( exposedApi ).toEqual( {
+			globalFormatter: 'function',
+			globalUtility: 'function',
+			ga4wFormatter: 'function',
+			ga4wUtility: 'function',
+		} );
+	} );
 } );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #470 
Closes STORMA-44

Exposes JS formatters and utilities on `window.wcGoogleAnalyticsIntegration`, and mirrors them onto `window.ga4w` once tracking data is ready. Existing `window.ga4w.data` and `window.ga4w.settings` behavior is unchanged.

### Checks:
* [x] Does your code follow the WordPress coding standards?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

### Screenshots:

N/A

### Detailed test instructions:

1. Run `npm run lint:js`.
2. Run `npm run dev`.
3. Run `npx playwright test --config=tests/e2e/config/playwright.config.js tests/e2e/specs/js-scripts/inline-data.test.js`.

### Additional details:

N/A

### Changelog entry

> Add - Expose JavaScript tracking formatters and utilities for custom integrations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

**Issues Found: 1**

**Category: Suggestion**

1. **Typo in comment (Line 40)**: The comment reads "document is fully loded" instead of the correct spelling "loaded". While this is a minor documentation issue, it should be corrected for consistency.

**Code Quality Summary**: The PR implementation is well-structured with proper safeguards:
- Correct exposure timing (after `window.ga4w` is ready via `ga4w:ready` event listener)
- Proper use of optional chaining throughout the utilities to handle undefined `window.ga4w.settings`
- Careful curation of public API surface (only product/cart formatting helpers exposed)
- Merge strategy using spread operator preserves existing `window.wcGoogleAnalyticsIntegration` properties
- Clear documentation comments explaining the public API contract and reasoning
- Comprehensive e2e test coverage verifying the exposed formatters and utilities are accessible globally

<!-- end of auto-generated comment: release notes by coderabbit.ai -->