### PR TITLE
Refresh global roles in PHPUnit bootstrap after WooCommerce install

### DIFF
--- a/tests/class-unittestsbootstrap.php
+++ b/tests/class-unittestsbootstrap.php
@@ -120,7 +120,16 @@ class UnitTestsBootstrap {
 		include $this->plugins_dir . '/woocommerce/uninstall.php';
 
 		\WC_Install::install();
-		new \WP_Roles();
+
+		// WC_Install::install() persists role capabilities to the wp_user_roles
+		// option, but does not refresh the runtime global $wp_roles. On a fresh
+		// database whose option was not already seeded, the administrator role
+		// is then left without manage_woocommerce. Unset the global so
+		// wp_roles() rebuilds it from the option. Instantiating `new WP_Roles()`
+		// does not help: it builds a discarded object and never reassigns the
+		// global.
+		unset( $GLOBALS['wp_roles'] );
+
 		WC()->init();
 
 		echo 'WooCommerce Finished Installing...' . PHP_EOL;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This surfaced while testing compatibility against WooCommerce 10.9.0-beta.1: the "PHP Unit Tests (for Release Candidates)" job fails on `Abilities::test_tracking_settings_ability_executes_with_curated_output` with `Ability ... does not have necessary permission`.

The PHPUnit bootstrap runs `WC_Install::install()` then `new WP_Roles()`. `WC_Install::install()` persists role capabilities to the `wp_user_roles` option but does not refresh the runtime global `$wp_roles`, and `new WP_Roles()` only builds a discarded object that never reassigns the global. On a fresh database (as in CI) the `administrator` role is then left without `manage_woocommerce`, failing the ability permission check. The miss is masked whenever the option was already seeded with the capability by an earlier install.

💡 This is contained to the test environment: the shipped ability and production are unaffected because the global is rebuilt on the next request after install.

### Checks:

* [x] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Screenshots:

#### 📷 Before

https://github.com/woocommerce/woocommerce-google-analytics-integration/actions/runs/27528661033/job/81361282603

<img width="1414" height="1081" alt="image" src="https://github.com/user-attachments/assets/22d90668-c3b0-489d-90fb-9efc54bc82c7" />

#### 📷 After

https://github.com/woocommerce/woocommerce-google-analytics-integration/actions/runs/27532533421/job/81373880118

<img width="1418" height="1109" alt="image" src="https://github.com/user-attachments/assets/288f593a-54ec-4cd4-8d4b-add50b422994" />

### Detailed test instructions:

1. Start the environment and install WooCommerce 10.9.0-beta.1.
2. Remove `manage_woocommerce` from the administrator role to simulate a fresh database.
3. Run PHPUnit tests to check if all tests can pass.

### Changelog entry


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Issues Found

**1 issue identified and fixed:**

- **Bug**: State management issue in the PHPUnit bootstrap process where `WC_Install::install()` persists role capabilities to the database but fails to refresh the runtime global `$wp_roles` object. This leaves the administrator role without the `manage_woocommerce` capability on fresh databases (as used in CI environments), causing permission checks to fail.

## Fix Applied

Modified `tests/class-unittestsbootstrap.php` in the `UnitTestsBootstrap::install_wc()` method to unset `$GLOBALS['wp_roles']` after `\WC_Install::install()` completes. This forces subsequent `wp_roles()` calls to rebuild capabilities from the persisted database state, ensuring runtime capabilities match those in storage. The change is isolated to the test environment and does not affect production code.

**Impact**: Test execution now succeeds with all 86 tests passing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->