### PR TITLE
Bump minimum WooCommerce version to 10.9 and compatibility version to 11.0

### DIFF
--- a/woocommerce-google-analytics-integration.php
+++ b/woocommerce-google-analytics-integration.php
@@ -6,8 +6,8 @@
  * Author: WooCommerce
  * Author URI: https://woocommerce.com
  * Version: 2.3.0
- * WC requires at least: 10.8
- * WC tested up to: 10.9
+ * WC requires at least: 10.9
+ * WC tested up to: 11.0
  * Requires at least: 6.9
  * Requires Plugins: woocommerce
  * Tested up to: 7.0
@@ -27,7 +27,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 if ( ! class_exists( 'WC_Google_Analytics_Integration' ) ) {
 
 	define( 'WC_GOOGLE_ANALYTICS_INTEGRATION_VERSION', '2.3.0' ); // WRCS: DEFINED_VERSION.
-	define( 'WC_GOOGLE_ANALYTICS_INTEGRATION_MIN_WC_VER', '10.8' );
+	define( 'WC_GOOGLE_ANALYTICS_INTEGRATION_MIN_WC_VER', '10.9' );
 
 	// Maybe show the GA Pro notice on plugin activation.
 	register_activation_hook(


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR bumps the minimum required WooCommerce version to 10.9 and the compatibility version to 11.0.

### Changelog entry

> Update - Bump the minimum required WooCommerce version to 10.9 and the compatibility version to 11.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->