### PR TITLE
Fallback for buttonless added_to_cart events

### DIFF
--- a/assets/js/src/integrations/classic.js
+++ b/assets/js/src/integrations/classic.js
@@ -196,7 +196,17 @@ export function classicTracking(
 			buttonElement?.dataset.product_id || buttonElement?.value
 		);
 
+		let productToHandle;
 		if ( Number.isNaN( productID ) ) {
+			productToHandle = addedToCart ?? product;
+
+			if ( productToHandle ) {
+				getEventHandler( 'add_to_cart' )( {
+					product: productToHandle,
+				} );
+				return;
+			}
+
 			// eslint-disable-next-line no-console
 			console.error(
 				'Google Analytics for WooCommerce: Could not read product ID from the button given in `added_to_cart` event. Check whether WooCommerce Core events or elements are malformed by other extensions.'
@@ -205,7 +215,7 @@ export function classicTracking(
 		}
 
 		// If the current product doesn't match search by ID.
-		const productToHandle =
+		productToHandle =
 			product?.id === productID
 				? product
 				: getProductFromID( productID, products, cart );

--- a/tests/e2e/specs/gtag-events/classic-pages.test.js
+++ b/tests/e2e/specs/gtag-events/classic-pages.test.js
@@ -141,6 +141,30 @@ test.describe( 'GTag events on classic pages', () => {
 		} );
 	} );
 
+	test( 'Add to cart event falls back to single product data when the event has no button', async ( {
+		page,
+	} ) => {
+		const event = trackGtagEvent( page, 'add_to_cart' );
+
+		await page.goto( `?p=${ simpleProductID }` );
+		await page.evaluate( () => {
+			window
+				.jQuery( document.body )
+				.trigger( 'added_to_cart', [ {}, 'test-cart-hash' ] );
+		} );
+
+		await event.then( ( request ) => {
+			const data = getEventData( request, 'add_to_cart' );
+			expect( data.product1 ).toEqual( {
+				id: simpleProductID.toString(),
+				nm: 'Simple product',
+				ca: 'Uncategorized',
+				qt: '1',
+				pr: simpleProductPrice.toString(),
+			} );
+		} );
+	} );
+
 	test( 'Add to cart event is sent on a variable product page', async ( {
 		page,
 	} ) => {


### PR DESCRIPTION
## Description
Closes #475
Closes STORMA-45

When a classic `added_to_cart` event has no button argument, fall back to server-rendered added-to-cart data or the current single-product data instead of only logging an error. This covers single-product AJAX flows from third-party plugins while avoiding guessed product data on other pages.

## Checks
- [x] Project linting passes
- [x] Automated tests pass
- [x] Manual testing completed

## Testing instructions
1. `npm run lint:js`
2. `npm run dev`
3. `npx playwright test --config=tests/e2e/config/playwright.config.js tests/e2e/specs/gtag-events/classic-pages.test.js --grep "event has no button"`

### Changelog entry

> Fix - Track classic add_to_cart events without a button when single-product data is available.