### PR TITLE
Bump dev dependencies and remove outdated npm overrides

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6674,6 +6674,16 @@
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
       "version": "9.0.9",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
@@ -8474,6 +8484,16 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/@wordpress/scripts/node_modules/brace-expansion": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
     },
     "node_modules/@wordpress/scripts/node_modules/doctrine": {
       "version": "3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13952,17 +13952,17 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -17040,14 +17040,14 @@
       }
     },
     "node_modules/launch-editor": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.9.0.tgz",
-      "integrity": "sha512-2fC2VVHR6j4vPp+WAjGmZzuThaKxBe5kq1/zV1E6Cd993hwUj73TmHSHTbEZGDeUILG3s1xkjpHTTZoNnJQA3g==",
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.14.1.tgz",
+      "integrity": "sha512-QWBrQsMpH7gPr965dsKD/3cKWiNoTjpATQf++Xq63N6sKRGMwlVXz41O1IZTMfZQgBctD/K5Zt06+/I6pP6+HA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "picocolors": "^1.0.0",
-        "shell-quote": "^1.8.1"
+        "picocolors": "^1.1.1",
+        "shell-quote": "^1.8.4"
       }
     },
     "node_modules/lazy-cache": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
   "overrides": {
     "@babel/runtime": "^7.27.6",
     "webpack-dev-server": "^5.2.4",
-    "launch-editor": "2.9.0",
     "lodash": "^4.17.24",
     "qs": "^6.15.2",
     "socks": {

--- a/package.json
+++ b/package.json
@@ -27,24 +27,12 @@
   "overrides": {
     "@babel/runtime": "^7.27.6",
     "webpack-dev-server": "^5.2.4",
-    "lodash": "^4.17.24",
     "qs": "^6.15.2",
-    "socks": {
-      ".": "2.8.9",
-      "ip-address": "10.1.1"
-    },
     "uuid": "11.1.1",
-    "brace-expansion": "^1.1.13",
     "minimatch": "^3.1.4",
-    "yaml": "^1.10.3",
-    "docker-compose": {
-      "yaml": "^2.8.3"
-    },
-    "path-to-regexp": "^0.1.13",
     "@typescript-eslint/typescript-estree": {
       "minimatch": "^9.0.7"
     },
-    "terser-webpack-plugin": "^5.3.17",
     "serialize-javascript": "^7.0.5",
     "schema-utils": {
       "ajv": "^8.18.0"


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR cleans up the dev dependency tree in two parts, all dev-only (the shipped plugin has no runtime npm dependencies affected). It eliminates the only high-severity npm audit finding and reduces override maintenance surface without changing the resolved dependency tree.

#### Fix security advisories

- Bump transitively pulled `form-data` (via `axios`) from 4.0.5 to 4.0.6.
- Remove the stale `launch-editor` override (2.9.0). Dropping it lets `webpack-dev-server` resolve `launch-editor` to 2.14.1.

#### Prune redundant overrides

Remove seven overrides (`lodash`, `socks`, `brace-expansion`, `yaml`, `docker-compose`, `path-to-regexp`, `terser-webpack-plugin`) that resolved to the same or higher versions without the pin. Removing them leaves the dependency tree and audit result unchanged.

### Checks:

* [x] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Detailed test instructions:

1. `npm install` and `npm audit` to confirm there are zero high-severity findings.
2. `npm run lint:js` to confirm linting passes.
3. `npm run build` to confirm a production build compiles successfully.

### Changelog entry
