### PR TITLE
Guard product formatting against non-WC_Product values

### DIFF
--- a/includes/class-wc-abstract-google-analytics-js.php
+++ b/includes/class-wc-abstract-google-analytics-js.php
@@ -79,7 +79,9 @@ abstract class WC_Abstract_Google_Analytics_JS {
 			'woocommerce_before_single_product',
 			function () {
 				global $product;
-				$this->set_script_data( 'product', $this->get_formatted_product( $product ) );
+				if ( $product instanceof WC_Product ) {
+					$this->set_script_data( 'product', $this->get_formatted_product( $product ) );
+				}
 			}
 		);
 
@@ -106,7 +108,7 @@ abstract class WC_Abstract_Google_Analytics_JS {
 		add_filter(
 			'woocommerce_loop_add_to_cart_link',
 			function ( $button, $product ) use ( &$product_list_items, $max_product_list_items ) {
-				if ( $product_list_items < $max_product_list_items ) {
+				if ( $product instanceof WC_Product && $product_list_items < $max_product_list_items ) {
 					$this->append_script_data( 'products', $this->get_formatted_product( $product ) );
 					++$product_list_items;
 				}
@@ -261,8 +263,13 @@ abstract class WC_Abstract_Google_Analytics_JS {
 
 		$items = array();
 		foreach ( $cart->get_cart() as $cart_item_key => $item ) {
+			$product = $item['data'] ?? null;
+			if ( ! $product instanceof WC_Product ) {
+				continue;
+			}
+
 			$items[] = array_merge(
-				$this->get_formatted_product( $item['data'] ),
+				$this->get_formatted_product( $product ),
 				array(
 					'key'      => $cart_item_key,
 					'quantity' => $item['quantity'],
@@ -288,15 +295,25 @@ abstract class WC_Abstract_Google_Analytics_JS {
 	/**
 	 * Returns an array of product data in the required format
 	 *
-	 * @param WC_Product $product   The product to format.
-	 * @param int        $variation_id Variation product ID.
-	 * @param array|bool $variation An array containing product variation attributes to include in the product data.
+	 * Returns an empty array when the product cannot be resolved. Several
+	 * callers pass a value that is not guaranteed to be a WC_Product (e.g. a
+	 * deleted product, or a product whose type class is not registered). The
+	 * argument is intentionally untyped so that such values degrade gracefully
+	 * instead of fataling the front-end render with a TypeError on PHP 8.
+	 *
+	 * @param WC_Product|false|null $product   The product to format.
+	 * @param int                   $variation_id Variation product ID.
+	 * @param array|bool            $variation An array containing product variation attributes to include in the product data.
 	 *                              For the "variation" type products, we'll use product->get_attributes.
-	 * @param bool|int   $quantity  Quantity to include in the formatted product object
+	 * @param bool|int              $quantity  Quantity to include in the formatted product object
 	 *
 	 * @return array
 	 */
-	public function get_formatted_product( WC_Product $product, $variation_id = 0, $variation = false, $quantity = false ): array {
+	public function get_formatted_product( $product, $variation_id = 0, $variation = false, $quantity = false ): array {
+		if ( ! $product instanceof WC_Product ) {
+			return array();
+		}
+
 		$product_id = $product->is_type( 'variation' ) ? $product->get_parent_id() : $product->get_id();
 		$price      = $product->get_price();
 
@@ -450,7 +467,11 @@ abstract class WC_Abstract_Google_Analytics_JS {
 			$cart_item = WC()->cart->cart_contents[ $cart_item_key ];
 		}
 
-		$product   = $cart_item['data'] ?? wc_get_product( $product_id );
+		$product = $cart_item['data'] ?? wc_get_product( $product_id );
+		if ( ! $product instanceof WC_Product ) {
+			return;
+		}
+
 		$formatted = $this->get_formatted_product( $product, $variation_id, $variation, $quantity );
 
 		if ( null === $this->pending_added_to_cart ) {
@@ -549,6 +570,24 @@ abstract class WC_Abstract_Google_Analytics_JS {
 		 */
 		$order_id = apply_filters( 'woocommerce_ga_order_id', $order->get_order_number(), $order );
 
+		$items = array();
+		foreach ( $order->get_items() as $item ) {
+			$product = $item->get_product();
+			if ( ! $product instanceof WC_Product ) {
+				continue;
+			}
+
+			$items[] = array_merge(
+				$this->get_formatted_product( $product ),
+				array(
+					'quantity'                    => $item->get_quantity(),
+					// The method get_total() will return the price after coupon discounts.
+					// https://github.com/woocommerce/woocommerce/blob/54eba223b8dec015c91a13423f9eced09e96f399/plugins/woocommerce/includes/class-wc-order-item-product.php#L308-L310
+					'price_after_coupon_discount' => $this->get_formatted_price( $item->get_total() ),
+				)
+			);
+		}
+
 		return array(
 			'id'          => $order_id,
 			'affiliation' => get_bloginfo( 'name' ),
@@ -559,20 +598,7 @@ abstract class WC_Abstract_Google_Analytics_JS {
 				'shipping_total'      => $this->get_formatted_price( $order->get_total_shipping() ),
 				'total_price'         => $this->get_formatted_price( $order->get_total() ),
 			),
-			'items'       => array_map(
-				function ( WC_Order_Item_Product $item ) {
-					return array_merge(
-						$this->get_formatted_product( $item->get_product() ),
-						array(
-							'quantity'                    => $item->get_quantity(),
-							// The method get_total() will return the price after coupon discounts.
-							// https://github.com/woocommerce/woocommerce/blob/54eba223b8dec015c91a13423f9eced09e96f399/plugins/woocommerce/includes/class-wc-order-item-product.php#L308-L310
-							'price_after_coupon_discount' => $this->get_formatted_price( $item->get_total() ),
-						)
-					);
-				},
-				array_values( $order->get_items() ),
-			),
+			'items'       => $items,
 		);
 	}
 

--- a/tests/unit-tests/DataFormatting.php
+++ b/tests/unit-tests/DataFormatting.php
@@ -96,6 +96,19 @@ class DataFormatting extends EventsDataTest {
 	}
 
 	/**
+	 * Test that the method returns an empty array for a non-product value.
+	 *
+	 * This is the central safety net: even if a caller (including third-party
+	 * or future code) passes a non-WC_Product, the method must not fatal.
+	 *
+	 * @return void
+	 */
+	public function test_get_formatted_product_returns_empty_for_non_product() {
+		$this->assertSame( array(), $this->gtag->get_formatted_product( false ) );
+		$this->assertSame( array(), $this->gtag->get_formatted_product( null ) );
+	}
+
+	/**
 	 * Test that a simple product returns correct structure and values.
 	 *
 	 * @return void
@@ -546,5 +559,127 @@ class DataFormatting extends EventsDataTest {
 		$this->assertEquals( get_woocommerce_currency(), $totals['currency_code'] );
 		$this->assertEquals( wc_get_price_decimals(), $totals['currency_minor_unit'] );
 		$this->assertIsInt( $totals['total_price'] );
+	}
+
+	/**
+	 * Test that a cart item whose 'data' is not a WC_Product is skipped
+	 * instead of fataling the whole render.
+	 *
+	 * Core drops unresolvable items while rebuilding the cart from session, so
+	 * a non-product 'data' in practice comes from third-party code mutating the
+	 * cart contents. Simulated here via the woocommerce_get_cart_contents
+	 * filter.
+	 *
+	 * @return void
+	 */
+	public function test_get_formatted_cart_skips_unresolvable_product() {
+		$product = WC_Helper_Product::create_simple_product();
+		WC()->cart->add_to_cart( $product->get_id(), 2 );
+
+		// Simulate third-party code leaving a cart item without a valid product.
+		$callback = function ( $contents ) {
+			foreach ( $contents as $key => $item ) {
+				$contents[ $key ]['data'] = false;
+			}
+			return $contents;
+		};
+		add_filter( 'woocommerce_get_cart_contents', $callback );
+
+		try {
+			$formatted = $this->gtag->get_formatted_cart();
+
+			$this->assertIsArray( $formatted );
+			$this->assertArrayHasKey( 'items', $formatted );
+			$this->assertEmpty( $formatted['items'], 'Unresolvable cart items should be skipped.' );
+		} finally {
+			remove_filter( 'woocommerce_get_cart_contents', $callback );
+		}
+	}
+
+	/**
+	 * Test that an order line whose product was deleted is skipped instead
+	 * of fataling the whole render.
+	 *
+	 * WC_Order_Item_Product::get_product() returns false for a deleted
+	 * order-line product.
+	 *
+	 * @return void
+	 */
+	public function test_get_formatted_order_skips_deleted_line_product() {
+		$order = $this->create_order_with_product();
+
+		// Delete the underlying product so get_product() returns false.
+		foreach ( $order->get_items() as $item ) {
+			wp_delete_post( $item->get_product_id(), true );
+		}
+
+		// Reload the order so the line items resolve their products fresh.
+		$order = wc_get_order( $order->get_id() );
+
+		$formatted = $this->gtag->get_formatted_order( $order );
+
+		$this->assertIsArray( $formatted['items'] );
+		$this->assertEmpty( $formatted['items'], 'Order items with a deleted product should be skipped.' );
+	}
+
+	/**
+	 * Test that the woocommerce_loop_add_to_cart_link callback ignores a
+	 * non-WC_Product value instead of fataling the page render.
+	 *
+	 * Third-party themes/extensions can apply this filter with a value that is
+	 * not a product.
+	 *
+	 * @return void
+	 */
+	public function test_loop_add_to_cart_link_filter_ignores_non_product() {
+		$button = '<a href="#">Add to cart</a>';
+
+		$result = apply_filters( 'woocommerce_loop_add_to_cart_link', $button, false );
+
+		$this->assertEquals( $button, $result, 'The filter should return the button unchanged for a non-product value.' );
+
+		$data = (array) json_decode( $this->gtag->get_script_data(), true );
+		$this->assertArrayNotHasKey( 'products', $data, 'No product data should be appended for a non-product value.' );
+	}
+
+	/**
+	 * Test that capturing an add-to-cart for an unresolvable product neither
+	 * fatals nor emits empty added_to_cart data.
+	 *
+	 * Covers the woocommerce_add_to_cart capture path: with no matching cart
+	 * item, wc_get_product() returns false for a product id that no longer
+	 * resolves.
+	 *
+	 * @return void
+	 */
+	public function test_capture_added_to_cart_ignores_unresolvable_product() {
+		$this->gtag->capture_added_to_cart( 'missing_key', 999999999, 1, 0, array() );
+
+		$data = (array) json_decode( $this->gtag->get_script_data(), true );
+
+		$this->assertArrayNotHasKey( 'added_to_cart', $data, 'No added_to_cart data should be set for an unresolvable product.' );
+	}
+
+	/**
+	 * Test that the woocommerce_before_single_product hook neither fatals nor
+	 * emits product data when the global $product is not a WC_Product.
+	 *
+	 * Covers the single-product render path.
+	 *
+	 * @return void
+	 */
+	public function test_before_single_product_action_ignores_non_product() {
+		global $product;
+		$original = $product;
+		$product  = false;
+
+		try {
+			do_action( 'woocommerce_before_single_product' );
+
+			$data = (array) json_decode( $this->gtag->get_script_data(), true );
+			$this->assertArrayNotHasKey( 'product', $data, 'No product data should be set when the global product is not a WC_Product.' );
+		} finally {
+			$product = $original;
+		}
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

STORMA-170

Closes #624

`WC_Abstract_Google_Analytics_JS::get_formatted_product()` was type-hinted to require a `WC_Product`. On PHP 8, any caller passing a value that is not a product turns into an uncaught `TypeError` that fatals the entire front-end render, instead of skipping a single untrackable item.

The argument can fail to resolve in several real cases: an old order whose line product has since been deleted (`WC_Order_Item_Product::get_product()` returns `false`), a third-party theme or page builder applying the `woocommerce_loop_add_to_cart_link` filter with a non-product argument, or third-party code mutating the cart contents so an item's `data` is no longer a product.

An analytics integration must never white-screen the store, so this PR makes the method itself the central safety net: the scalar type-hint is dropped and an empty array is returned for any non-`WC_Product`. In addition, each call site skips invalid products so no malformed item data is emitted downstream.

### Checks:

* [x] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Detailed test instructions:

1. On a PHP 8 site, ensure the plugin is active and a Measurement ID is configured so front-end tracking runs.
2. Add the following temporary code snippet to forcibly reproduce the issue:
   ```php
   add_filter(
   	'the_content',
   	function ( $content ) {
   		apply_filters( 'woocommerce_loop_add_to_cart_link', '', false );
   		return $content;
   	}
   );
   ```
3. As a logged-out visitor, load a page whose content renders through `the_content`. The Cart page is reliable, since the block Cart renders through `core/post-content`.
4. Without this PR, the page render aborts with a white screen or a fatal error.
   <img width="1277" height="591" alt="image" src="https://github.com/user-attachments/assets/78d71eaf-d593-4a9b-8bc7-bf2e942d9be6" />
5. With this PR, the page renders normally and the non-product value is simply skipped from tracking.

### Changelog entry

> Fix - Prevent a fatal TypeError on PHP 8 when a cart item, order line, or product loop references a product that no longer resolves to a WC_Product.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

**Issues Found: 1**

**Category: Bug**

This PR addresses a critical bug where `WC_Abstract_Google_Analytics_JS::get_formatted_product()` causes fatal TypeErrors on PHP 8 when receiving non-`WC_Product` values, white-screening the storefront instead of gracefully skipping untrackable items. The fix eliminates the scalar type-hint from the method signature and adds defensive `instanceof WC_Product` checks at three unguarded call sites (the `woocommerce_loop_add_to_cart_link` filter, `get_formatted_cart()`, and `get_formatted_order()`) to ensure invalid products are skipped rather than causing fatal errors. Comprehensive test coverage has been added to verify graceful degradation across all affected code paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->