### PR TITLE
Exclude development-only files from the packaged plugin

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -30,3 +30,11 @@ node_modules export-ignore
 languages export-ignore
 assets/js/src export-ignore
 webpack.config.js export-ignore
+eslint.config.mjs export-ignore
+.npmrc export-ignore
+.wp-env.json export-ignore
+.coderabbit.yaml export-ignore
+.ai export-ignore
+.claude export-ignore
+AGENTS.md export-ignore
+CLAUDE.md export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -4,7 +4,6 @@
 .github export-ignore
 bin export-ignore
 tests export-ignore
-Gruntfile.js export-ignore
 README.md export-ignore
 .nvmrc export-ignore
 package.json export-ignore
@@ -14,14 +13,7 @@ composer.lock export-ignore
 phpunit.xml.dist export-ignore
 phpunit.xml export-ignore
 phpcs.xml.dist export-ignore
-.eslintrc.js export-ignore
-.eslintignore export-ignore
-.tx export-ignore
 .editorconfig export-ignore
-.jshintrc export-ignore
-.phpcs.xml export-ignore
-.travis.yml export-ignore
-.babelrc export-ignore
 docs export-ignore
 wordpress_org_assets export-ignore
 assets/css/*.scss export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -21,7 +21,6 @@ phpcs.xml.dist export-ignore
 .jshintrc export-ignore
 .phpcs.xml export-ignore
 .travis.yml export-ignore
-.editorconfig export-ignore
 .babelrc export-ignore
 docs export-ignore
 wordpress_org_assets export-ignore


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The packaged `woocommerce-google-analytics-integration.zip` currently includes several files that are only used during development and are never loaded at runtime. This PR adds `export-ignore` rules in `.gitattributes` to ignore them from the release zip.

Files newly excluded by this PR:

- `eslint.config.mjs`
- `.npmrc`
- `.wp-env.json`
- `.coderabbit.yaml`
- `.ai`
- `.claude`
- `AGENTS.md`
- `CLAUDE.md`

While reviewing the list, two cleanups were also made:

- Removed a duplicate `.editorconfig` entry.
- Dropped `export-ignore` entries for tooling that no longer exists in the repository

### Checks:

* [x] Does your code follow the WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

### Detailed test instructions:

1. Run `npm run build`.
2. Unzip the generated `woocommerce-google-analytics-integration.zip`.
3. Confirm the above files are absent from the unzipped contents:

### Changelog entry
