### PR TITLE
Add unit tests for the tracking gate and gtag setup snippet

### DIFF
--- a/tests/unit-tests/DisableTracking.php
+++ b/tests/unit-tests/DisableTracking.php
@@ -1,0 +1,157 @@
+<?php
+
+namespace GoogleAnalyticsIntegration\Tests;
+
+use WC_Google_Analytics;
+use WP_UnitTestCase;
+
+/**
+ * Unit tests for WC_Google_Analytics::disable_tracking().
+ *
+ * This method is the gate that decides whether the front end tracking scripts
+ * are loaded at all, so each condition that can switch tracking off is worth
+ * pinning down.
+ *
+ * @package GoogleAnalyticsIntegration\Tests
+ */
+class DisableTracking extends WP_UnitTestCase {
+
+	/**
+	 * Reset the current user that individual tests may change. The framework's
+	 * tear_down already restores the admin screen state.
+	 *
+	 * @return void
+	 */
+	public function tear_down() {
+		wp_set_current_user( 0 );
+		parent::tear_down();
+	}
+
+	/**
+	 * Tracking should stay enabled on the front end for a visitor without admin
+	 * capabilities when a measurement id is configured and the event type is on.
+	 *
+	 * @return void
+	 */
+	public function test_tracking_enabled_on_happy_path() {
+		$ga = $this->create_ga_instance( [ 'ga_id' => 'G-TEST123' ] );
+
+		$this->assertFalse( $this->disable_tracking( $ga, 'yes' ) );
+	}
+
+	/**
+	 * An empty or missing measurement id must disable tracking, otherwise the
+	 * gtag config would point at no property.
+	 *
+	 * @return void
+	 */
+	public function test_tracking_disabled_when_ga_id_is_empty() {
+		$ga = $this->create_ga_instance( [ 'ga_id' => '' ] );
+		$this->assertTrue( $this->disable_tracking( $ga, 'yes' ), 'Empty ga_id should disable tracking' );
+
+		$ga = $this->create_ga_instance( [] );
+		$this->assertTrue( $this->disable_tracking( $ga, 'yes' ), 'Missing ga_id should disable tracking' );
+	}
+
+	/**
+	 * A 'no' event type means the merchant turned that event off, so tracking
+	 * for it must be disabled even when everything else is in place.
+	 *
+	 * @return void
+	 */
+	public function test_tracking_disabled_when_type_is_no() {
+		$ga = $this->create_ga_instance( [ 'ga_id' => 'G-TEST123' ] );
+
+		$this->assertTrue( $this->disable_tracking( $ga, 'no' ) );
+	}
+
+	/**
+	 * Requests inside wp-admin should never emit front end tracking.
+	 *
+	 * @return void
+	 */
+	public function test_tracking_disabled_in_admin_area() {
+		set_current_screen( 'edit.php' );
+		$this->assertTrue( is_admin(), 'Sanity check: the admin screen should make is_admin() true' );
+
+		$ga = $this->create_ga_instance( [ 'ga_id' => 'G-TEST123' ] );
+
+		$this->assertTrue( $this->disable_tracking( $ga, 'yes' ) );
+	}
+
+	/**
+	 * Users with the manage_options capability (administrators) are excluded
+	 * from tracking so their own browsing does not pollute the store's
+	 * analytics. Note this does not cover shop managers, who only hold
+	 * manage_woocommerce.
+	 *
+	 * @return void
+	 */
+	public function test_tracking_disabled_for_users_who_can_manage_options() {
+		$admin_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $admin_id );
+		$this->assertTrue( current_user_can( 'manage_options' ), 'Sanity check: the admin user should have manage_options' );
+
+		$ga = $this->create_ga_instance( [ 'ga_id' => 'G-TEST123' ] );
+
+		$this->assertTrue( $this->disable_tracking( $ga, 'yes' ) );
+	}
+
+	/**
+	 * The woocommerce_ga_disable_tracking filter must be able to force tracking
+	 * off, and it should receive the event type so integrations can decide per
+	 * event.
+	 *
+	 * @return void
+	 */
+	public function test_tracking_can_be_disabled_via_filter() {
+		$ga = $this->create_ga_instance( [ 'ga_id' => 'G-TEST123' ] );
+
+		$received_type = null;
+		$callback      = function ( $disabled, $type ) use ( &$received_type ) {
+			$received_type = $type;
+			return true;
+		};
+		add_filter( 'woocommerce_ga_disable_tracking', $callback, 10, 2 );
+
+		$this->assertTrue( $this->disable_tracking( $ga, 'yes' ) );
+		$this->assertEquals( 'yes', $received_type, 'The filter should receive the event type' );
+
+		remove_filter( 'woocommerce_ga_disable_tracking', $callback, 10 );
+	}
+
+	/**
+	 * Invoke the private disable_tracking() method via reflection.
+	 *
+	 * @param WC_Google_Analytics $instance The integration instance.
+	 * @param string              $type     The event type to evaluate.
+	 *
+	 * @return bool
+	 */
+	private function disable_tracking( $instance, $type ) {
+		$reflection = new \ReflectionMethod( WC_Google_Analytics::class, 'disable_tracking' );
+		$reflection->setAccessible( true );
+		return $reflection->invokeArgs( $instance, [ $type ] );
+	}
+
+	/**
+	 * Build a WC_Google_Analytics instance with injected settings while skipping
+	 * the constructor side effects (option reads, hook registration).
+	 *
+	 * @param array $settings Settings to inject.
+	 *
+	 * @return WC_Google_Analytics
+	 */
+	private function create_ga_instance( $settings = [] ) {
+		$ga = $this->getMockBuilder( WC_Google_Analytics::class )
+					->disableOriginalConstructor()
+					->onlyMethods( [] )
+					->getMock();
+
+		$reflection = new \ReflectionProperty( WC_Google_Analytics::class, 'settings' );
+		$reflection->setAccessible( true );
+		$reflection->setValue( $ga, $settings );
+
+		return $ga;
+	}
+}

--- a/tests/unit-tests/RegisterScripts.php
+++ b/tests/unit-tests/RegisterScripts.php
@@ -1,0 +1,178 @@
+<?php
+
+namespace GoogleAnalyticsIntegration\Tests;
+
+use WC_Google_Gtag_JS;
+use WC_Abstract_Google_Analytics_JS;
+use WP_UnitTestCase;
+
+/**
+ * Unit tests for the inline gtag setup snippet produced by
+ * WC_Google_Gtag_JS::register_scripts().
+ *
+ * The measurement id baked into the GTM URL and the re-registration on
+ * rehydration are already covered in WCGoogleGtagJS. These tests focus on the
+ * inline config snippet, which is what actually boots gtag with the property id,
+ * the consent defaults, and the tracker function name. If that snippet is wrong,
+ * no events are recorded even though the script handles register fine.
+ *
+ * @package GoogleAnalyticsIntegration\Tests
+ */
+class RegisterScripts extends WP_UnitTestCase {
+
+	/**
+	 * Start each test from a clean script registry and singleton so the
+	 * constructor re-runs register_scripts() against a known state.
+	 *
+	 * @return void
+	 */
+	public function set_up() {
+		parent::set_up();
+		$this->reset_gtag_instance();
+		wp_deregister_script( 'google-tag-manager' );
+		wp_deregister_script( 'woocommerce-google-analytics-integration-gtag' );
+		wp_deregister_script( 'woocommerce-google-analytics-integration' );
+	}
+
+	/**
+	 * Clear the singleton installed by the constructors above so it does not
+	 * leak into test classes that run after this one.
+	 *
+	 * @return void
+	 */
+	public function tear_down() {
+		$this->reset_gtag_instance();
+		parent::tear_down();
+	}
+
+	/**
+	 * The setup script should carry an inline snippet that boots the dataLayer,
+	 * defines the tracker function, and configures the property with the
+	 * measurement id from settings.
+	 *
+	 * @return void
+	 */
+	public function test_inline_snippet_configures_the_measurement_id() {
+		$gtag    = new WC_Google_Gtag_JS( [ 'ga_id' => 'G-TEST123' ] );
+		$snippet = $this->get_inline_snippet( $gtag->gtag_script_handle );
+
+		$this->assertStringContainsString( 'window.dataLayer = window.dataLayer', $snippet, 'Snippet should initialize the dataLayer' );
+		$this->assertStringContainsString( 'function gtag(', $snippet, 'Snippet should define the default gtag function' );
+		$this->assertStringContainsString( 'gtag("config", "G-TEST123"', $snippet, 'Snippet should configure the property with the measurement id' );
+	}
+
+	/**
+	 * The plugin identifies itself to Google through a developer id, which must be
+	 * present in the snippet.
+	 *
+	 * @return void
+	 */
+	public function test_inline_snippet_sets_the_developer_id() {
+		$gtag    = new WC_Google_Gtag_JS( [ 'ga_id' => 'G-TEST123' ] );
+		$snippet = $this->get_inline_snippet( $gtag->gtag_script_handle );
+
+		$this->assertStringContainsString(
+			'developer_id.' . WC_Abstract_Google_Analytics_JS::DEVELOPER_ID,
+			$snippet,
+			'Snippet should register the plugin developer id'
+		);
+	}
+
+	/**
+	 * Consent Mode defaults must be emitted so the EEA region is denied until the
+	 * visitor updates consent.
+	 *
+	 * @return void
+	 */
+	public function test_inline_snippet_includes_consent_defaults() {
+		$gtag    = new WC_Google_Gtag_JS( [ 'ga_id' => 'G-TEST123' ] );
+		$snippet = $this->get_inline_snippet( $gtag->gtag_script_handle );
+
+		$this->assertStringContainsString( '"consent", "default"', $snippet, 'Snippet should set default consent state' );
+		$this->assertStringContainsString( 'analytics_storage', $snippet, 'Consent defaults should reference analytics_storage' );
+	}
+
+	/**
+	 * The tracker function name is filterable, and register_scripts() must honor
+	 * the override so the config call and the function definition stay in sync.
+	 *
+	 * @return void
+	 */
+	public function test_inline_snippet_uses_custom_tracker_function_name() {
+		$callback = function () {
+			return 'customGtag';
+		};
+		add_filter( 'woocommerce_gtag_tracker_variable', $callback );
+
+		$gtag    = new WC_Google_Gtag_JS( [ 'ga_id' => 'G-TEST123' ] );
+		$snippet = $this->get_inline_snippet( $gtag->gtag_script_handle );
+
+		remove_filter( 'woocommerce_gtag_tracker_variable', $callback );
+
+		$this->assertStringContainsString( 'function customGtag(', $snippet, 'Snippet should define the filtered tracker function' );
+		$this->assertStringContainsString( 'customGtag("config", "G-TEST123"', $snippet, 'Snippet should configure the property through the filtered function' );
+	}
+
+	/**
+	 * The woocommerce_gtag_snippet filter must be able to replace the snippet
+	 * entirely so advanced integrations can supply their own bootstrap.
+	 *
+	 * @return void
+	 */
+	public function test_inline_snippet_can_be_replaced_by_filter() {
+		$callback = function () {
+			return '/* replaced snippet */';
+		};
+		add_filter( 'woocommerce_gtag_snippet', $callback );
+
+		$gtag    = new WC_Google_Gtag_JS( [ 'ga_id' => 'G-TEST123' ] );
+		$snippet = $this->get_inline_snippet( $gtag->gtag_script_handle );
+
+		remove_filter( 'woocommerce_gtag_snippet', $callback );
+
+		$this->assertStringContainsString( '/* replaced snippet */', $snippet );
+		$this->assertStringNotContainsString( 'gtag("config"', $snippet, 'The default snippet should be replaced, not appended' );
+	}
+
+	/**
+	 * The main bundle must depend on the gtag library so gtag is defined before
+	 * the tracker runs.
+	 *
+	 * @return void
+	 */
+	public function test_main_script_depends_on_google_tag_manager() {
+		$gtag = new WC_Google_Gtag_JS( [ 'ga_id' => 'G-TEST123' ] );
+
+		$registered = wp_scripts()->query( $gtag->script_handle );
+		$this->assertNotFalse( $registered, 'The main script should be registered' );
+		$this->assertContains( 'google-tag-manager', $registered->deps, 'The main script should depend on the gtag library' );
+	}
+
+	/**
+	 * Read the concatenated inline "after" data attached to a script handle.
+	 *
+	 * @param string $handle The registered script handle.
+	 *
+	 * @return string
+	 */
+	private function get_inline_snippet( $handle ) {
+		// query() returns false for an unregistered handle instead of raising an
+		// undefined-array-key warning like a direct registered[] access would.
+		$registered = wp_scripts()->query( $handle );
+		$this->assertNotFalse( $registered, "Script handle '{$handle}' should be registered" );
+
+		$after = $registered->extra['after'] ?? [];
+		return implode( "\n", array_filter( (array) $after, 'is_string' ) );
+	}
+
+	/**
+	 * Reset the shared tracking singleton.
+	 *
+	 * @return void
+	 */
+	private function reset_gtag_instance(): void {
+		$property = new \ReflectionProperty( WC_Abstract_Google_Analytics_JS::class, 'instance' );
+		$property->setAccessible( true );
+		$property->setValue( null, null );
+	}
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds PHPUnit coverage for two pieces of server-side tracking logic that were previously untested.

1. `WC_Google_Analytics::disable_tracking()` is the gate that decides whether the frontend tracking scripts are loaded at all. The tests cover every condition that switches tracking off: an admin-area request, a user with `manage_options`, an empty or missing measurement ID, a `'no'` event type, and the `woocommerce_ga_disable_tracking` filter (including that the filter receives the event type). The happy path (frontend visitor, configured ID, event on) is asserted to keep tracking enabled.

2. `WC_Google_Gtag_JS::register_scripts()` already had coverage for the measurement ID baked into the GTM URL and the re-registration on rehydration. These tests focus on the inline gtag setup snippet, which is what actually boots gtag with the property ID, consent defaults, developer ID, and the tracker function name. The tests assert the snippet configures the measurement ID, sets the developer ID, emits the Consent Mode defaults, honors the `woocommerce_gtag_tracker_variable` filter, can be replaced wholesale by the `woocommerce_gtag_snippet` filter, and that the main bundle depends on the gtag library.

### Checks:

* [x] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Detailed test instructions:

1. Start the test environment: `npm run wp-env:up`
2. Install the PHPUnit dependencies once: `npm run test:php:setup`
3. Run the PHPUnit tests to confirm all the tests can pass: `npm run test:php`

### Changelog entry


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->