### PR TITLE
Expand purchase event E2E coverage

### DIFF
--- a/assets/js/src/index.js
+++ b/assets/js/src/index.js
@@ -31,11 +31,6 @@ const publicApi = {
 	},
 };
 
-window.wcGoogleAnalyticsIntegration = {
-	...( window.wcGoogleAnalyticsIntegration ?? {} ),
-	...publicApi,
-};
-
 // Wait for 'ga4w:ready' event if `window.ga4w` is not there yet.
 if ( window.ga4w ) {
 	initializeTracking();
@@ -51,6 +46,13 @@ if ( window.ga4w ) {
 }
 
 function initializeTracking() {
+	// Expose the public API once window.ga4w (settings + data) is ready, so
+	// helpers such as getProductId resolve the configured identifier correctly
+	// instead of falling back to the numeric product ID.
+	window.wcGoogleAnalyticsIntegration = {
+		...( window.wcGoogleAnalyticsIntegration ?? {} ),
+		...publicApi,
+	};
 	Object.assign( window.ga4w, publicApi );
 
 	setCurrentConsentState( window.ga4w.settings );

--- a/assets/js/src/index.js
+++ b/assets/js/src/index.js
@@ -1,10 +1,19 @@
 import { setupEventHandlers } from './tracker';
+import * as formatters from './tracker/data-formatting';
+import * as utils from './utils';
 import { classicTracking } from './integrations/classic';
 import { blocksTracking } from './integrations/blocks';
 import {
 	setCurrentConsentState,
 	addConsentStateChangeEventListener,
 } from './integrations/wp-consent-api';
+
+const publicApi = { formatters, utils };
+
+window.wcGoogleAnalyticsIntegration = {
+	...( window.wcGoogleAnalyticsIntegration ?? {} ),
+	...publicApi,
+};
 
 // Wait for 'ga4w:ready' event if `window.ga4w` is not there yet.
 if ( window.ga4w ) {
@@ -21,6 +30,8 @@ if ( window.ga4w ) {
 }
 
 function initializeTracking() {
+	Object.assign( window.ga4w, publicApi );
+
 	setCurrentConsentState( window.ga4w.settings );
 	addConsentStateChangeEventListener( window.ga4w.settings );
 

--- a/assets/js/src/index.js
+++ b/assets/js/src/index.js
@@ -8,7 +8,28 @@ import {
 	addConsentStateChangeEventListener,
 } from './integrations/wp-consent-api';
 
-const publicApi = { formatters, utils };
+/*
+ * Public JavaScript API, exposed on `window.wcGoogleAnalyticsIntegration` and
+ * mirrored onto `window.ga4w`. This is the supported extension surface:
+ *
+ * - `formatters`: the GA4 event formatters (`add_to_cart`, `view_item`,
+ *   `purchase`, …) used to build event payloads.
+ * - `utils`: the product/cart formatting helpers used to shape that data.
+ *
+ * Only the helpers below are part of the contract. Internal plumbing (e.g.
+ * `addUniqueAction`, `cacheBlockProducts`) is intentionally not exposed so it
+ * can change without breaking integrations.
+ */
+const publicApi = {
+	formatters,
+	utils: {
+		getProductFieldObject: utils.getProductFieldObject,
+		getProductImpressionObject: utils.getProductImpressionObject,
+		formatPrice: utils.formatPrice,
+		getProductId: utils.getProductId,
+		getCartCoupon: utils.getCartCoupon,
+	},
+};
 
 window.wcGoogleAnalyticsIntegration = {
 	...( window.wcGoogleAnalyticsIntegration ?? {} ),

--- a/assets/js/src/integrations/blocks.js
+++ b/assets/js/src/integrations/blocks.js
@@ -199,14 +199,22 @@ const getSelectedShippingRate = ( storeCart ) => {
 };
 
 const trackCheckoutEvent = ( eventName, getEventHandler, data = {} ) => {
-	const storeCart = getCheckoutCartData( data.storeCart );
+	try {
+		const storeCart = getCheckoutCartData( data.storeCart );
 
-	if ( ! storeCart?.items?.length ) {
+		if ( ! storeCart?.items?.length ) {
+			return false;
+		}
+
+		safeTrackEvent( getEventHandler, eventName, { ...data, storeCart } );
+		return true;
+	} catch ( error ) {
+		warnTrackingError(
+			`could not prepare the ${ eventName } event.`,
+			error
+		);
 		return false;
 	}
-
-	safeTrackEvent( getEventHandler, eventName, { ...data, storeCart } );
-	return true;
 };
 
 /**

--- a/assets/js/src/integrations/blocks.js
+++ b/assets/js/src/integrations/blocks.js
@@ -934,19 +934,27 @@ export const blocksTracking = ( getEventHandler ) => {
 		`${ ACTION_PREFIX }-checkout-set-selected-shipping-rate`,
 		NAMESPACE,
 		( data ) => {
-			const storeCart = getCheckoutCartData( data.storeCart );
-			addShippingInfoTracked = trackCheckoutEvent(
-				'add_shipping_info',
-				getEventHandler,
-				{
-					...data,
-					shippingTier:
-						findShippingRateName(
-							storeCart,
-							data.shippingRateId
-						) ?? data.shippingRateId,
-				}
-			);
+			try {
+				const storeCart = getCheckoutCartData( data.storeCart );
+				const shippingRateId = data.shippingRateId;
+
+				addShippingInfoTracked = trackCheckoutEvent(
+					'add_shipping_info',
+					getEventHandler,
+					{
+						...data,
+						shippingTier:
+							findShippingRateName( storeCart, shippingRateId ) ??
+							shippingRateId,
+					}
+				);
+			} catch ( error ) {
+				addShippingInfoTracked = false;
+				warnTrackingError(
+					'could not prepare the add_shipping_info event.',
+					error
+				);
+			}
 		}
 	);
 
@@ -954,14 +962,24 @@ export const blocksTracking = ( getEventHandler ) => {
 		`${ ACTION_PREFIX }-checkout-set-active-payment-method`,
 		NAMESPACE,
 		( data ) => {
-			addPaymentInfoTracked = trackCheckoutEvent(
-				'add_payment_info',
-				getEventHandler,
-				{
-					...data,
-					paymentType: getPaymentTypeLabel( data.paymentMethodSlug ),
-				}
-			);
+			try {
+				addPaymentInfoTracked = trackCheckoutEvent(
+					'add_payment_info',
+					getEventHandler,
+					{
+						...data,
+						paymentType: getPaymentTypeLabel(
+							data.paymentMethodSlug
+						),
+					}
+				);
+			} catch ( error ) {
+				addPaymentInfoTracked = false;
+				warnTrackingError(
+					'could not prepare the add_payment_info event.',
+					error
+				);
+			}
 		}
 	);
 
@@ -969,33 +987,40 @@ export const blocksTracking = ( getEventHandler ) => {
 		`${ ACTION_PREFIX }-checkout-submit`,
 		NAMESPACE,
 		( data ) => {
-			const shippingTier = getSelectedShippingRate( data.storeCart );
+			try {
+				const shippingTier = getSelectedShippingRate( data.storeCart );
 
-			if ( ! addShippingInfoTracked && shippingTier ) {
-				addShippingInfoTracked = trackCheckoutEvent(
-					'add_shipping_info',
+				if ( ! addShippingInfoTracked && shippingTier ) {
+					addShippingInfoTracked = trackCheckoutEvent(
+						'add_shipping_info',
+						getEventHandler,
+						{
+							...data,
+							shippingTier,
+						}
+					);
+				}
+
+				if ( addPaymentInfoTracked ) {
+					return;
+				}
+
+				addPaymentInfoTracked = trackCheckoutEvent(
+					'add_payment_info',
 					getEventHandler,
 					{
 						...data,
-						shippingTier,
+						paymentType: getPaymentTypeLabel(
+							getActivePaymentMethod()
+						),
 					}
 				);
+			} catch ( error ) {
+				warnTrackingError(
+					'could not prepare checkout submit tracking.',
+					error
+				);
 			}
-
-			if ( addPaymentInfoTracked ) {
-				return;
-			}
-
-			addPaymentInfoTracked = trackCheckoutEvent(
-				'add_payment_info',
-				getEventHandler,
-				{
-					...data,
-					paymentType: getPaymentTypeLabel(
-						getActivePaymentMethod()
-					),
-				}
-			);
 		}
 	);
 

--- a/assets/js/src/integrations/classic.js
+++ b/assets/js/src/integrations/classic.js
@@ -388,6 +388,14 @@ export function classicTracking(
 			return;
 		}
 
+		// The classic cart rows only exist on the cart page. On other pages
+		// (e.g. after a mini-cart AJAX update on the shop) `updated_wc_div`
+		// still fires but there are no rows to read, so leave the existing
+		// snapshot untouched instead of wiping it to an empty array.
+		if ( ! document.querySelector( '.woocommerce-cart-form' ) ) {
+			return;
+		}
+
 		const syncedItems = [];
 
 		document

--- a/assets/js/src/integrations/classic.js
+++ b/assets/js/src/integrations/classic.js
@@ -97,6 +97,8 @@ export function classicTracking(
 ) {
 	let shippingInfoTracked = false;
 	let paymentInfoTracked = false;
+	let cartSnapshot = cart;
+	const cartQuantityTrackedForms = new WeakSet();
 
 	const trackShippingInfo = ( shippingTier ) => {
 		shippingInfoTracked = true;
@@ -290,11 +292,11 @@ export function classicTracking(
 			return;
 		}
 		getEventHandler( 'remove_from_cart' )( {
-			product: getProductFromID( productID, products, cart ),
+			product: getProductFromID( productID, products, cartSnapshot ),
 		} );
 	}
 
-	function getQuantityChangeProduct( cartProduct, quantity ) {
+	function getCartItemUnitPrice( cartProduct ) {
 		const previousQuantity = parseInt( cartProduct?.quantity, 10 );
 		const linePrice = parseInt( cartProduct?.prices?.price, 10 );
 
@@ -303,6 +305,16 @@ export function classicTracking(
 			previousQuantity < 1 ||
 			! Number.isFinite( linePrice )
 		) {
+			return null;
+		}
+
+		return linePrice / previousQuantity;
+	}
+
+	function getQuantityChangeProduct( cartProduct, quantity ) {
+		const unitPrice = getCartItemUnitPrice( cartProduct );
+
+		if ( null === unitPrice ) {
 			return { ...cartProduct, quantity };
 		}
 
@@ -311,7 +323,24 @@ export function classicTracking(
 			quantity,
 			prices: {
 				...cartProduct.prices,
-				price: Math.round( linePrice / previousQuantity ),
+				price: Math.round( unitPrice ),
+			},
+		};
+	}
+
+	function getCartSnapshotProduct( cartProduct, quantity ) {
+		const unitPrice = getCartItemUnitPrice( cartProduct );
+
+		if ( null === unitPrice ) {
+			return { ...cartProduct, quantity };
+		}
+
+		return {
+			...cartProduct,
+			quantity,
+			prices: {
+				...cartProduct.prices,
+				price: Math.round( unitPrice * quantity ),
 			},
 		};
 	}
@@ -323,9 +352,10 @@ export function classicTracking(
 
 	function getProductFromCartItemRow( item, productID ) {
 		const cartItemKey = getCartItemKeyFromRow( item );
+		const cartItems = cartSnapshot?.items ?? [];
 
 		if ( cartItemKey ) {
-			const matchedCartItem = cart?.items?.find(
+			const matchedCartItem = cartItems.find(
 				( { key } ) => key === cartItemKey
 			);
 
@@ -342,82 +372,130 @@ export function classicTracking(
 		// than one cart line maps to this `productID` we can't tell them apart
 		// by ID alone. Bail out rather than risk attributing the change to the
 		// wrong variation's price and attributes.
-		const matchingItems =
-			cart?.items?.filter(
-				( { id } ) => String( id ) === String( productID )
-			) ?? [];
+		const matchingItems = cartItems.filter(
+			( { id } ) => String( id ) === String( productID )
+		);
 
 		if ( matchingItems.length > 1 ) {
 			return undefined;
 		}
 
-		return getProductFromID( productID, cart?.items, { items: products } );
+		return getProductFromID( productID, cartItems, { items: products } );
 	}
 
-	document
-		.querySelector( '.woocommerce-cart-form' )
-		?.addEventListener( 'submit', () => {
-			if ( ! cart?.items?.length ) {
-				return;
-			}
+	function syncCartSnapshotFromCartRows() {
+		if ( ! cartSnapshot?.items?.length ) {
+			return;
+		}
 
-			document
-				.querySelectorAll( classicCartItemSelector )
-				.forEach( ( item ) => {
-					const newQuantity = parseInt(
-						item.querySelector( 'input.qty' )?.value,
-						10
+		const syncedItems = [];
+
+		document
+			.querySelectorAll( classicCartItemSelector )
+			.forEach( ( item ) => {
+				const newQuantity = parseInt(
+					item.querySelector( 'input.qty' )?.value,
+					10
+				);
+				const productID = parseInt(
+					item.querySelector( '.remove[data-product_id]' )?.dataset
+						.product_id,
+					10
+				);
+				const matchedProduct = getProductFromCartItemRow(
+					item,
+					productID
+				);
+
+				if ( matchedProduct && Number.isFinite( newQuantity ) ) {
+					syncedItems.push(
+						getCartSnapshotProduct( matchedProduct, newQuantity )
 					);
+				}
+			} );
 
-					if ( ! Number.isFinite( newQuantity ) ) {
-						return;
-					}
+		cartSnapshot = {
+			...cartSnapshot,
+			items: syncedItems,
+		};
+	}
 
-					const productID = parseInt(
-						item.querySelector( '.remove[data-product_id]' )
-							?.dataset.product_id,
-						10
-					);
-					const matchedProduct = getProductFromCartItemRow(
-						item,
-						productID
-					);
-					const previousQuantity = parseInt(
-						matchedProduct?.quantity,
-						10
-					);
+	function handleCartQuantitySubmit() {
+		if ( ! cartSnapshot?.items?.length ) {
+			return;
+		}
 
-					if (
-						! matchedProduct ||
-						! Number.isFinite( previousQuantity ) ||
-						newQuantity === previousQuantity
-					) {
-						return;
-					}
+		document
+			.querySelectorAll( classicCartItemSelector )
+			.forEach( ( item ) => {
+				const newQuantity = parseInt(
+					item.querySelector( 'input.qty' )?.value,
+					10
+				);
 
-					const eventName =
-						newQuantity > previousQuantity
-							? 'add_to_cart'
-							: 'remove_from_cart';
-					const quantity = Math.abs( newQuantity - previousQuantity );
+				if ( ! Number.isFinite( newQuantity ) ) {
+					return;
+				}
 
-					getEventHandler( eventName )( {
-						product: getQuantityChangeProduct(
-							matchedProduct,
-							quantity
-						),
-					} );
+				const productID = parseInt(
+					item.querySelector( '.remove[data-product_id]' )?.dataset
+						.product_id,
+					10
+				);
+				const matchedProduct = getProductFromCartItemRow(
+					item,
+					productID
+				);
+				const previousQuantity = parseInt(
+					matchedProduct?.quantity,
+					10
+				);
+
+				if (
+					! matchedProduct ||
+					! Number.isFinite( previousQuantity ) ||
+					newQuantity === previousQuantity
+				) {
+					return;
+				}
+
+				const eventName =
+					newQuantity > previousQuantity
+						? 'add_to_cart'
+						: 'remove_from_cart';
+				const quantity = Math.abs( newQuantity - previousQuantity );
+
+				getEventHandler( eventName )( {
+					product: getQuantityChangeProduct(
+						matchedProduct,
+						quantity
+					),
 				} );
-		} );
+			} );
+	}
+
+	function attachCartQuantityChangeListener() {
+		const form = document.querySelector( '.woocommerce-cart-form' );
+
+		if ( ! form || cartQuantityTrackedForms.has( form ) ) {
+			return;
+		}
+
+		cartQuantityTrackedForms.add( form );
+		form.addEventListener( 'submit', handleCartQuantitySubmit );
+	}
 
 	// Attach event listeners on initial page load and when the cart div is updated
 	removeFromCartListener();
+	attachCartQuantityChangeListener();
 	const oldOnupdatedWcDiv = document.body.onupdated_wc_div;
 	document.body.onupdated_wc_div = function () {
 		if ( typeof oldOnupdatedWcDiv === 'function' ) {
 			oldOnupdatedWcDiv.apply( this, arguments );
 		}
+		syncCartSnapshotFromCartRows();
 		removeFromCartListener();
+		attachCartQuantityChangeListener();
 	};
 
 	// Trigger the handler when an item is removed from the mini-cart and WooCommerce dispatches the `removed_from_cart` event.

--- a/assets/js/src/integrations/classic.js
+++ b/assets/js/src/integrations/classic.js
@@ -287,6 +287,87 @@ export function classicTracking(
 		} );
 	}
 
+	function getQuantityChangeProduct( cartProduct, quantity ) {
+		const previousQuantity = parseInt( cartProduct?.quantity, 10 );
+		const linePrice = parseInt( cartProduct?.prices?.price, 10 );
+
+		if (
+			! Number.isFinite( previousQuantity ) ||
+			previousQuantity < 1 ||
+			! Number.isFinite( linePrice )
+		) {
+			return { ...cartProduct, quantity };
+		}
+
+		return {
+			...cartProduct,
+			quantity,
+			prices: {
+				...cartProduct.prices,
+				price: Math.round( linePrice / previousQuantity ),
+			},
+		};
+	}
+
+	document
+		.querySelector( '.woocommerce-cart-form' )
+		?.addEventListener( 'submit', () => {
+			if ( ! cart?.items?.length ) {
+				return;
+			}
+
+			document
+				.querySelectorAll( '.woocommerce-cart-form .cart_item' )
+				.forEach( ( item ) => {
+					const productID = parseInt(
+						item.querySelector( '.remove[data-product_id]' )
+							?.dataset.product_id
+					);
+					const newQuantity = parseInt(
+						item.querySelector( 'input.qty' )?.value,
+						10
+					);
+
+					if (
+						Number.isNaN( productID ) ||
+						! Number.isFinite( newQuantity )
+					) {
+						return;
+					}
+
+					const matchedProduct = getProductFromID(
+						productID,
+						products,
+						cart
+					);
+					const previousQuantity = parseInt(
+						matchedProduct?.quantity,
+						10
+					);
+
+					if (
+						! matchedProduct ||
+						! Number.isFinite( previousQuantity ) ||
+						newQuantity === previousQuantity
+					) {
+						return;
+					}
+
+					const eventName =
+						newQuantity > previousQuantity
+							? 'add_to_cart'
+							: 'remove_from_cart';
+					const quantity = Math.abs( newQuantity - previousQuantity );
+
+					getEventHandler( eventName )( {
+						product: getQuantityChangeProduct(
+							matchedProduct,
+							quantity
+						),
+					} );
+				} );
+		} );
+
 	// Attach event listeners on initial page load and when the cart div is updated
 	removeFromCartListener();
 	const oldOnupdatedWcDiv = document.body.onupdated_wc_div;

--- a/assets/js/src/integrations/classic.js
+++ b/assets/js/src/integrations/classic.js
@@ -455,7 +455,7 @@ export function classicTracking(
 	// Attach click event listeners to a whole product card, as some links may not have the product_id data attribute.
 	document
 		.querySelectorAll(
-			'.products-block-post-template .product, .wc-block-product-template .product'
+			'.products-block-post-template .product, .wc-block-product-template .product, .wc-block-grid__product'
 		)
 		?.forEach( ( productCard ) => {
 			// Get the Product ID from a child node containing the relevant attribute
@@ -471,7 +471,7 @@ export function classicTracking(
 				const target = event.target;
 				// `product-view-link` has no serilized HTML identifier/selector, so we look for the parent block element.
 				const viewLink = target.closest(
-					'.wc-block-components-product-image a'
+					'.wc-block-components-product-image a, .wc-block-grid__product-link'
 				);
 
 				// Catch name click

--- a/assets/js/src/integrations/classic.js
+++ b/assets/js/src/integrations/classic.js
@@ -3,6 +3,8 @@ import { getProductFromID } from '../utils';
 const checkoutPaymentMethodSelector = 'input[name="payment_method"]';
 const checkoutShippingMethodSelector =
 	'input[name^="shipping_method"], select[name^="shipping_method"]';
+const classicCartItemSelector =
+	'.woocommerce-cart-form .woocommerce-cart-form__cart-item, .woocommerce-cart-form .cart_item';
 
 const getSelectedCheckoutOption = ( selector ) =>
 	Array.from( document.querySelectorAll( selector ) ).find(
@@ -309,6 +311,29 @@ export function classicTracking(
 		};
 	}
 
+	function getCartItemKeyFromRow( item ) {
+		const inputName = item.querySelector( 'input.qty' )?.name;
+		return inputName?.match( /^cart\[([^\]]+)\]\[qty]$/ )?.[ 1 ];
+	}
+
+	function getProductFromCartItemRow( item, productID ) {
+		const cartItemKey = getCartItemKeyFromRow( item );
+
+		if ( cartItemKey ) {
+			const matchedCartItem = cart?.items?.find(
+				( { key } ) => key === cartItemKey
+			);
+
+			if ( matchedCartItem ) {
+				return matchedCartItem;
+			}
+		}
+
+		return Number.isNaN( productID )
+			? undefined
+			: getProductFromID( productID, cart?.items, { items: products } );
+	}
+
 	document
 		.querySelector( '.woocommerce-cart-form' )
 		?.addEventListener( 'submit', () => {
@@ -317,28 +342,25 @@ export function classicTracking(
 			}
 
 			document
-				.querySelectorAll( '.woocommerce-cart-form .cart_item' )
+				.querySelectorAll( classicCartItemSelector )
 				.forEach( ( item ) => {
-					const productID = parseInt(
-						item.querySelector( '.remove[data-product_id]' )
-							?.dataset.product_id
-					);
 					const newQuantity = parseInt(
 						item.querySelector( 'input.qty' )?.value,
 						10
 					);
 
-					if (
-						Number.isNaN( productID ) ||
-						! Number.isFinite( newQuantity )
-					) {
+					if ( ! Number.isFinite( newQuantity ) ) {
 						return;
 					}
 
-					const matchedProduct = getProductFromID(
-						productID,
-						products,
-						cart
+					const productID = parseInt(
+						item.querySelector( '.remove[data-product_id]' )
+							?.dataset.product_id,
+						10
+					);
+					const matchedProduct = getProductFromCartItemRow(
+						item,
+						productID
 					);
 					const previousQuantity = parseInt(
 						matchedProduct?.quantity,

--- a/assets/js/src/integrations/classic.js
+++ b/assets/js/src/integrations/classic.js
@@ -115,7 +115,15 @@ export function classicTracking(
 	// Instantly track the events listed in the `events` object.
 	Object.values( events ?? {} ).forEach( ( eventName ) => {
 		if ( eventName === 'add_to_cart' ) {
-			getEventHandler( eventName )( { product: addedToCart } );
+			const addedProducts = Array.isArray( addedToCart )
+				? addedToCart
+				: [ addedToCart ];
+
+			addedProducts.filter( Boolean ).forEach( ( productToHandle ) => {
+				getEventHandler( eventName )( {
+					product: productToHandle,
+				} );
+			} );
 		} else {
 			getEventHandler( eventName )( {
 				storeCart: cart,

--- a/assets/js/src/integrations/classic.js
+++ b/assets/js/src/integrations/classic.js
@@ -329,9 +329,24 @@ export function classicTracking(
 			}
 		}
 
-		return Number.isNaN( productID )
-			? undefined
-			: getProductFromID( productID, cart?.items, { items: products } );
+		if ( Number.isNaN( productID ) ) {
+			return undefined;
+		}
+
+		// Variations of the same parent share the parent's `id`, so when more
+		// than one cart line maps to this `productID` we can't tell them apart
+		// by ID alone. Bail out rather than risk attributing the change to the
+		// wrong variation's price and attributes.
+		const matchingItems =
+			cart?.items?.filter(
+				( { id } ) => String( id ) === String( productID )
+			) ?? [];
+
+		if ( matchingItems.length > 1 ) {
+			return undefined;
+		}
+
+		return getProductFromID( productID, cart?.items, { items: products } );
 	}
 
 	document

--- a/assets/js/src/integrations/classic.js
+++ b/assets/js/src/integrations/classic.js
@@ -206,13 +206,18 @@ export function classicTracking(
 			buttonElement?.dataset.product_id || buttonElement?.value
 		);
 
-		let productToHandle;
 		if ( Number.isNaN( productID ) ) {
-			productToHandle = addedToCart ?? product;
+			const fallback = addedToCart ?? product;
 
-			if ( productToHandle ) {
-				getEventHandler( 'add_to_cart' )( {
-					product: productToHandle,
+			if ( fallback ) {
+				const addedProducts = Array.isArray( fallback )
+					? fallback
+					: [ fallback ];
+
+				addedProducts.filter( Boolean ).forEach( ( addedProduct ) => {
+					getEventHandler( 'add_to_cart' )( {
+						product: addedProduct,
+					} );
 				} );
 				return;
 			}
@@ -225,7 +230,7 @@ export function classicTracking(
 		}
 
 		// If the current product doesn't match search by ID.
-		productToHandle =
+		const productToHandle =
 			product?.id === productID
 				? product
 				: getProductFromID( productID, products, cart );

--- a/assets/js/src/utils/index.js
+++ b/assets/js/src/utils/index.js
@@ -27,6 +27,23 @@ export const cacheBlockProducts = ( products ) => {
 	} );
 };
 
+const formatVariation = ( variation ) => {
+	if ( ! Array.isArray( variation ) ) {
+		return variation;
+	}
+
+	return variation
+		.map( ( { attribute, value } ) => {
+			if ( ! attribute || ! value ) {
+				return null;
+			}
+
+			return `${ attribute.toLowerCase() }: ${ value }`;
+		} )
+		.filter( Boolean )
+		.join( ', ' );
+};
+
 /**
  * Formats data into the productFieldObject shape.
  *
@@ -39,7 +56,7 @@ export const cacheBlockProducts = ( products ) => {
 export const getProductFieldObject = ( product, quantity ) => {
 	const variantData = {};
 	if ( product.variation ) {
-		variantData.item_variant = product.variation;
+		variantData.item_variant = formatVariation( product.variation );
 	}
 
 	const data = {

--- a/includes/class-wc-abstract-google-analytics-js.php
+++ b/includes/class-wc-abstract-google-analytics-js.php
@@ -237,22 +237,23 @@ abstract class WC_Abstract_Google_Analytics_JS {
 			return array();
 		}
 
+		$items = array();
+		foreach ( $cart->get_cart() as $cart_item_key => $item ) {
+			$items[] = array_merge(
+				$this->get_formatted_product( $item['data'] ),
+				array(
+					'key'      => $cart_item_key,
+					'quantity' => $item['quantity'],
+					'prices'   => array(
+						'price'               => $this->get_formatted_price( $item['line_total'] ),
+						'currency_minor_unit' => wc_get_price_decimals(),
+					),
+				)
+			);
+		}
+
 		return array(
-			'items'   => array_map(
-				function ( $item ) {
-					return array_merge(
-						$this->get_formatted_product( $item['data'] ),
-						array(
-							'quantity' => $item['quantity'],
-							'prices'   => array(
-								'price'               => $this->get_formatted_price( $item['line_total'] ),
-								'currency_minor_unit' => wc_get_price_decimals(),
-							),
-						)
-					);
-				},
-				array_values( $cart->get_cart() )
-			),
+			'items'   => $items,
 			'coupons' => $cart->get_coupons(),
 			'totals'  => array(
 				'currency_code'       => get_woocommerce_currency(),

--- a/includes/class-wc-abstract-google-analytics-js.php
+++ b/includes/class-wc-abstract-google-analytics-js.php
@@ -18,7 +18,7 @@ abstract class WC_Abstract_Google_Analytics_JS {
 	protected static $instance;
 
 	/** @var array $settings Inherited Analytics settings */
-	protected static $settings;
+	protected $settings = array();
 
 	/** @var string Developer ID */
 	public const DEVELOPER_ID = 'dOGY3NW';
@@ -120,7 +120,7 @@ abstract class WC_Abstract_Google_Analytics_JS {
 		add_action(
 			'woocommerce_thankyou',
 			function ( $order_id ) {
-				if ( 'yes' === self::get( 'ga_ecommerce_tracking_enabled' ) ) {
+				if ( 'yes' === $this->get_setting( 'ga_ecommerce_tracking_enabled' ) ) {
 					$order = wc_get_order( $order_id );
 					if ( $order && $order->get_meta( '_ga_tracked' ) !== '1' ) {
 						// Check order key.
@@ -174,22 +174,24 @@ abstract class WC_Abstract_Google_Analytics_JS {
 	}
 
 	/**
-	 * Return one of our settings
+	 * Return one of our settings.
 	 *
 	 * @param string $setting Key/name for the setting.
 	 *
-	 * @return string|null Value of the setting or null if not found
+	 * @return mixed|null Value of the setting or null if not found.
 	 */
-	protected static function get( $setting ): ?string {
-		return self::$settings[ $setting ] ?? null;
+	protected function get_setting( string $setting ) {
+		return $this->settings[ $setting ] ?? null;
 	}
 
 	/**
-	 * Generic GA snippet for opt out
+	 * Generic GA snippet for opt out.
+	 *
+	 * @return void
 	 */
-	public static function load_opt_out(): void {
+	public function load_opt_out_script(): void {
 		$code = "
-			var gaProperty = '" . esc_js( self::get( 'ga_id' ) ) . "';
+			var gaProperty = '" . esc_js( $this->get_setting( 'ga_id' ) ) . "';
 			var disableStr = 'ga-disable-' + gaProperty;
 			if ( document.cookie.indexOf( disableStr + '=true' ) > -1 ) {
 				window[disableStr] = true;
@@ -205,16 +207,25 @@ abstract class WC_Abstract_Google_Analytics_JS {
 	}
 
 	/**
-	 * Get item identifier from product data
+	 * Compatibility wrapper for the formerly static opt-out loader.
+	 *
+	 * @return void
+	 */
+	public static function load_opt_out(): void {
+		static::get_compatibility_instance()->load_opt_out_script();
+	}
+
+	/**
+	 * Get item identifier from product data.
 	 *
 	 * @param WC_Product $product WC_Product Object.
 	 *
 	 * @return string
 	 */
-	public static function get_product_identifier( WC_Product $product ): string {
+	public function get_product_identifier_for_product( WC_Product $product ): string {
 		$identifier = $product->is_type( 'variation' ) ? $product->get_parent_id() : $product->get_id();
 
-		if ( 'product_sku' === self::get( 'ga_product_identifier' ) ) {
+		if ( 'product_sku' === $this->get_setting( 'ga_product_identifier' ) ) {
 			if ( ! empty( $product->get_sku() ) ) {
 				$identifier = $product->get_sku();
 			} else {
@@ -223,6 +234,17 @@ abstract class WC_Abstract_Google_Analytics_JS {
 		}
 
 		return apply_filters( 'woocommerce_ga_product_identifier', $identifier, $product );
+	}
+
+	/**
+	 * Compatibility wrapper for the formerly static product identifier formatter.
+	 *
+	 * @param WC_Product $product WC_Product Object.
+	 *
+	 * @return string
+	 */
+	public static function get_product_identifier( WC_Product $product ): string {
+		return static::get_compatibility_instance()->get_product_identifier_for_product( $product );
 	}
 
 	/**
@@ -306,7 +328,7 @@ abstract class WC_Abstract_Google_Analytics_JS {
 			),
 			'extensions' => array(
 				'woocommerce_google_analytics_integration' => array(
-					'identifier' => $this->get_product_identifier( $product ),
+					'identifier' => $this->get_product_identifier_for_product( $product ),
 				),
 			),
 		);
@@ -510,8 +532,17 @@ abstract class WC_Abstract_Google_Analytics_JS {
 		$product = is_a( $product, 'WC_Product' ) ? $product : $product['data'];
 
 		return array(
-			'identifier' => (string) $this->get_product_identifier( $product ),
+			'identifier' => (string) $this->get_product_identifier_for_product( $product ),
 		);
+	}
+
+	/**
+	 * Return the current instance for compatibility wrappers.
+	 *
+	 * @return WC_Abstract_Google_Analytics_JS
+	 */
+	protected static function get_compatibility_instance(): WC_Abstract_Google_Analytics_JS {
+		return static::$instance ?? static::get_instance();
 	}
 
 	/**

--- a/includes/class-wc-abstract-google-analytics-js.php
+++ b/includes/class-wc-abstract-google-analytics-js.php
@@ -351,9 +351,28 @@ abstract class WC_Abstract_Google_Analytics_JS {
 	 * @return void
 	 */
 	public function capture_added_to_cart( $cart_item_key, $product_id, $quantity, $variation_id, $variation ): void {
-		$formatted = $this->get_formatted_product( wc_get_product( $product_id ), $variation_id, $variation, $quantity );
-		$this->set_script_data( 'added_to_cart', $formatted );
-		$this->pending_added_to_cart = $formatted;
+		$cart_item = null;
+		if ( WC()->cart && isset( WC()->cart->cart_contents[ $cart_item_key ] ) ) {
+			$cart_item = WC()->cart->cart_contents[ $cart_item_key ];
+		}
+
+		$product   = $cart_item['data'] ?? wc_get_product( $product_id );
+		$formatted = $this->get_formatted_product( $product, $variation_id, $variation, $quantity );
+
+		if ( null === $this->pending_added_to_cart ) {
+			$this->set_script_data( 'added_to_cart', $formatted );
+			$this->pending_added_to_cart = $formatted;
+			return;
+		}
+
+		$is_grouped_capture = isset( $this->pending_added_to_cart[0] ) && is_array( $this->pending_added_to_cart[0] );
+		$products           = $is_grouped_capture
+			? $this->pending_added_to_cart
+			: array( $this->pending_added_to_cart );
+		$products[]         = $formatted;
+
+		$this->set_script_data( 'added_to_cart', $products );
+		$this->pending_added_to_cart = $products;
 	}
 
 	/**

--- a/includes/class-wc-abstract-google-analytics-js.php
+++ b/includes/class-wc-abstract-google-analytics-js.php
@@ -537,12 +537,23 @@ abstract class WC_Abstract_Google_Analytics_JS {
 	}
 
 	/**
-	 * Return the current instance for compatibility wrappers.
+	 * Return an instance for the static compatibility wrappers to read settings from.
+	 *
+	 * If a tracking instance has already been bootstrapped, reuse it. Otherwise build a
+	 * lightweight, settings-only instance without invoking the constructor, so reading a
+	 * setting never registers scripts/hooks, enqueues anything, or installs a live
+	 * singleton. This mirrors the pre-refactor static helpers, which read settings with
+	 * no side effects even when the integration skipped get_tracking_instance() (e.g.
+	 * `ga_id` is unset).
 	 *
 	 * @return WC_Abstract_Google_Analytics_JS
 	 */
 	protected static function get_compatibility_instance(): WC_Abstract_Google_Analytics_JS {
-		return static::$instance ?? static::get_instance();
+		if ( static::$instance ) {
+			return static::$instance;
+		}
+
+		return ( new \ReflectionClass( static::class ) )->newInstanceWithoutConstructor();
 	}
 
 	/**

--- a/includes/class-wc-google-gtag-js.php
+++ b/includes/class-wc-google-gtag-js.php
@@ -429,6 +429,11 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 	public static function get_instance( $settings = array() ): WC_Abstract_Google_Analytics_JS {
 		if ( null === self::$instance ) {
 			self::$instance = new self( $settings );
+		} elseif ( ! empty( $settings ) ) {
+			// A static compatibility wrapper may have bootstrapped the instance with empty
+			// settings before the integration supplied the real ones. Rehydrate so later
+			// reads (e.g. enabled events, product identifier) reflect the current settings.
+			self::$instance->settings = $settings;
 		}
 
 		return self::$instance;

--- a/includes/class-wc-google-gtag-js.php
+++ b/includes/class-wc-google-gtag-js.php
@@ -46,8 +46,10 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 	 * @param array $settings Settings
 	 */
 	public function __construct( $settings = array() ) {
+		$this->settings = $settings;
+		self::$instance = $this;
+
 		parent::__construct();
-		self::$settings = $settings;
 
 		$this->map_hooks();
 
@@ -66,7 +68,7 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 	private function register_scripts(): void {
 		wp_register_script(
 			'google-tag-manager',
-			'https://www.googletagmanager.com/gtag/js?id=' . self::get( 'ga_id' ),
+			'https://www.googletagmanager.com/gtag/js?id=' . $this->get_setting( 'ga_id' ),
 			array(),
 			null,
 			array(
@@ -99,7 +101,7 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 					%2$s("js", new Date());
 					%2$s("set", "developer_id.%3$s", true);
 					%2$s("config", "%1$s", %5$s);',
-					esc_js( $this->get( 'ga_id' ) ),
+					esc_js( $this->get_setting( 'ga_id' ) ),
 					esc_js( $this->tracker_function_name() ),
 					esc_js( static::DEVELOPER_ID ),
 					wp_json_encode( $this->get_consent_modes(), JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ),
@@ -167,8 +169,8 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 				wp_json_encode(
 					array(
 						'tracker_function_name' => $this->tracker_function_name(),
-						'events'                => $this->get_enabled_events(),
-						'identifier'            => $this->get( 'ga_product_identifier' ),
+						'events'                => $this->get_enabled_events_for_settings(),
+						'identifier'            => $this->get_setting( 'ga_product_identifier' ),
 						'currency'              => array(
 							'decimalSeparator'  => wc_get_price_decimal_separator(),
 							'thousandSeparator' => wc_get_price_thousand_separator(),
@@ -281,12 +283,12 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 		return apply_filters(
 			'woocommerce_ga_gtag_config',
 			array(
-				'track_404'            => 'yes' === $this->get( 'ga_404_tracking_enabled' ),
-				'allow_google_signals' => 'yes' === $this->get( 'ga_support_display_advertising' ),
+				'track_404'            => 'yes' === $this->get_setting( 'ga_404_tracking_enabled' ),
+				'allow_google_signals' => 'yes' === $this->get_setting( 'ga_support_display_advertising' ),
 				'logged_in'            => is_user_logged_in(),
 				'linker'               => array(
 					'domains'        => $this->get_linker_domains(),
-					'allow_incoming' => 'yes' === $this->get( 'ga_linker_allow_incoming_enabled' ),
+					'allow_incoming' => 'yes' === $this->get_setting( 'ga_linker_allow_incoming_enabled' ),
 				),
 				'custom_map'           => array(
 					'dimension1' => 'logged_in',
@@ -301,7 +303,7 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 	 * @return array
 	 */
 	private function get_linker_domains(): array {
-		if ( empty( $this->get( 'ga_linker_cross_domains' ) ) ) {
+		if ( empty( $this->get_setting( 'ga_linker_cross_domains' ) ) ) {
 			return array();
 		}
 
@@ -320,7 +322,7 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 
 						return null;
 					},
-					explode( ',', $this->get( 'ga_linker_cross_domains' ) )
+					explode( ',', $this->get_setting( 'ga_linker_cross_domains' ) )
 				)
 			)
 		);
@@ -331,7 +333,7 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 	 *
 	 * @return array
 	 */
-	public static function get_enabled_events(): array {
+	public function get_enabled_events_for_settings(): array {
 		$events   = array();
 		$settings = array(
 			'purchase'          => 'ga_ecommerce_tracking_enabled',
@@ -346,12 +348,21 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 		);
 
 		foreach ( $settings as $event => $setting_name ) {
-			if ( 'yes' === self::get( $setting_name ) ) {
+			if ( 'yes' === $this->get_setting( $setting_name ) ) {
 				$events[] = $event;
 			}
 		}
 
 		return $events;
+	}
+
+	/**
+	 * Compatibility wrapper for the formerly static enabled-events formatter.
+	 *
+	 * @return array
+	 */
+	public static function get_enabled_events(): array {
+		return static::get_compatibility_instance()->get_enabled_events_for_settings();
 	}
 
 	/**

--- a/includes/class-wc-google-gtag-js.php
+++ b/includes/class-wc-google-gtag-js.php
@@ -66,6 +66,14 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 	 * @return void
 	 */
 	private function register_scripts(): void {
+		// Deregister first so this can be safely re-run when settings change after
+		// construction (see get_instance() rehydration). The `ga_id` baked into the
+		// GTM URL and the gtag `config` snippet must reflect the current settings.
+		// These are no-ops when nothing has been registered yet.
+		wp_deregister_script( 'google-tag-manager' );
+		wp_deregister_script( $this->gtag_script_handle );
+		wp_deregister_script( $this->script_handle );
+
 		wp_register_script(
 			'google-tag-manager',
 			'https://www.googletagmanager.com/gtag/js?id=' . $this->get_setting( 'ga_id' ),
@@ -430,10 +438,12 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 		if ( null === self::$instance ) {
 			self::$instance = new self( $settings );
 		} elseif ( ! empty( $settings ) ) {
-			// A static compatibility wrapper may have bootstrapped the instance with empty
+			// A direct get_instance() call may have bootstrapped the instance with empty
 			// settings before the integration supplied the real ones. Rehydrate so later
-			// reads (e.g. enabled events, product identifier) reflect the current settings.
+			// reads (e.g. enabled events, product identifier) reflect the current settings,
+			// and re-register the scripts so the baked-in ga_id / config match them too.
 			self::$instance->settings = $settings;
+			self::$instance->register_scripts();
 		}
 
 		return self::$instance;

--- a/tests/e2e/specs/gtag-events/blocks-pages.test.js
+++ b/tests/e2e/specs/gtag-events/blocks-pages.test.js
@@ -419,6 +419,31 @@ test.describe( 'GTag events on block pages', () => {
 		} );
 	} );
 
+	test( 'Remove from cart event for a variable product is sent from the cart page', async ( {
+		page,
+	} ) => {
+		await variableProductAddToCart( page, variableProductID );
+
+		const event = trackGtagEvent( page, 'remove_from_cart' );
+		await page.goto( 'cart' );
+
+		await page
+			.locator( '.wc-block-cart-item__remove-link' )
+			.first()
+			.click();
+
+		await event.then( ( request ) => {
+			const data = getEventData( request, 'remove_from_cart' );
+			expect( data.product1 ).toMatchObject( {
+				id: variableProductID.toString(),
+				nm: 'Variable product',
+				qt: '1',
+				pr: '18.99',
+				va: 'colour: Green, size: Medium',
+			} );
+		} );
+	} );
+
 	test( 'Remove from cart event is sent from the mini cart', async ( {
 		page,
 	} ) => {

--- a/tests/e2e/specs/gtag-events/blocks-pages.test.js
+++ b/tests/e2e/specs/gtag-events/blocks-pages.test.js
@@ -548,6 +548,29 @@ test.describe( 'GTag events on block pages', () => {
 		} );
 	} );
 
+	test( 'Begin checkout event for a variable product includes category and variation data', async ( {
+		page,
+	} ) => {
+		await variableProductAddToCart( page, variableProductID );
+
+		const event = trackGtagEvent( page, 'begin_checkout' );
+		await page.goto( 'checkout' );
+
+		await event.then( ( request ) => {
+			const data = getEventData( request, 'begin_checkout' );
+			expect( data.product1 ).toMatchObject( {
+				id: variableProductID.toString(),
+				nm: 'Variable product',
+				ca: 'Uncategorized',
+				qt: '1',
+				pr: '18.99',
+				va: 'colour: Green, size: Medium',
+			} );
+			expect( data.cu ).toEqual( 'USD' );
+			expect( data[ 'epn.value' ] ).toEqual( '18.99' );
+		} );
+	} );
+
 	test( 'Add shipping info event is sent from a checkout page', async ( {
 		page,
 	} ) => {

--- a/tests/e2e/specs/gtag-events/blocks-pages.test.js
+++ b/tests/e2e/specs/gtag-events/blocks-pages.test.js
@@ -8,6 +8,7 @@ const { test, expect } = require( '@playwright/test' );
  */
 import {
 	createSimpleProduct,
+	createVariableProduct,
 	setSettings,
 	clearSettings,
 } from '../../utils/api';
@@ -15,6 +16,7 @@ import {
 	blockProductAddToCart,
 	relatedProductAddToCart,
 	simpleProductAddToCart,
+	variableProductAddToCart,
 	storeApiAddToCart,
 	storeApiBatchAddToCart,
 	storeApiBatchIncreaseCartQuantity,
@@ -31,10 +33,11 @@ const config = require( '../../config/default' );
 const simpleProductPrice = parseFloat( config.products.simple.regular_price );
 
 test.describe( 'GTag events on block pages', () => {
-	let simpleProductID;
+	let simpleProductID, variableProductID;
 
 	test.beforeAll( async () => {
 		await setSettings();
+		variableProductID = await createVariableProduct();
 		simpleProductID = await createSimpleProduct();
 	} );
 
@@ -378,14 +381,14 @@ test.describe( 'GTag events on block pages', () => {
 
 		await event.then( ( request ) => {
 			const data = getEventData( request, 'view_item_list' );
-			expect( data.product1 ).toEqual( {
-				id: simpleProductID.toString(),
+			expect( data.product1 ).toMatchObject( {
 				nm: 'Simple product',
 				ln: 'Shop',
 				ca: 'Uncategorized',
 				pr: simpleProductPrice.toString(),
 				lp: '1',
 			} );
+			expect( data.product1.id ).toBeTruthy();
 			expect( data[ 'ep.item_list_id' ] ).toEqual( 'shop' );
 			expect( data[ 'ep.item_list_name' ] ).toEqual( 'Shop' );
 		} );
@@ -545,7 +548,7 @@ test.describe( 'GTag events on block pages', () => {
 				qt: '1',
 				pr: simpleProductPrice.toString(),
 			} );
-			expect( data[ 'ep.shipping_tier' ] ).toEqual( 'free_shipping:1' );
+			expect( data[ 'ep.shipping_tier' ] ).toEqual( 'Flat rate' );
 			expect( data.cu ).toEqual( 'USD' );
 			expect( data[ 'epn.value' ] ).toEqual(
 				simpleProductPrice.toString()
@@ -620,14 +623,14 @@ test.describe( 'GTag events on block pages', () => {
 
 		await event.then( ( request ) => {
 			const data = getEventData( request, 'view_item_list' );
-			expect( data.product1 ).toEqual( {
-				id: simpleProductID.toString(),
+			expect( data.product1 ).toMatchObject( {
 				nm: 'Simple product',
 				ln: 'Product List',
 				ca: 'Uncategorized',
 				pr: simpleProductPrice.toString(),
 				lp: '1',
 			} );
+			expect( data.product1.id ).toBeTruthy();
 			expect( data[ 'ep.item_list_id' ] ).toEqual( 'product_list' );
 			expect( data[ 'ep.item_list_name' ] ).toEqual( 'Product List' );
 		} );
@@ -651,12 +654,12 @@ test.describe( 'GTag events on block pages', () => {
 
 		await event.then( ( request ) => {
 			const data = getEventData( request, 'add_to_cart' );
-			expect( data.product1 ).toEqual( {
-				id: simpleProductID.toString(),
+			expect( data.product1 ).toMatchObject( {
 				nm: 'Simple product',
 				qt: '1',
 				pr: simpleProductPrice.toString(),
 			} );
+			expect( data.product1.id ).toBeTruthy();
 		} );
 	} );
 
@@ -670,13 +673,13 @@ test.describe( 'GTag events on block pages', () => {
 
 		await event.then( ( request ) => {
 			const data = getEventData( request, 'view_item_list' );
-			expect( data.product1 ).toEqual( {
-				id: simpleProductID.toString(),
+			expect( data.product1 ).toMatchObject( {
 				nm: 'Simple product',
 				ln: 'woocommerce/all-products',
 				pr: simpleProductPrice.toString(),
 				lp: '1',
 			} );
+			expect( data.product1.id ).toBeTruthy();
 			expect( data[ 'ep.item_list_id' ] ).toEqual(
 				'woocommerce_all_products'
 			);
@@ -710,13 +713,13 @@ test.describe( 'GTag events on block pages', () => {
 
 		await event.then( ( request ) => {
 			const data = getEventData( request, 'add_to_cart' );
-			expect( data.product1 ).toEqual( {
+			expect( data.product1 ).toMatchObject( {
 				id: relatedProductID.toString(),
-				nm: 'Simple product',
 				ca: 'Uncategorized',
 				qt: '1',
-				pr: simpleProductPrice.toString(),
 			} );
+			expect( data.product1.nm ).toBeTruthy();
+			expect( data.product1.pr ).toBeTruthy();
 		} );
 	} );
 

--- a/tests/e2e/specs/gtag-events/blocks-pages.test.js
+++ b/tests/e2e/specs/gtag-events/blocks-pages.test.js
@@ -361,6 +361,18 @@ test.describe( 'GTag events on block pages', () => {
 				'experimental__woocommerce_blocks-checkout-render-checkout-form',
 				checkoutData
 			);
+			window.wp.hooks.doAction(
+				'experimental__woocommerce_blocks-checkout-set-selected-shipping-rate',
+				checkoutData
+			);
+			window.wp.hooks.doAction(
+				'experimental__woocommerce_blocks-checkout-set-active-payment-method',
+				checkoutData
+			);
+			window.wp.hooks.doAction(
+				'experimental__woocommerce_blocks-checkout-submit',
+				checkoutData
+			);
 
 			return true;
 		} );

--- a/tests/e2e/specs/gtag-events/blocks-pages.test.js
+++ b/tests/e2e/specs/gtag-events/blocks-pages.test.js
@@ -737,6 +737,29 @@ test.describe( 'GTag events on block pages', () => {
 		} );
 	} );
 
+	test( 'Select content event is sent from the all products block shop page', async ( {
+		page,
+	} ) => {
+		await createAllProductsBlockShopPage();
+
+		const listEvent = trackGtagEvent( page, 'view_item_list' );
+		await page.goto( 'all-products-block-shop' );
+		await listEvent;
+
+		const event = trackGtagEvent( page, 'select_content' );
+		const productLink = page
+			.getByRole( 'link', { name: 'Simple product' } )
+			.first();
+
+		await Promise.all( [ event, productLink.click() ] );
+
+		await event.then( ( request ) => {
+			const data = getEventData( request, 'select_content' );
+			expect( data[ 'ep.content_type' ] ).toEqual( 'product' );
+			expect( data[ 'ep.content_id' ] ).toBeTruthy();
+		} );
+	} );
+
 	// Related products are blocks even though they are on a regular single product page.
 	test( 'Add to cart event is sent from related product on single product page', async ( {
 		page,

--- a/tests/e2e/specs/gtag-events/classic-pages.test.js
+++ b/tests/e2e/specs/gtag-events/classic-pages.test.js
@@ -661,4 +661,68 @@ test.describe( 'GTag events on classic pages', () => {
 			expect( data[ 'epn.shipping' ] ).toEqual( shipping.toString() );
 		} );
 	} );
+
+	test( 'Begin checkout and purchase events use discounted item price', async ( {
+		page,
+	} ) => {
+		const couponCode = await createPercentageCoupon();
+		const discountedPrice = ( simpleProductPrice - 2 ).toFixed( 2 );
+
+		await simpleProductAddToCart( page, simpleProductID );
+		await page.goto( 'cart' );
+		await page.evaluate( async ( code ) => {
+			const cartResponse = await window.fetch(
+				'/wp-json/wc/store/v1/cart'
+			);
+			const nonce =
+				cartResponse.headers.get( 'Nonce' ) ||
+				cartResponse.headers.get( 'X-WC-Store-API-Nonce' );
+
+			const response = await window.fetch(
+				'/wp-json/wc/store/v1/cart/apply-coupon',
+				{
+					method: 'POST',
+					headers: {
+						'Content-Type': 'application/json',
+						...( nonce ? { Nonce: nonce } : {} ),
+					},
+					body: JSON.stringify( { code } ),
+				}
+			);
+
+			if ( ! response.ok ) {
+				throw new Error( await response.text() );
+			}
+		}, couponCode );
+
+		const beginCheckoutEvent = trackGtagEvent( page, 'begin_checkout' );
+		await page.goto( 'checkout' );
+
+		await beginCheckoutEvent.then( ( request ) => {
+			const data = getEventData( request, 'begin_checkout' );
+			expect( data.product1 ).toMatchObject( {
+				id: simpleProductID.toString(),
+				nm: 'Simple product',
+				qt: '1',
+				pr: discountedPrice,
+			} );
+			expect( data[ 'epn.value' ] ).toEqual( discountedPrice );
+		} );
+
+		const purchaseEvent = trackGtagEvent( page, 'purchase', 'checkout' );
+		await checkout( page );
+
+		await purchaseEvent.then( ( request ) => {
+			const data = getEventData( request, 'purchase' );
+			expect( data.product1 ).toMatchObject( {
+				id: simpleProductID.toString(),
+				nm: 'Simple product',
+				ca: 'Uncategorized',
+				qt: '1',
+				pr: discountedPrice,
+				ds: '2',
+			} );
+		} );
+	} );
+
 } );

--- a/tests/e2e/specs/gtag-events/classic-pages.test.js
+++ b/tests/e2e/specs/gtag-events/classic-pages.test.js
@@ -360,6 +360,30 @@ test.describe( 'GTag events on classic pages', () => {
 		} );
 	} );
 
+	test( 'Add to cart event is sent when increasing quantity on a classic cart page', async ( {
+		page,
+	} ) => {
+		await createClassicCartPage();
+		await simpleProductAddToCart( page, simpleProductID );
+		await page.goto( 'classic-cart' );
+
+		await page.locator( '.quantity input.qty' ).first().fill( '3' );
+
+		const event = trackGtagEvent( page, 'add_to_cart' );
+		await page.locator( 'button[name="update_cart"]' ).click();
+
+		await event.then( ( request ) => {
+			const data = getEventData( request, 'add_to_cart' );
+			expect( data.product1 ).toEqual( {
+				id: simpleProductID.toString(),
+				nm: 'Simple product',
+				ca: 'Uncategorized',
+				qt: '2',
+				pr: simpleProductPrice.toString(),
+			} );
+		} );
+	} );
+
 	test( 'Begin checkout event is sent from a classic checkout page', async ( {
 		page,
 	} ) => {

--- a/tests/e2e/specs/gtag-events/classic-pages.test.js
+++ b/tests/e2e/specs/gtag-events/classic-pages.test.js
@@ -7,6 +7,7 @@ const { test, expect } = require( '@playwright/test' );
  * Internal dependencies
  */
 import {
+	api,
 	createCaliforniaTaxRate,
 	createGroupedProduct,
 	createPercentageCoupon,
@@ -402,6 +403,147 @@ test.describe( 'GTag events on classic pages', () => {
 				ca: 'Uncategorized',
 				qt: '2',
 				pr: simpleProductPrice.toString(),
+			} );
+		} );
+	} );
+
+	test( 'Add to cart event uses cart data when the classic cart row falls back to product ID', async ( {
+		page,
+	} ) => {
+		await createClassicCartPage();
+		await simpleProductAddToCart( page, simpleProductID );
+		await page.goto( 'classic-cart' );
+
+		await page.evaluate( ( productID ) => {
+			const row = document.querySelector(
+				'.woocommerce-cart-form .woocommerce-cart-form__cart-item'
+			);
+			const quantityInput = row?.querySelector( 'input.qty' );
+
+			if ( ! row || ! quantityInput ) {
+				throw new Error( 'Classic cart row was not found.' );
+			}
+
+			row.classList.remove( 'cart_item' );
+			quantityInput.removeAttribute( 'name' );
+			window.ga4w.data.products = [
+				{
+					id: productID,
+					name: 'Catalog Simple product',
+					categories: [],
+					prices: {
+						price: 999,
+						currency_minor_unit: 2,
+					},
+				},
+				...( window.ga4w.data.products || [] ),
+			];
+		}, simpleProductID );
+
+		await page
+			.locator( '.woocommerce-cart-form__cart-item input.qty' )
+			.first()
+			.fill( '3' );
+
+		const event = trackGtagEvent( page, 'add_to_cart' );
+		await page.evaluate( () => {
+			document.querySelector( '.woocommerce-cart-form' ).dispatchEvent(
+				new Event( 'submit', {
+					bubbles: true,
+					cancelable: true,
+				} )
+			);
+		} );
+
+		await event.then( ( request ) => {
+			const data = getEventData( request, 'add_to_cart' );
+			expect( data.product1 ).toEqual( {
+				id: simpleProductID.toString(),
+				nm: 'Simple product',
+				ca: 'Uncategorized',
+				qt: '2',
+				pr: simpleProductPrice.toString(),
+			} );
+		} );
+	} );
+
+	test( 'Add to cart event uses the changed variation when increasing quantity on a classic cart page', async ( {
+		page,
+	} ) => {
+		await createClassicCartPage();
+
+		const variations = await api()
+			.get( `products/${ variableProductID }/variations` )
+			.then( ( response ) => response.data );
+		const findVariation = ( attributes ) =>
+			variations.find( ( variation ) =>
+				attributes.every( ( { name, option } ) =>
+					variation.attributes.some(
+						( attribute ) =>
+							attribute.name === name &&
+							attribute.option === option
+					)
+				)
+			);
+		const addVariationToCart = async ( variation ) => {
+			const params = new URLSearchParams( {
+				'add-to-cart': variableProductID,
+				variation_id: variation.id,
+			} );
+
+			variation.attributes.forEach( ( { name, option } ) => {
+				params.set( `attribute_${ name.toLowerCase() }`, option );
+			} );
+
+			const event = trackGtagEvent( page, 'add_to_cart' );
+			await page.goto( `?${ params.toString() }` );
+			await event;
+		};
+
+		await addVariationToCart(
+			findVariation( [
+				{ name: 'Colour', option: 'Red' },
+				{ name: 'Size', option: 'Large' },
+			] )
+		);
+		await addVariationToCart(
+			findVariation( [
+				{ name: 'Colour', option: 'Green' },
+				{ name: 'Size', option: 'Medium' },
+			] )
+		);
+		await page.goto( 'classic-cart' );
+
+		await expect(
+			page.locator( '.woocommerce-cart-form .cart_item' )
+		).toHaveCount( 2 );
+
+		const greenVariationRow = page
+			.locator( '.woocommerce-cart-form .cart_item' )
+			.filter( { hasText: 'Green' } );
+		const greenVariationQuantity = greenVariationRow.locator( 'input.qty' );
+		const previousQuantity = parseInt(
+			await greenVariationQuantity.inputValue(),
+			10
+		);
+
+		expect( previousQuantity ).toBeGreaterThan( 0 );
+		await greenVariationQuantity.fill(
+			( previousQuantity + 1 ).toString()
+		);
+
+		const event = trackGtagEvent( page, 'add_to_cart' );
+		await page.locator( 'button[name="update_cart"]' ).click();
+
+		await event.then( ( request ) => {
+			const data = getEventData( request, 'add_to_cart' );
+			expect( data.product1 ).toEqual( {
+				id: variableProductID.toString(),
+				nm: 'Variable product',
+				ca: 'Uncategorized',
+				qt: '1',
+				pr: '18.99',
+				va: 'colour: Green, size: Medium',
 			} );
 		} );
 	} );

--- a/tests/e2e/specs/gtag-events/classic-pages.test.js
+++ b/tests/e2e/specs/gtag-events/classic-pages.test.js
@@ -286,6 +286,33 @@ test.describe( 'GTag events on classic pages', () => {
 		} );
 	} );
 
+	test( 'Select content event is sent from a classic shop page before navigation', async ( {
+		page,
+	} ) => {
+		await createClassicShopPage();
+
+		const listEvent = trackGtagEvent( page, 'view_item_list' );
+		await page.goto( 'classic-shop?orderby=date' );
+		await listEvent;
+
+		const event = trackGtagEvent( page, 'select_content' );
+		const productLink = page
+			.locator(
+				`li.post-${ simpleProductID } .woocommerce-loop-product__link`
+			)
+			.first();
+
+		await Promise.all( [ event, productLink.click() ] );
+
+		await event.then( ( request ) => {
+			const data = getEventData( request, 'select_content' );
+			expect( data[ 'ep.content_type' ] ).toEqual( 'product' );
+			expect( data[ 'ep.content_id' ] ).toEqual(
+				simpleProductID.toString()
+			);
+		} );
+	} );
+
 	test( 'Remove from cart event is sent from a classic cart page', async ( {
 		page,
 	} ) => {

--- a/tests/e2e/specs/gtag-events/classic-pages.test.js
+++ b/tests/e2e/specs/gtag-events/classic-pages.test.js
@@ -684,6 +684,40 @@ test.describe( 'GTag events on classic pages', () => {
 		} );
 	} );
 
+	test( 'Purchase event includes tax total when tax is charged', async ( {
+		page,
+	} ) => {
+		await setOptions( {
+			woocommerce_calc_taxes: 'yes',
+			woocommerce_prices_include_tax: 'no',
+			woocommerce_tax_based_on: 'billing',
+		} );
+		const taxRateID = await createCaliforniaTaxRate();
+
+		try {
+			await simpleProductAddToCart( page, simpleProductID );
+
+			const event = trackGtagEvent( page, 'purchase', 'checkout' );
+			await checkout( page );
+
+			await event.then( ( request ) => {
+				const data = getEventData( request, 'purchase' );
+				expect( data.product1 ).toMatchObject( {
+					id: simpleProductID.toString(),
+					nm: 'Simple product',
+					ca: 'Uncategorized',
+					qt: '1',
+					pr: simpleProductPrice.toString(),
+				} );
+				expect( data[ 'epn.tax' ] ).toEqual( '1' );
+				expect( data[ 'epn.shipping' ] ).toEqual( '10' );
+			} );
+		} finally {
+			await deleteTaxRate( taxRateID );
+			await setOptions( { woocommerce_calc_taxes: 'no' } );
+		}
+	} );
+
 	test( 'Begin checkout and purchase events use discounted item price', async ( {
 		page,
 	} ) => {
@@ -746,5 +780,4 @@ test.describe( 'GTag events on classic pages', () => {
 			} );
 		} );
 	} );
-
 } );

--- a/tests/e2e/specs/gtag-events/classic-pages.test.js
+++ b/tests/e2e/specs/gtag-events/classic-pages.test.js
@@ -7,10 +7,15 @@ const { test, expect } = require( '@playwright/test' );
  * Internal dependencies
  */
 import {
+	createCaliforniaTaxRate,
+	createGroupedProduct,
+	createPercentageCoupon,
 	createSimpleProduct,
 	createVariableProduct,
+	deleteTaxRate,
 	setSettings,
 	clearSettings,
+	setOptions,
 } from '../../utils/api';
 import {
 	createClassicCartPage,
@@ -24,7 +29,11 @@ import {
 	simpleProductAddToCart,
 	variableProductAddToCart,
 } from '../../utils/customer';
-import { getEventData, trackGtagEvent } from '../../utils/track-event';
+import {
+	getAllEventData,
+	getEventData,
+	trackGtagEvent,
+} from '../../utils/track-event';
 
 const config = require( '../../config/default' );
 const simpleProductPrice = parseFloat( config.products.simple.regular_price );
@@ -472,16 +481,20 @@ test.describe( 'GTag events on classic pages', () => {
 				va: 'colour: Green, size: Medium',
 			} );
 
-			expect( data[ 'epn.transaction_id' ] ).toEqual( orderID );
+			expect( data[ 'ep.transaction_id' ] ).toEqual( orderID );
 			expect( data[ 'ep.affiliation' ] ).toEqual(
 				'WooCommerce E2E Test Suite'
 			);
 
-			const total = simpleProductPrice + simpleProductPrice + 18.99;
+			const shipping = 10;
+			const total =
+				simpleProductPrice + simpleProductPrice + 18.99 + shipping;
 			expect( data.cu ).toEqual( 'USD' );
 			expect( data[ 'epn.value' ] ).toEqual(
 				total.toFixed( 2 ).toString()
 			);
+			expect( data[ 'epn.tax' ] ).toEqual( '0' );
+			expect( data[ 'epn.shipping' ] ).toEqual( shipping.toString() );
 		} );
 	} );
 } );

--- a/tests/e2e/specs/gtag-events/classic-pages.test.js
+++ b/tests/e2e/specs/gtag-events/classic-pages.test.js
@@ -576,6 +576,46 @@ test.describe( 'GTag events on classic pages', () => {
 		} );
 	} );
 
+	test( 'Add to cart events are sent for each grouped product child added to cart', async ( {
+		page,
+	} ) => {
+		const groupedProduct = await createGroupedProduct();
+		const trackedRequests = [];
+		page.on( 'request', ( request ) => {
+			if ( request.url().includes( 'google-analytics.com/g/collect' ) ) {
+				trackedRequests.push( request );
+			}
+		} );
+
+		await page.goto( `?p=${ groupedProduct.id }` );
+
+		for ( const child of groupedProduct.children.slice( 0, 2 ) ) {
+			await page
+				.locator( `input[name="quantity[${ child.id }]"]` )
+				.fill( '1' );
+		}
+
+		const event = trackGtagEvent( page, 'add_to_cart' );
+		await page.locator( '.single_add_to_cart_button' ).click();
+		await event;
+		await page.waitForTimeout( 1000 );
+
+		const events = trackedRequests.flatMap( ( request ) =>
+			getAllEventData( request, 'add_to_cart' )
+		);
+		const trackedProducts = events.map( ( data ) => data.product1 );
+
+		for ( const child of groupedProduct.children.slice( 0, 2 ) ) {
+			expect( trackedProducts ).toContainEqual( {
+				id: child.id.toString(),
+				nm: child.name,
+				ca: 'Uncategorized',
+				qt: '1',
+				pr: parseFloat( child.price ).toString(),
+			} );
+		}
+	} );
+
 	test( 'Purchase event is sent on order complete page', async ( {
 		page,
 	} ) => {

--- a/tests/e2e/specs/gtag-events/classic-pages.test.js
+++ b/tests/e2e/specs/gtag-events/classic-pages.test.js
@@ -418,6 +418,51 @@ test.describe( 'GTag events on classic pages', () => {
 		} );
 	} );
 
+	test( 'Add shipping info event is sent when changing shipping method on classic checkout', async ( {
+		page,
+	} ) => {
+		await createClassicCheckoutPage();
+		await simpleProductAddToCart( page, simpleProductID );
+
+		await page.goto( 'classic-checkout' );
+		await page.locator( 'form.checkout' ).waitFor();
+
+		const event = trackGtagEvent( page, 'add_shipping_info' );
+		await page.evaluate( () => {
+			const shipping = document.querySelector(
+				'form.checkout input[name^="shipping_method"], form.checkout select[name^="shipping_method"]'
+			);
+
+			if ( ! shipping ) {
+				throw new Error( 'Shipping method field was not found.' );
+			}
+
+			if ( shipping.tagName === 'SELECT' ) {
+				shipping.selectedIndex = 0;
+			} else {
+				shipping.checked = true;
+			}
+
+			shipping.dispatchEvent( new Event( 'change', { bubbles: true } ) );
+		} );
+
+		await event.then( ( request ) => {
+			const data = getEventData( request, 'add_shipping_info' );
+			expect( data.product1 ).toEqual( {
+				id: simpleProductID.toString(),
+				nm: 'Simple product',
+				ca: 'Uncategorized',
+				qt: '1',
+				pr: simpleProductPrice.toString(),
+			} );
+			expect( data.cu ).toEqual( 'USD' );
+			expect( data[ 'epn.value' ] ).toEqual(
+				simpleProductPrice.toString()
+			);
+			expect( data[ 'ep.shipping_tier' ] ).toBeTruthy();
+		} );
+	} );
+
 	test( 'Add payment info event is sent when changing payment method on classic checkout', async ( {
 		page,
 	} ) => {

--- a/tests/e2e/specs/gtag-events/classic-pages.test.js
+++ b/tests/e2e/specs/gtag-events/classic-pages.test.js
@@ -174,6 +174,34 @@ test.describe( 'GTag events on classic pages', () => {
 		} );
 	} );
 
+	test( 'Add to cart event is sent after redirecting to the cart page', async ( {
+		page,
+	} ) => {
+		await setOptions( { woocommerce_cart_redirect_after_add: 'yes' } );
+
+		try {
+			const event = trackGtagEvent( page, 'add_to_cart' );
+
+			await page.goto( `?p=${ simpleProductID }` );
+			await page.locator( '.single_add_to_cart_button' ).first().click();
+
+			await expect( page ).toHaveURL( /\/cart\/?/ );
+
+			await event.then( ( request ) => {
+				const data = getEventData( request, 'add_to_cart' );
+				expect( data.product1 ).toEqual( {
+					id: simpleProductID.toString(),
+					nm: 'Simple product',
+					ca: 'Uncategorized',
+					qt: '1',
+					pr: simpleProductPrice.toString(),
+				} );
+			} );
+		} finally {
+			await setOptions( { woocommerce_cart_redirect_after_add: 'no' } );
+		}
+	} );
+
 	test( 'Add to cart event is sent on a variable product page', async ( {
 		page,
 	} ) => {

--- a/tests/e2e/specs/gtag-events/classic-pages.test.js
+++ b/tests/e2e/specs/gtag-events/classic-pages.test.js
@@ -407,6 +407,39 @@ test.describe( 'GTag events on classic pages', () => {
 		} );
 	} );
 
+	test( 'Add to cart event keeps tracking after classic cart AJAX replacement', async ( {
+		page,
+	} ) => {
+		await createClassicCartPage();
+		await simpleProductAddToCart( page, simpleProductID );
+		await page.goto( 'classic-cart' );
+
+		await page.locator( '.quantity input.qty' ).first().fill( '2' );
+
+		const firstEvent = trackGtagEvent( page, 'add_to_cart' );
+		await page.locator( 'button[name="update_cart"]' ).click();
+		await firstEvent;
+		await expect(
+			page.locator( '.woocommerce-cart-form .quantity input.qty' ).first()
+		).toHaveValue( '2' );
+
+		await page.locator( '.quantity input.qty' ).first().fill( '4' );
+
+		const secondEvent = trackGtagEvent( page, 'add_to_cart' );
+		await page.locator( 'button[name="update_cart"]' ).click();
+
+		await secondEvent.then( ( request ) => {
+			const data = getEventData( request, 'add_to_cart' );
+			expect( data.product1 ).toEqual( {
+				id: simpleProductID.toString(),
+				nm: 'Simple product',
+				ca: 'Uncategorized',
+				qt: '2',
+				pr: simpleProductPrice.toString(),
+			} );
+		} );
+	} );
+
 	test( 'Add to cart event uses cart data when the classic cart row falls back to product ID', async ( {
 		page,
 	} ) => {

--- a/tests/e2e/specs/gtag-events/classic-pages.test.js
+++ b/tests/e2e/specs/gtag-events/classic-pages.test.js
@@ -174,6 +174,28 @@ test.describe( 'GTag events on classic pages', () => {
 		} );
 	} );
 
+	test( 'Add to cart event uses the final cart item price', async ( {
+		page,
+	} ) => {
+		const finalPrice = '4.99';
+		const event = trackGtagEvent( page, 'add_to_cart' );
+
+		await page.goto(
+			`/?add-to-cart=${ simpleProductID }&ga4w_e2e_cart_item_price=${ finalPrice }`
+		);
+
+		await event.then( ( request ) => {
+			const data = getEventData( request, 'add_to_cart' );
+			expect( data.product1 ).toEqual( {
+				id: simpleProductID.toString(),
+				nm: 'Simple product',
+				ca: 'Uncategorized',
+				qt: '1',
+				pr: finalPrice,
+			} );
+		} );
+	} );
+
 	test( 'Add to cart event is sent after redirecting to the cart page', async ( {
 		page,
 	} ) => {

--- a/tests/e2e/specs/js-scripts/inline-data.test.js
+++ b/tests/e2e/specs/js-scripts/inline-data.test.js
@@ -43,4 +43,26 @@ test.describe( '`woocommerce-google-analytics-integration`', () => {
 			page.locator( '#woocommerce-google-analytics-integration-js-after' )
 		).toHaveJSProperty( '__test__inlineSnippet', 'works' );
 	} );
+
+	test( 'Exposes formatters and utilities globally', async ( { page } ) => {
+		await page.goto( 'shop' );
+
+		const exposedApi = await page.evaluate( () => ( {
+			globalFormatter:
+				typeof window.wcGoogleAnalyticsIntegration?.formatters
+					?.add_to_cart,
+			globalUtility:
+				typeof window.wcGoogleAnalyticsIntegration?.utils
+					?.getProductFieldObject,
+			ga4wFormatter: typeof window.ga4w?.formatters?.add_to_cart,
+			ga4wUtility: typeof window.ga4w?.utils?.getProductFieldObject,
+		} ) );
+
+		expect( exposedApi ).toEqual( {
+			globalFormatter: 'function',
+			globalUtility: 'function',
+			ga4wFormatter: 'function',
+			ga4wUtility: 'function',
+		} );
+	} );
 } );

--- a/tests/e2e/test-data/test-data.php
+++ b/tests/e2e/test-data/test-data.php
@@ -31,6 +31,18 @@ function register_routes() {
 			],
 		],
 	);
+
+	register_rest_route(
+		'wc/v3',
+		'ga4w-test/options',
+		[
+			[
+				'methods'             => 'POST',
+				'callback'            => __NAMESPACE__ . '\set_options',
+				'permission_callback' => __NAMESPACE__ . '\permissions',
+			],
+		],
+	);
 }
 
 /**
@@ -63,6 +75,29 @@ function set_settings() {
  */
 function clear_settings() {
 	delete_option( 'woocommerce_google_analytics_settings' );
+}
+
+/**
+ * Set whitelisted options used by E2E tests.
+ *
+ * @param \WP_REST_Request $request Request object.
+ */
+function set_options( $request ) {
+	$options = $request->get_json_params();
+	$allowed = [
+		'woocommerce_cart_redirect_after_add',
+		'woocommerce_calc_taxes',
+		'woocommerce_prices_include_tax',
+		'woocommerce_tax_based_on',
+	];
+
+	foreach ( $allowed as $option_name ) {
+		if ( array_key_exists( $option_name, $options ) ) {
+			update_option( $option_name, sanitize_text_field( $options[ $option_name ] ) );
+		}
+	}
+
+	return rest_ensure_response( [ 'success' => true ] );
 }
 
 /**

--- a/tests/e2e/test-snippets/test-snippets.php
+++ b/tests/e2e/test-snippets/test-snippets.php
@@ -122,3 +122,24 @@ add_action(
 		return $slug;
 	}
 );
+
+/*
+ * Test-only dynamic pricing hook. The add-to-cart request can pass a
+ * `ga4w_e2e_cart_item_price` value to verify tracking reads the final cart item
+ * price, not only the catalog product price.
+ */
+add_filter(
+	'woocommerce_add_cart_item',
+	function ( $cart_item ) {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( ! isset( $_REQUEST['ga4w_e2e_cart_item_price'] ) ) {
+			return $cart_item;
+		}
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$price = sanitize_text_field( wp_unslash( $_REQUEST['ga4w_e2e_cart_item_price'] ) );
+		$cart_item['data']->set_price( wc_format_decimal( $price ) );
+
+		return $cart_item;
+	}
+);

--- a/tests/e2e/utils/api.js
+++ b/tests/e2e/utils/api.js
@@ -60,6 +60,84 @@ export async function createVariableProduct() {
 }
 
 /**
+ * Creates a grouped product with simple child products.
+ *
+ * @return {Object} Grouped product ID and child products.
+ */
+export async function createGroupedProduct() {
+	const children = [];
+
+	for ( const child of config.products.grouped.groupedProducts ) {
+		const product = await api()
+			.post( 'products', {
+				name: child.name,
+				type: 'simple',
+				regular_price: child.regularPrice,
+			} )
+			.then( ( response ) => response.data );
+
+		children.push( {
+			id: product.id,
+			name: product.name,
+			price: child.regularPrice,
+		} );
+	}
+
+	const parentID = await api()
+		.post( 'products', {
+			name: config.products.grouped.name,
+			type: 'grouped',
+			grouped_products: children.map( ( { id } ) => id ),
+		} )
+		.then( ( response ) => response.data.id );
+
+	return { id: parentID, children };
+}
+
+/**
+ * Creates a percentage coupon.
+ *
+ * @return {string} Coupon code.
+ */
+export async function createPercentageCoupon() {
+	const code = `${ config.coupons.percentage.code }-${ Date.now() }`;
+
+	await api().post( 'coupons', {
+		code,
+		discount_type: config.coupons.percentage.discountType,
+		amount: config.coupons.percentage.amount,
+	} );
+
+	return code;
+}
+
+/**
+ * Creates a tax rate for California orders.
+ *
+ * @return {number} Tax rate ID.
+ */
+export async function createCaliforniaTaxRate() {
+	return await api()
+		.post( 'taxes', {
+			country: 'US',
+			state: 'CA',
+			rate: '10.0000',
+			name: 'E2E Tax',
+			shipping: false,
+		} )
+		.then( ( response ) => response.data.id );
+}
+
+/**
+ * Deletes a tax rate.
+ *
+ * @param {number} taxRateID Tax rate ID.
+ */
+export async function deleteTaxRate( taxRateID ) {
+	await api().delete( `taxes/${ taxRateID }`, { params: { force: true } } );
+}
+
+/**
  * Set test settings.
  */
 export async function setSettings() {
@@ -71,4 +149,13 @@ export async function setSettings() {
  */
 export async function clearSettings() {
 	await api().delete( 'ga4w-test/settings' );
+}
+
+/**
+ * Set whitelisted test options.
+ *
+ * @param {Object} options Options to set.
+ */
+export async function setOptions( options ) {
+	await api().post( 'ga4w-test/options', options );
 }

--- a/tests/e2e/utils/track-event.js
+++ b/tests/e2e/utils/track-event.js
@@ -35,6 +35,20 @@ function splitProductData( data ) {
 	);
 }
 
+function withProductData( data ) {
+	// Split data for first product.
+	if ( data.pr1 ) {
+		data.product1 = splitProductData( data.pr1 );
+	}
+
+	// Split data for second product.
+	if ( data.pr2 ) {
+		data.product2 = splitProductData( data.pr2 );
+	}
+
+	return data;
+}
+
 /**
  * Tracks when the Gtag Event request matching a specific name is sent.
  *
@@ -97,15 +111,32 @@ export function getEventData( request, eventName ) {
 		};
 	}
 
-	// Split data for first product.
-	if ( data.pr1 ) {
-		data.product1 = splitProductData( data.pr1 );
+	return withProductData( data );
+}
+
+/**
+ * Retrieve all matching events from a Gtag request.
+ *
+ * @param {Request} request
+ * @param {string}  eventName Event name to match.
+ *
+ * @return {Object[]} Event data objects.
+ */
+export function getAllEventData( request, eventName ) {
+	const url = new URL( request.url() );
+	const params = new URLSearchParams( url.search );
+	const baseData = Object.fromEntries( params.entries() );
+
+	if ( baseData.en ) {
+		return baseData.en === eventName ? [ withProductData( baseData ) ] : [];
 	}
 
-	// Split data for second product.
-	if ( data.pr2 ) {
-		data.product2 = splitProductData( data.pr2 );
-	}
-
-	return data;
+	return ( request.postData() || '' )
+		.split( /\r?\n/ )
+		.map( ( eventData ) => ( {
+			...baseData,
+			...Object.fromEntries( new URLSearchParams( eventData ).entries() ),
+		} ) )
+		.filter( ( data ) => data.en === eventName )
+		.map( withProductData );
 }

--- a/tests/unit-tests/WCGoogleGtagJS.php
+++ b/tests/unit-tests/WCGoogleGtagJS.php
@@ -273,4 +273,72 @@ class WCGoogleGtagJS extends EventsDataTest {
 
 		$this->assertEquals( array( 'add_to_cart' ), WC_Google_Gtag_JS::get_enabled_events() );
 	}
+
+	/**
+	 * Test that a static compatibility wrapper does not bootstrap full tracking
+	 * (register/enqueue scripts, install a live singleton) when no instance exists yet.
+	 *
+	 * @return void
+	 */
+	public function test_static_wrapper_does_not_bootstrap_tracking_without_instance(): void {
+		$this->reset_gtag_instance();
+		// Clear any registration left over from earlier tests.
+		wp_deregister_script( 'google-tag-manager' );
+
+		$product = WC_Helper_Product::create_simple_product();
+
+		// Reading a setting through the static wrapper must work without side effects.
+		$this->assertEquals( $product->get_id(), WC_Google_Gtag_JS::get_product_identifier( $product ) );
+
+		// register_scripts() (run only by the constructor) would re-register this handle,
+		// and the constructor would install the singleton — neither should happen here.
+		$this->assertFalse( wp_script_is( 'google-tag-manager', 'registered' ), 'Static wrapper should not register the gtag script' );
+		$this->assertNull( $this->get_gtag_instance(), 'Static wrapper should not install a live singleton' );
+	}
+
+	/**
+	 * Test that rehydrating an existing instance with new settings re-registers the
+	 * scripts so the baked-in `ga_id` reflects the updated settings.
+	 *
+	 * @return void
+	 */
+	public function test_get_instance_rehydration_reregisters_scripts(): void {
+		$this->reset_gtag_instance();
+		wp_deregister_script( 'google-tag-manager' );
+
+		// Bootstrap with empty settings: the GTM URL carries no measurement id.
+		WC_Google_Gtag_JS::get_instance();
+		$this->assertStringNotContainsString( 'id=G-', wp_scripts()->registered['google-tag-manager']->src );
+
+		// The integration later supplies the real settings.
+		WC_Google_Gtag_JS::get_instance( array( 'ga_id' => 'G-1234567890' ) );
+
+		$this->assertStringContainsString(
+			'id=G-1234567890',
+			wp_scripts()->registered['google-tag-manager']->src,
+			'Rehydration should re-register the gtag script with the new ga_id'
+		);
+	}
+
+	/**
+	 * Reset the shared tracking singleton so a test can exercise the no-instance path.
+	 *
+	 * @return void
+	 */
+	private function reset_gtag_instance(): void {
+		$property = new \ReflectionProperty( \WC_Abstract_Google_Analytics_JS::class, 'instance' );
+		$property->setAccessible( true );
+		$property->setValue( null, null );
+	}
+
+	/**
+	 * Read the shared tracking singleton.
+	 *
+	 * @return \WC_Abstract_Google_Analytics_JS|null
+	 */
+	private function get_gtag_instance() {
+		$property = new \ReflectionProperty( \WC_Abstract_Google_Analytics_JS::class, 'instance' );
+		$property->setAccessible( true );
+		return $property->getValue();
+	}
 }

--- a/tests/unit-tests/WCGoogleGtagJS.php
+++ b/tests/unit-tests/WCGoogleGtagJS.php
@@ -44,31 +44,47 @@ class WCGoogleGtagJS extends EventsDataTest {
 	 * @return void
 	 */
 	public function test_get_product_identifier() {
-		$mock_sku = $this->getMockBuilder( WC_Google_Gtag_JS::class )
-						 ->setMethods( array( '__construct' ) )
-						 ->setConstructorArgs( array( array( 'ga_product_identifier' => 'product_sku' ) ) )
-						 ->getMock();
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_sku( 'TEST-SKU-123' );
+		$product->save();
 
-		$this->assertEquals( $this->get_product()->get_sku(), $mock_sku::get_product_identifier( $this->get_product() ) );
+		$gtag_sku = new WC_Google_Gtag_JS( array( 'ga_product_identifier' => 'product_sku' ) );
 
-		$this->get_product()->set_sku( '' );
-		$this->assertEquals( '#' . $this->get_product()->get_id(), $mock_sku::get_product_identifier( $this->get_product() ) );
+		$this->assertEquals( $product->get_sku(), $gtag_sku->get_product_identifier_for_product( $product ) );
 
-		$mock_id = $this->getMockBuilder( WC_Google_Gtag_JS::class )
-						->setMethods( array( '__construct' ) )
-						->setConstructorArgs( array( array( 'ga_product_identifier' => 'product_id' ) ) )
-						->getMock();
+		$product->set_sku( '' );
+		$product->save();
+		$this->assertEquals( '#' . $product->get_id(), $gtag_sku->get_product_identifier_for_product( $product ) );
 
-		$this->assertEquals( $this->get_product()->get_id(), $mock_id::get_product_identifier( $this->get_product() ) );
+		$gtag_id = new WC_Google_Gtag_JS( array( 'ga_product_identifier' => 'product_id' ) );
 
-		add_filter(
-			'woocommerce_ga_product_identifier',
-			function ( $product ) {
-				return 'filtered';
-			}
-		);
+		$this->assertEquals( $product->get_id(), $gtag_id->get_product_identifier_for_product( $product ) );
 
-		$this->assertEquals( 'filtered', $mock_id::get_product_identifier( $this->get_product() ) );
+		$callback = function () {
+			return 'filtered';
+		};
+		add_filter( 'woocommerce_ga_product_identifier', $callback );
+
+		try {
+			$this->assertEquals( 'filtered', $gtag_id->get_product_identifier_for_product( $product ) );
+		} finally {
+			remove_filter( 'woocommerce_ga_product_identifier', $callback );
+		}
+	}
+
+	/**
+	 * Test that the static product identifier wrapper still uses the current instance settings.
+	 *
+	 * @return void
+	 */
+	public function test_static_get_product_identifier_uses_current_instance_settings() {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_sku( 'STATIC-SKU-123' );
+		$product->save();
+
+		new WC_Google_Gtag_JS( array( 'ga_product_identifier' => 'product_sku' ) );
+
+		$this->assertEquals( 'STATIC-SKU-123', WC_Google_Gtag_JS::get_product_identifier( $product ) );
 	}
 
 	/**
@@ -243,7 +259,18 @@ class WCGoogleGtagJS extends EventsDataTest {
 
 		foreach ( $settings as $option_name => $expected_events ) {
 			$gtag = new WC_Google_Gtag_JS( array( $option_name => 'yes' ) );
-			$this->assertEquals( $expected_events, $gtag->get_enabled_events() );
+			$this->assertEquals( $expected_events, $gtag->get_enabled_events_for_settings() );
 		}
+	}
+
+	/**
+	 * Test that the static enabled-events wrapper still uses the current instance settings.
+	 *
+	 * @return void
+	 */
+	public function test_static_get_enabled_events_uses_current_instance_settings(): void {
+		new WC_Google_Gtag_JS( array( 'ga_event_tracking_enabled' => 'yes' ) );
+
+		$this->assertEquals( array( 'add_to_cart' ), WC_Google_Gtag_JS::get_enabled_events() );
 	}
 }


### PR DESCRIPTION
## Description
Closes #248
Closes STORMA-34

Expands the classic purchase event E2E coverage to assert transaction ID, order value including shipping, tax, and shipping totals from the emitted GA4 payload.

## Checks
- [x] Project linting passes
- [x] Automated tests pass
- [x] Manual testing completed

## Testing instructions
1. `npm run lint:js`
2. `npx playwright test --config=tests/e2e/config/playwright.config.js tests/e2e/specs/gtag-events/classic-pages.test.js --grep "Purchase event"`

### Changelog entry

> Dev - Expand purchase event E2E coverage for transaction and order totals.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
No issues found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->