### PR TITLE
Remove the compatibility declaration for the product editor beta

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,7 +113,7 @@ wp-env automatically installs Basic Auth plugin for API testing and runs `tests/
 - `WC_Google_Analytics` (the integration class) handles settings, admin UI, and script enqueuing.
 - `WC_Google_Gtag_JS` generates server-side JavaScript snippets for GA4 events. It extends `WC_Abstract_Google_Analytics_JS`.
 - Client-side tracking in `assets/js/src/` handles cart interactions and checkout events that can't be tracked server-side.
-- The plugin declares HPOS (High-Performance Order Storage), cart/checkout blocks, and product block editor compatibility.
+- The plugin declares HPOS (High-Performance Order Storage) and cart/checkout blocks compatibility.
 - GA4 measurement ID (format: `G-XXXXXXXXXX`) is configured in plugin settings, not hardcoded.
 
 ## Common Pitfalls

--- a/woocommerce-google-analytics-integration.php
+++ b/woocommerce-google-analytics-integration.php
@@ -45,7 +45,6 @@ if ( ! class_exists( 'WC_Google_Analytics_Integration' ) ) {
 			if ( class_exists( FeaturesUtil::class ) ) {
 				FeaturesUtil::declare_compatibility( 'custom_order_tables', __FILE__ );
 				FeaturesUtil::declare_compatibility( 'cart_checkout_blocks', __FILE__ );
-				FeaturesUtil::declare_compatibility( 'product_block_editor', __FILE__ );
 			}
 		}
 	);


### PR DESCRIPTION
Development of the product editor beta was paused in 2024 and it is being deprecated in WooCommerce 10.9 and removed in 11.0. The declaration has no actual code connection to the editor, so it is now obsolete and removed.

### Changes proposed in this Pull Request:

See https://linear.app/a8c/issue/STOMAIL-8140

Development of the product editor beta was paused in 2024. According to the [Product Editor Beta retiring](https://developer.woocommerce.com/2026/06/02/product-editor-beta-retiring/) announcement, it will be marked as deprecated in WooCommerce 10.9 and removed in WooCommerce 11.0, with plugins advised to remove support by July 28, 2026.

This plugin declared compatibility with this feature in #354, but the declaration has no actual code connection to the editor. As of WooCommerce 11.0 the `product_block_editor` feature is no longer registered, so the declaration is now obsolete and is removed in this PR.

### Checks:

* [x] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Detailed test instructions:

The `product_block_editor` feature has had [`skip_compatibility_checks` (formerly `is_legacy`) set to `true`](https://github.com/woocommerce/woocommerce/blob/10.8.1/plugins/woocommerce/src/Internal/Features/FeaturesController.php#L308) for years, so the compatibility declaration was not actually checked, and there is no meaningful way to test it through the UI. The steps below only cover the most basic plugin checks to confirm this change does not affect the plugin itself.

1. Check out this branch and make sure Google Analytics for WooCommerce is active.
2. Confirm the plugin loads with no PHP errors or warnings.
3. Go to **WooCommerce > Status > Logs** and confirm there are no new fatal errors or notices related to feature compatibility.

### Changelog entry

> Tweak - Remove the compatibility declaration for the product editor beta, which is being retired in WooCommerce 11.0.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->