### PR TITLE
Increase test coverage for Google Analytics integration

### DIFF
--- a/includes/class-wc-abstract-google-analytics-js.php
+++ b/includes/class-wc-abstract-google-analytics-js.php
@@ -586,7 +586,7 @@ abstract class WC_Abstract_Google_Analytics_JS {
 	public function get_formatted_price( $value ): int {
 		return intval(
 			round(
-				( (float) wc_format_decimal( $value ) ) * ( 10 ** absint( wc_get_price_decimals() ) ),
+				wc_add_number_precision( (float) wc_format_decimal( $value ), false ),
 				0
 			)
 		);

--- a/tests/unit-tests/PluginAssets.php
+++ b/tests/unit-tests/PluginAssets.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace GoogleAnalyticsIntegration\Tests;
+
+use WP_UnitTestCase;
+
+/**
+ * Unit tests for plugin asset metadata helpers.
+ *
+ * @package GoogleAnalyticsIntegration\Tests
+ */
+class PluginAssets extends WP_UnitTestCase {
+
+	/** @var \WC_Google_Analytics_Integration */
+	private $plugin;
+
+	/**
+	 * Set up the plugin instance.
+	 *
+	 * @return void
+	 */
+	public function set_up() {
+		parent::set_up();
+		$this->plugin = \WC_Google_Analytics_Integration::get_instance();
+	}
+
+	/**
+	 * Test that committed asset metadata is loaded for the main bundle.
+	 *
+	 * @return void
+	 */
+	public function test_get_js_asset_file_loads_existing_metadata() {
+		$asset = $this->plugin->get_js_asset_file( 'main' );
+
+		$this->assertSame( array( 'wp-hooks', 'wp-i18n' ), $asset['dependencies'] );
+		$this->assertIsString( $asset['version'] );
+		$this->assertNotEmpty( $asset['version'] );
+	}
+
+	/**
+	 * Test that missing asset metadata returns the documented empty array.
+	 *
+	 * @return void
+	 */
+	public function test_get_js_asset_file_returns_empty_array_for_missing_metadata() {
+		$this->assertSame( array(), $this->plugin->get_js_asset_file( 'missing-bundle' ) );
+	}
+
+	/**
+	 * Test dependency lookup and explicit extra dependencies.
+	 *
+	 * @return void
+	 */
+	public function test_get_js_asset_dependencies_merges_extra_dependencies_once() {
+		$this->assertSame(
+			array( 'wp-hooks', 'wp-i18n', 'jquery' ),
+			array_values( $this->plugin->get_js_asset_dependencies( 'main', array( 'wp-hooks', 'jquery' ) ) )
+		);
+	}
+
+	/**
+	 * Test missing asset dependency and version fallbacks.
+	 *
+	 * @return void
+	 */
+	public function test_missing_asset_dependency_and_version_fallbacks() {
+		$this->assertSame( array( 'jquery' ), $this->plugin->get_js_asset_dependencies( 'missing-bundle', array( 'jquery' ) ) );
+		$this->assertFalse( $this->plugin->get_js_asset_version( 'missing-bundle' ) );
+	}
+}

--- a/tests/unit-tests/PluginAssets.php
+++ b/tests/unit-tests/PluginAssets.php
@@ -14,27 +14,66 @@ class PluginAssets extends WP_UnitTestCase {
 	/** @var \WC_Google_Analytics_Integration */
 	private $plugin;
 
+	/** @var string */
+	private $asset_dir;
+
 	/**
-	 * Set up the plugin instance.
+	 * Set up a plugin instance with controlled asset metadata fixtures.
 	 *
 	 * @return void
 	 */
 	public function set_up() {
 		parent::set_up();
-		$this->plugin = \WC_Google_Analytics_Integration::get_instance();
+		$this->asset_dir = trailingslashit( sys_get_temp_dir() ) . 'wc-ga-assets-' . uniqid();
+		wp_mkdir_p( $this->asset_dir );
+
+		$this->plugin = $this->getMockBuilder( \WC_Google_Analytics_Integration::class )
+			->disableOriginalConstructor()
+			->onlyMethods( array( 'get_js_asset_path' ) )
+			->getMock();
+
+		$this->plugin->method( 'get_js_asset_path' )->willReturnCallback(
+			function ( $end = '' ) {
+				return trailingslashit( $this->asset_dir ) . $end;
+			}
+		);
 	}
 
 	/**
-	 * Test that committed asset metadata is loaded for the main bundle.
+	 * Clean up temporary asset metadata fixtures.
+	 *
+	 * @return void
+	 */
+	public function tear_down() {
+		foreach ( glob( trailingslashit( $this->asset_dir ) . '*' ) as $asset_file ) {
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- Test fixture cleanup.
+			unlink( $asset_file );
+		}
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir -- Test fixture cleanup.
+		rmdir( $this->asset_dir );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Test that existing asset metadata is loaded.
 	 *
 	 * @return void
 	 */
 	public function test_get_js_asset_file_loads_existing_metadata() {
+		$this->write_asset_file(
+			'main',
+			array(
+				'dependencies' => array( 'wp-hooks', 'wp-i18n' ),
+				'version'      => 'test-version',
+			)
+		);
+
 		$asset = $this->plugin->get_js_asset_file( 'main' );
 
 		$this->assertSame( array( 'wp-hooks', 'wp-i18n' ), $asset['dependencies'] );
-		$this->assertIsString( $asset['version'] );
-		$this->assertNotEmpty( $asset['version'] );
+		$this->assertSame( 'test-version', $asset['version'] );
 	}
 
 	/**
@@ -52,6 +91,14 @@ class PluginAssets extends WP_UnitTestCase {
 	 * @return void
 	 */
 	public function test_get_js_asset_dependencies_merges_extra_dependencies_once() {
+		$this->write_asset_file(
+			'main',
+			array(
+				'dependencies' => array( 'wp-hooks', 'wp-i18n' ),
+				'version'      => 'test-version',
+			)
+		);
+
 		$this->assertSame(
 			array( 'wp-hooks', 'wp-i18n', 'jquery' ),
 			array_values( $this->plugin->get_js_asset_dependencies( 'main', array( 'wp-hooks', 'jquery' ) ) )
@@ -66,5 +113,22 @@ class PluginAssets extends WP_UnitTestCase {
 	public function test_missing_asset_dependency_and_version_fallbacks() {
 		$this->assertSame( array( 'jquery' ), $this->plugin->get_js_asset_dependencies( 'missing-bundle', array( 'jquery' ) ) );
 		$this->assertFalse( $this->plugin->get_js_asset_version( 'missing-bundle' ) );
+	}
+
+	/**
+	 * Write a temporary asset metadata fixture.
+	 *
+	 * @param string $asset_name Asset name.
+	 * @param array  $asset      Asset metadata.
+	 *
+	 * @return void
+	 */
+	private function write_asset_file( string $asset_name, array $asset ): void {
+		$asset_path = $this->plugin->get_js_asset_path( $asset_name . '.asset.php' );
+		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export -- Test fixture setup.
+		$contents = '<?php return ' . var_export( $asset, true ) . ';';
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Test fixture setup.
+		file_put_contents( $asset_path, $contents );
 	}
 }

--- a/tests/unit-tests/TrackingSettingsService.php
+++ b/tests/unit-tests/TrackingSettingsService.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace GoogleAnalyticsIntegration\Tests;
+
+use WP_UnitTestCase;
+
+require_once dirname( __DIR__, 2 ) . '/includes/class-wc-google-analytics-tracking-settings-service.php';
+
+/**
+ * Unit tests for WC_Google_Analytics_Tracking_Settings_Service.
+ *
+ * @package GoogleAnalyticsIntegration\Tests
+ */
+class TrackingSettingsService extends WP_UnitTestCase {
+
+	/**
+	 * Test the public event settings contract and order.
+	 *
+	 * @return void
+	 */
+	public function test_get_event_settings_map_returns_expected_contract() {
+		$this->assertSame(
+			array(
+				'purchase'         => 'ga_ecommerce_tracking_enabled',
+				'add_to_cart'      => 'ga_event_tracking_enabled',
+				'remove_from_cart' => 'ga_enhanced_remove_from_cart_enabled',
+				'view_item_list'   => 'ga_enhanced_product_impression_enabled',
+				'select_content'   => 'ga_enhanced_product_click_enabled',
+				'view_item'        => 'ga_enhanced_product_detail_view_enabled',
+				'begin_checkout'   => 'ga_enhanced_checkout_process_enabled',
+			),
+			\WC_Google_Analytics_Tracking_Settings_Service::get_event_settings_map()
+		);
+	}
+
+	/**
+	 * Test linker domain parsing trims values, lowercases domains, and drops invalid entries.
+	 *
+	 * @return void
+	 */
+	public function test_parse_linker_domains_sanitizes_values() {
+		$this->assertSame(
+			array( 'example.com', 'sub.example.org', 'ok-store.co.uk', 'shop.xn--p1ai' ),
+			\WC_Google_Analytics_Tracking_Settings_Service::parse_linker_domains(
+				' EXAMPLE.com, bad domain, https://example.net, sub.Example.ORG, example, -bad.com, ok-store.co.uk, shop.xn--p1ai '
+			)
+		);
+	}
+
+	/**
+	 * Test an empty settings snapshot returns stable false/empty values.
+	 *
+	 * @return void
+	 */
+	public function test_get_tracking_settings_returns_disabled_snapshot_when_settings_empty() {
+		$service  = $this->create_service( array(), false );
+		$settings = $service->get_tracking_settings();
+
+		$this->assertFalse( $settings['setup_complete'] );
+		$this->assertSame( '', $settings['measurement_id'] );
+		$this->assertSame( '', $settings['measurement_id_prefix'] );
+		$this->assertSame( '', $settings['product_identifier'] );
+		$this->assertFalse( $settings['display_advertising_enabled'] );
+		$this->assertFalse( $settings['track_404_enabled'] );
+		$this->assertFalse( $settings['linker']['allow_incoming'] );
+		$this->assertSame( array(), $settings['linker']['domains'] );
+		$this->assertSame( array(), $settings['enabled_events'] );
+		$this->assertSame( WC_GOOGLE_ANALYTICS_INTEGRATION_VERSION, $settings['plugin_version'] );
+
+		foreach ( array_keys( \WC_Google_Analytics_Tracking_Settings_Service::get_event_settings_map() ) as $event ) {
+			$this->assertFalse( $settings['event_tracking'][ $event ], "Expected {$event} to be disabled." );
+		}
+	}
+
+	/**
+	 * Test a mixed settings snapshot returns sanitized output and enabled events in contract order.
+	 *
+	 * @return void
+	 */
+	public function test_get_tracking_settings_returns_enabled_events_in_contract_order() {
+		$service  = $this->create_service(
+			array(
+				'ga_id'                                   => 'ZZ-12345',
+				'ga_product_identifier'                   => 'product_sku',
+				'ga_support_display_advertising'          => 'yes',
+				'ga_404_tracking_enabled'                 => 'no',
+				'ga_linker_allow_incoming_enabled'        => 'yes',
+				'ga_linker_cross_domains'                 => 'STORE.EXAMPLE.COM, bad domain, checkout.example.net',
+				'ga_ecommerce_tracking_enabled'           => 'yes',
+				'ga_event_tracking_enabled'               => 'no',
+				'ga_enhanced_remove_from_cart_enabled'    => 'yes',
+				'ga_enhanced_product_impression_enabled'  => 'no',
+				'ga_enhanced_product_click_enabled'       => 'yes',
+				'ga_enhanced_product_detail_view_enabled' => 'no',
+				'ga_enhanced_checkout_process_enabled'    => 'yes',
+			)
+		);
+		$settings = $service->get_tracking_settings();
+
+		$this->assertTrue( $settings['setup_complete'] );
+		$this->assertSame( 'ZZ-12345', $settings['measurement_id'] );
+		$this->assertSame( 'X', $settings['measurement_id_prefix'] );
+		$this->assertSame( 'product_sku', $settings['product_identifier'] );
+		$this->assertTrue( $settings['display_advertising_enabled'] );
+		$this->assertFalse( $settings['track_404_enabled'] );
+		$this->assertTrue( $settings['linker']['allow_incoming'] );
+		$this->assertSame( array( 'store.example.com', 'checkout.example.net' ), $settings['linker']['domains'] );
+		$this->assertSame( array( 'purchase', 'remove_from_cart', 'select_content', 'begin_checkout' ), $settings['enabled_events'] );
+		$this->assertTrue( $settings['event_tracking']['purchase'] );
+		$this->assertFalse( $settings['event_tracking']['add_to_cart'] );
+		$this->assertTrue( $settings['event_tracking']['remove_from_cart'] );
+		$this->assertFalse( $settings['event_tracking']['view_item_list'] );
+		$this->assertTrue( $settings['event_tracking']['select_content'] );
+		$this->assertFalse( $settings['event_tracking']['view_item'] );
+		$this->assertTrue( $settings['event_tracking']['begin_checkout'] );
+	}
+
+	/**
+	 * Create the service with a mocked integration.
+	 *
+	 * @param array $settings Settings returned by get_option().
+	 * @param bool  $setup_complete Whether the integration reports setup as complete.
+	 *
+	 * @return \WC_Google_Analytics_Tracking_Settings_Service
+	 */
+	private function create_service( array $settings, bool $setup_complete = true ): \WC_Google_Analytics_Tracking_Settings_Service {
+		$integration = $this->getMockBuilder( \WC_Google_Analytics::class )
+			->disableOriginalConstructor()
+			->onlyMethods( array( 'get_option', 'is_setup_complete' ) )
+			->getMock();
+
+		$integration->method( 'get_option' )->willReturnCallback(
+			function ( $key ) use ( $settings ) {
+				return $settings[ $key ] ?? '';
+			}
+		);
+		$integration->method( 'is_setup_complete' )->willReturn( $setup_complete );
+
+		return new \WC_Google_Analytics_Tracking_Settings_Service( $integration );
+	}
+}

--- a/woocommerce-google-analytics-integration.php
+++ b/woocommerce-google-analytics-integration.php
@@ -285,11 +285,17 @@ if ( ! class_exists( 'WC_Google_Analytics_Integration' ) ) {
 		 * @return array The asset file. Or an empty array if the file doesn't exist.
 		 */
 		public function get_js_asset_file( $asset_name ) {
+			$asset_path = $this->get_js_asset_path( $asset_name . '.asset.php' );
+
+			if ( ! file_exists( $asset_path ) ) {
+				return [];
+			}
+
 			try {
 				// Exclusion reason: No reaching any user input
 				// nosemgrep audit.php.lang.security.file.inclusion-arg
-				return require $this->get_js_asset_path( $asset_name . '.asset.php' );
-			} catch ( Exception $e ) {
+				return require $asset_path;
+			} catch ( Throwable $e ) {
 				return [];
 			}
 		}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Linear: STORMA-166

Adds focused PHP unit coverage for asset metadata helpers and tracking settings snapshots. Also fixes two small issues found while testing: missing asset metadata now returns the documented empty array, and price minor-unit formatting uses WooCommerce precision handling.

### Checks:
* [x] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Screenshots:

N/A

### Detailed test instructions:

1. Run `vendor/bin/phpunit`.
2. Run `vendor/bin/phpcs`.
3. Run `npm run lint:js`.

### Additional details:

### Changelog entry

> Fix - Price minor-unit rounding.
> Dev - Add focused unit coverage for asset metadata and tracking settings snapshots.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

**Issues found: 2**

1. **Bug**: Missing asset metadata fallback - `get_js_asset_file()` now returns an empty array as documented when the asset file doesn't exist (in `woocommerce-google-analytics-integration.php`)

2. **Bug**: Price minor-unit rounding precision - `get_formatted_price()` now uses `wc_add_number_precision()` for correct WooCommerce precision handling instead of manual rounding calculations (in `includes/class-wc-abstract-google-analytics-js.php`)

Additionally, the PR includes comprehensive unit test coverage for these fixes and related functionality through new test classes `PluginAssets` and `TrackingSettingsService`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->