### PR TITLE
Defer tracker bundle loading

### DIFF
--- a/includes/class-wc-google-gtag-js.php
+++ b/includes/class-wc-google-gtag-js.php
@@ -118,7 +118,10 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 				'google-tag-manager',
 			),
 			Plugin::get_instance()->get_js_asset_version( 'main' ),
-			true
+			array(
+				'in_footer' => true,
+				'strategy'  => 'defer',
+			)
 		);
 	}
 
@@ -130,8 +133,8 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 	 */
 	public function enqueue_tracker(): void {
 		wp_enqueue_script( 'google-tag-manager' );
-		// tracker.js needs to be executed ASAP, the remaining bits for main.js could be deferred,
-		// but to reduce the traffic, we ship it all together.
+		// Keep the tracker bundle in the classic script queue so inline data and
+		// classic WordPress package dependencies remain compatible.
 		wp_enqueue_script( $this->script_handle );
 	}
 

--- a/tests/unit-tests/WCGoogleGtagJS.php
+++ b/tests/unit-tests/WCGoogleGtagJS.php
@@ -31,6 +31,7 @@ class WCGoogleGtagJS extends EventsDataTest {
 		$this->assertEquals( true, wp_script_is( $gtag->script_handle, 'enqueued' ), '`…-main` script was not enqueued' );
 		$registered_url = wp_scripts()->registered[ $gtag->script_handle ]->src;
 		$this->assertStringContainsString( 'assets/js/build/main.js', $registered_url, 'The script does not point to the correct URL' );
+		$this->assertEquals( 'defer', wp_scripts()->get_data( $gtag->script_handle, 'strategy' ), 'The script should request WordPress defer loading.' );
 	}
 
 	/**


### PR DESCRIPTION
## Description
Closes #411.

WordPress Script Modules are available now, but this bundle still relies on classic WordPress package globals and the existing classic script handle is part of the inline-data compatibility surface. Instead of moving to modules in a risky partial migration, this keeps the classic queue and requests WordPress `defer` loading for the main tracker bundle.

## Checks
- [x] Project linting passes
- [x] Automated tests pass
- [x] Manual testing completed

## Testing instructions
1. `npm run lint:php`
2. `npm run test:php`
3. Seed a product if the E2E test site is empty: `npm run -- wp-env run tests-cli wp wc product create --name="Load order product" --type=simple --regular_price=9.99 --user=admin`
4. `npx playwright test --config=tests/e2e/config/playwright.config.js tests/e2e/specs/js-scripts/load-order.test.js`

## Changelog
Update - Request deferred loading for the main tracker bundle while preserving classic script compatibility.