### PR TITLE
Add E2E coverage for purchase on both checkout forms, SKU identifier, disabled events, and settings form

### DIFF
--- a/tests/e2e/specs/gtag-events/blocks-pages.test.js
+++ b/tests/e2e/specs/gtag-events/blocks-pages.test.js
@@ -14,6 +14,7 @@ import {
 } from '../../utils/api';
 import {
 	blockProductAddToCart,
+	checkout,
 	relatedProductAddToCart,
 	simpleProductAddToCart,
 	variableProductAddToCart,
@@ -820,6 +821,60 @@ test.describe( 'GTag events on block pages', () => {
 			expect( data[ 'epn.value' ] ).toEqual(
 				simpleProductPrice.toString()
 			);
+		} );
+	} );
+
+	// The purchase event itself is built server-side from the order, so its data
+	// does not depend on which checkout a shopper used. What this test guards is
+	// the block-specific surface around it: placing an order through the
+	// `woocommerce/checkout` block and the block order-confirmation page still
+	// firing `woocommerce_thankyou`, which is where the purchase event is
+	// enqueued. Those pieces can break independently of the classic checkout when
+	// WooCommerce updates, so the block path is verified on its own here.
+	test( 'Purchase event is sent after completing the block checkout', async ( {
+		page,
+	} ) => {
+		// Add the simple product twice and one variable product so quantity and
+		// variation handling are both exercised in the order.
+		await simpleProductAddToCart( page, simpleProductID );
+		await simpleProductAddToCart( page, simpleProductID );
+		await variableProductAddToCart( page, variableProductID );
+
+		const event = trackGtagEvent( page, 'purchase', 'checkout' );
+		const orderID = await checkout( page );
+
+		await event.then( ( request ) => {
+			const data = getEventData( request, 'purchase' );
+			expect( data.product1 ).toEqual( {
+				id: simpleProductID.toString(),
+				nm: 'Simple product',
+				ca: 'Uncategorized',
+				qt: '2',
+				pr: simpleProductPrice.toString(),
+			} );
+			expect( data.product2 ).toEqual( {
+				id: variableProductID.toString(),
+				nm: 'Variable product',
+				ca: 'Uncategorized',
+				qt: '1',
+				pr: '18.99',
+				va: 'colour: Green, size: Medium',
+			} );
+
+			expect( data[ 'ep.transaction_id' ] ).toEqual( orderID );
+			expect( data[ 'ep.affiliation' ] ).toEqual(
+				'WooCommerce E2E Test Suite'
+			);
+
+			const shipping = 10;
+			const total =
+				simpleProductPrice + simpleProductPrice + 18.99 + shipping;
+			expect( data.cu ).toEqual( 'USD' );
+			expect( data[ 'epn.value' ] ).toEqual(
+				total.toFixed( 2 ).toString()
+			);
+			expect( data[ 'epn.tax' ] ).toEqual( '0' );
+			expect( data[ 'epn.shipping' ] ).toEqual( shipping.toString() );
 		} );
 	} );
 

--- a/tests/e2e/specs/gtag-events/classic-pages.test.js
+++ b/tests/e2e/specs/gtag-events/classic-pages.test.js
@@ -27,6 +27,7 @@ import {
 import {
 	blockProductAddToCart,
 	checkout,
+	classicCheckout,
 	simpleProductAddToCart,
 	variableProductAddToCart,
 } from '../../utils/customer';
@@ -813,16 +814,22 @@ test.describe( 'GTag events on classic pages', () => {
 		}
 	} );
 
-	test( 'Purchase event is sent on order complete page', async ( {
+	// The default checkout page is the block checkout, so the block purchase
+	// test in the blocks spec covers that form. This test drives the purchase
+	// through the classic `[woocommerce_checkout]` shortcode form instead
+	// (a wc-ajax=checkout submission rather than the Store API).
+	test( 'Purchase event is sent after completing the classic shortcode checkout', async ( {
 		page,
 	} ) => {
+		await createClassicCheckoutPage();
+
 		// Add simple product twice, and one variable product.
 		await simpleProductAddToCart( page, simpleProductID );
 		await simpleProductAddToCart( page, simpleProductID );
 		await variableProductAddToCart( page, variableProductID );
 
 		const event = trackGtagEvent( page, 'purchase', 'checkout' );
-		const orderID = await checkout( page );
+		const orderID = await classicCheckout( page );
 
 		await event.then( ( request ) => {
 			const data = getEventData( request, 'purchase' );

--- a/tests/e2e/specs/gtag-events/disabled-events.test.js
+++ b/tests/e2e/specs/gtag-events/disabled-events.test.js
@@ -1,0 +1,149 @@
+/**
+ * External dependencies
+ */
+const { test, expect } = require( '@playwright/test' );
+
+/**
+ * Internal dependencies
+ */
+import {
+	createSimpleProduct,
+	setSettings,
+	clearSettings,
+} from '../../utils/api';
+import {
+	blockProductAddToCart,
+	storeApiAddToCart,
+	storeApiBatchDecreaseCartQuantity,
+} from '../../utils/customer';
+import { trackGtagEvent } from '../../utils/track-event';
+
+/**
+ * Collects the names of every gtag event sent to google-analytics.com/g/collect
+ * after this is attached. Used to assert that a disabled event never fires:
+ * unlike trackGtagEvent(), which waits for a request, asserting an absence needs
+ * to observe the traffic and then check what was (not) seen.
+ *
+ * @param {import('@playwright/test').Page} page
+ *
+ * @return {string[]} A live array of event names, appended to as requests arrive.
+ */
+function collectGtagEventNames( page ) {
+	const names = [];
+
+	page.on( 'request', ( request ) => {
+		const url = request.url();
+		if ( ! url.includes( 'google-analytics.com/g/collect' ) ) {
+			return;
+		}
+
+		// A single event is sent in the query string, multiple events in the body.
+		const queryEvent = new URL( url ).searchParams.get( 'en' );
+		if ( queryEvent ) {
+			names.push( queryEvent );
+		}
+
+		for ( const line of ( request.postData() || '' ).split( /\r?\n/ ) ) {
+			const bodyEvent = new URLSearchParams( line ).get( 'en' );
+			if ( bodyEvent ) {
+				names.push( bodyEvent );
+			}
+		}
+	} );
+
+	return names;
+}
+
+test.describe( 'Disabled event tracking', () => {
+	let productID;
+
+	test.beforeAll( async () => {
+		productID = await createSimpleProduct();
+	} );
+
+	test.afterAll( async () => {
+		await clearSettings();
+	} );
+
+	test( 'No ecommerce events fire when all event tracking is disabled', async ( {
+		page,
+	} ) => {
+		await setSettings( {
+			ga_ecommerce_tracking_enabled: 'no',
+			ga_event_tracking_enabled: 'no',
+			ga_enhanced_remove_from_cart_enabled: 'no',
+			ga_enhanced_product_impression_enabled: 'no',
+			ga_enhanced_product_click_enabled: 'no',
+			ga_enhanced_product_detail_view_enabled: 'no',
+			ga_enhanced_checkout_process_enabled: 'no',
+		} );
+
+		const eventNames = collectGtagEventNames( page );
+
+		await page.goto( 'shop?orderby=date' );
+		await blockProductAddToCart( page, productID );
+
+		// The tracking scripts still load with everything disabled; only the list
+		// of events the tracker will emit is empty. Asserting that proves the
+		// disabled state propagated to the client rather than the scripts simply
+		// failing to load (which would also produce no events).
+		const enabledEvents = await page.evaluate(
+			() => window.ga4w?.settings?.events
+		);
+		expect( enabledEvents ).toEqual( [] );
+
+		// page_view is gtag's own config hit, not gated by the plugin toggles, so
+		// it always fires. Awaiting one on a fresh navigation is a deterministic
+		// barrier: any leaked ecommerce event from the interactions above would
+		// have been collected before it.
+		const pageView = trackGtagEvent( page, 'page_view' );
+		await page.goto( 'shop' );
+		await pageView;
+
+		// Assert against every event the plugin can send rather than a
+		// whitelist of the collected names, because gtag emits automatic
+		// events of its own (page_view, session_start, user_engagement).
+		const pluginEvents = [
+			'purchase',
+			'add_to_cart',
+			'remove_from_cart',
+			'view_item_list',
+			'select_content',
+			'view_item',
+			'begin_checkout',
+			'add_shipping_info',
+			'add_payment_info',
+		];
+		expect(
+			eventNames.filter( ( name ) => pluginEvents.includes( name ) )
+		).toEqual( [] );
+	} );
+
+	test( 'Disabling add to cart leaves the other events working', async ( {
+		page,
+	} ) => {
+		await setSettings( { ga_event_tracking_enabled: 'no' } );
+
+		const eventNames = collectGtagEventNames( page );
+
+		await page.goto( 'shop?orderby=date' );
+
+		// Add two units (add_to_cart is disabled, so it must stay silent), then
+		// remove one. The remove_from_cart event is still enabled and fires after
+		// the add would have, so awaiting it is a deterministic barrier: once it
+		// arrives, a non-suppressed add_to_cart would already have been collected.
+		await storeApiAddToCart( page, productID, 2 );
+		const removeEvent = trackGtagEvent( page, 'remove_from_cart' );
+		await storeApiBatchDecreaseCartQuantity( page, productID, 1 );
+		await removeEvent;
+
+		const enabledEvents = await page.evaluate(
+			() => window.ga4w?.settings?.events
+		);
+		expect( enabledEvents ).toContain( 'remove_from_cart' );
+		expect( enabledEvents ).not.toContain( 'add_to_cart' );
+
+		expect( eventNames ).toContain( 'remove_from_cart' );
+		expect( eventNames ).not.toContain( 'add_to_cart' );
+	} );
+} );

--- a/tests/e2e/specs/gtag-events/product-identifier.test.js
+++ b/tests/e2e/specs/gtag-events/product-identifier.test.js
@@ -1,0 +1,95 @@
+/**
+ * External dependencies
+ */
+const { test, expect } = require( '@playwright/test' );
+
+/**
+ * Internal dependencies
+ */
+import {
+	createSimpleProduct,
+	setSettings,
+	clearSettings,
+} from '../../utils/api';
+import { storeApiAddToCart } from '../../utils/customer';
+import { getEventData, trackGtagEvent } from '../../utils/track-event';
+
+const config = require( '../../config/default' );
+const simpleProductPrice = parseFloat( config.products.simple.regular_price );
+
+// The product identifier is a merchant setting: events can report a product by
+// its WooCommerce id (the default, already exercised across the other specs) or
+// by its SKU. The SKU value is resolved server-side into the event data and
+// falls back to a "#id" form when a product has no SKU, so it can break when
+// store settings or WooCommerce versions change. These tests pin that end-to-end
+// behavior with the setting switched to SKU.
+test.describe( 'Product identifier setting (SKU)', () => {
+	let skuProductID, noSkuProductID;
+	const sku = `E2E-IDENT-${ Date.now() }`;
+
+	test.beforeAll( async () => {
+		await setSettings( { ga_product_identifier: 'product_sku' } );
+		skuProductID = await createSimpleProduct( { sku } );
+		// The default product config has no SKU, so this exercises the fallback.
+		noSkuProductID = await createSimpleProduct();
+	} );
+
+	test.afterAll( async () => {
+		await clearSettings();
+	} );
+
+	test( 'View item reports the product SKU', async ( { page } ) => {
+		const event = trackGtagEvent( page, 'view_item' );
+
+		await page.goto( `?p=${ skuProductID }` );
+
+		await event.then( ( request ) => {
+			const data = getEventData( request, 'view_item' );
+			expect( data.product1 ).toMatchObject( {
+				id: sku,
+				nm: 'Simple product',
+				pr: simpleProductPrice.toString(),
+			} );
+		} );
+	} );
+
+	test( 'View item falls back to the prefixed id when the product has no SKU', async ( {
+		page,
+	} ) => {
+		const event = trackGtagEvent( page, 'view_item' );
+
+		await page.goto( `?p=${ noSkuProductID }` );
+
+		await event.then( ( request ) => {
+			const data = getEventData( request, 'view_item' );
+			expect( data.product1 ).toMatchObject( {
+				id: `#${ noSkuProductID }`,
+				nm: 'Simple product',
+				pr: simpleProductPrice.toString(),
+			} );
+		} );
+	} );
+
+	// The block add-to-cart flow carries the identifier in the Store API cart
+	// item's extensions, which is a separate resolution path from the
+	// server-rendered single product page above. This guards the SKU on the
+	// block storefront specifically.
+	test( 'Store API add to cart reports the product SKU', async ( {
+		page,
+	} ) => {
+		await page.goto( 'shop?orderby=date' );
+
+		const event = trackGtagEvent( page, 'add_to_cart' );
+		await storeApiAddToCart( page, skuProductID );
+
+		await event.then( ( request ) => {
+			const data = getEventData( request, 'add_to_cart' );
+			expect( data.product1 ).toMatchObject( {
+				id: sku,
+				nm: 'Simple product',
+				qt: '1',
+				pr: simpleProductPrice.toString(),
+			} );
+		} );
+	} );
+} );

--- a/tests/e2e/specs/integration-settings.test.js
+++ b/tests/e2e/specs/integration-settings.test.js
@@ -5,14 +5,56 @@ const { test, expect } = require( '@playwright/test' );
 
 test.use( { storageState: process.env.ADMINSTATE } );
 
+const SETTINGS_URL =
+	'/wp-admin/admin.php?page=wc-settings&tab=integration&section=google_analytics';
+
 test( 'Able to setup in WooCommerce > Settings > Integration', async ( {
 	page,
 } ) => {
-	await page.goto(
-		'/wp-admin/admin.php?page=wc-settings&tab=integration&section=google_analytics'
-	);
+	await page.goto( SETTINGS_URL );
 
 	await expect(
 		page.getByRole( 'heading', { name: 'Google Analytics' } )
 	).toBeVisible();
+} );
+
+// The settings form is defined by the plugin's init_form_fields(). Asserting the
+// controls render guards against a control being dropped (and the identifier
+// select against mislabeled options). The save mechanism itself is WooCommerce
+// core and is not exercised here.
+test( 'Settings form renders the plugin controls', async ( { page } ) => {
+	await page.goto( SETTINGS_URL );
+
+	const identifier = page.locator(
+		'#woocommerce_google_analytics_ga_product_identifier'
+	);
+	await expect( identifier ).toBeVisible();
+	await expect( identifier.locator( 'option' ) ).toHaveText( [
+		'Product ID',
+		'Product SKU with prefixed (#) ID as fallback',
+	] );
+
+	await expect(
+		page.locator( '#woocommerce_google_analytics_ga_id' )
+	).toBeVisible();
+
+	// Every remaining control defined by init_form_fields() is present.
+	const controls = [
+		'ga_support_display_advertising',
+		'ga_404_tracking_enabled',
+		'ga_linker_allow_incoming_enabled',
+		'ga_ecommerce_tracking_enabled',
+		'ga_event_tracking_enabled',
+		'ga_enhanced_remove_from_cart_enabled',
+		'ga_enhanced_product_impression_enabled',
+		'ga_enhanced_product_click_enabled',
+		'ga_enhanced_product_detail_view_enabled',
+		'ga_enhanced_checkout_process_enabled',
+		'ga_linker_cross_domains',
+	];
+	for ( const control of controls ) {
+		await expect(
+			page.locator( `#woocommerce_google_analytics_${ control }` )
+		).toBeVisible();
+	}
 } );

--- a/tests/e2e/test-data/test-data.php
+++ b/tests/e2e/test-data/test-data.php
@@ -47,27 +47,36 @@ function register_routes() {
 
 /**
  * Set the settings to enable tracking.
+ *
+ * The product identifier can be overridden through the request body so tests
+ * can exercise both the default product id and the SKU based identifier.
+ *
+ * @param \WP_REST_Request $request Request object.
  */
-function set_settings() {
-	update_option(
-		'woocommerce_google_analytics_settings',
-		[
-			'ga_product_identifier'                   => 'product_id',
-			'ga_id'                                   => 'G-ABCD123',
-			'ga_support_display_advertising'          => 'no',
-			'ga_404_tracking_enabled'                 => 'yes',
-			'ga_linker_allow_incoming_enabled'        => 'no',
-			'ga_ecommerce_tracking_enabled'           => 'yes',
-			'ga_event_tracking_enabled'               => 'yes',
-			'ga_enhanced_ecommerce_tracking_enabled'  => 'yes',
-			'ga_enhanced_remove_from_cart_enabled'    => 'yes',
-			'ga_enhanced_product_impression_enabled'  => 'yes',
-			'ga_enhanced_product_click_enabled'       => 'yes',
-			'ga_enhanced_product_detail_view_enabled' => 'yes',
-			'ga_enhanced_checkout_process_enabled'    => 'yes',
-			'ga_linker_cross_domains'                 => '',
-		]
-	);
+function set_settings( $request ) {
+	$settings = [
+		'ga_product_identifier'                   => 'product_id',
+		'ga_id'                                   => 'G-ABCD123',
+		'ga_support_display_advertising'          => 'no',
+		'ga_404_tracking_enabled'                 => 'yes',
+		'ga_linker_allow_incoming_enabled'        => 'no',
+		'ga_ecommerce_tracking_enabled'           => 'yes',
+		'ga_event_tracking_enabled'               => 'yes',
+		'ga_enhanced_ecommerce_tracking_enabled'  => 'yes',
+		'ga_enhanced_remove_from_cart_enabled'    => 'yes',
+		'ga_enhanced_product_impression_enabled'  => 'yes',
+		'ga_enhanced_product_click_enabled'       => 'yes',
+		'ga_enhanced_product_detail_view_enabled' => 'yes',
+		'ga_enhanced_checkout_process_enabled'    => 'yes',
+		'ga_linker_cross_domains'                 => '',
+	];
+
+	$identifier = $request->get_json_params()['ga_product_identifier'] ?? null;
+	if ( in_array( $identifier, [ 'product_id', 'product_sku' ], true ) ) {
+		$settings['ga_product_identifier'] = $identifier;
+	}
+
+	update_option( 'woocommerce_google_analytics_settings', $settings );
 }
 
 /**

--- a/tests/e2e/test-data/test-data.php
+++ b/tests/e2e/test-data/test-data.php
@@ -48,8 +48,9 @@ function register_routes() {
 /**
  * Set the settings to enable tracking.
  *
- * The product identifier can be overridden through the request body so tests
- * can exercise both the default product id and the SKU based identifier.
+ * The product identifier and the per-event tracking toggles can be overridden
+ * through the request body so tests can exercise the SKU based identifier and
+ * the disabled-event behavior.
  *
  * @param \WP_REST_Request $request Request object.
  */
@@ -71,9 +72,26 @@ function set_settings( $request ) {
 		'ga_linker_cross_domains'                 => '',
 	];
 
-	$identifier = $request->get_json_params()['ga_product_identifier'] ?? null;
-	if ( in_array( $identifier, [ 'product_id', 'product_sku' ], true ) ) {
-		$settings['ga_product_identifier'] = $identifier;
+	$params = $request->get_json_params();
+	if ( is_array( $params ) ) {
+		if ( in_array( $params['ga_product_identifier'] ?? null, [ 'product_id', 'product_sku' ], true ) ) {
+			$settings['ga_product_identifier'] = $params['ga_product_identifier'];
+		}
+
+		$event_toggles = [
+			'ga_ecommerce_tracking_enabled',
+			'ga_event_tracking_enabled',
+			'ga_enhanced_remove_from_cart_enabled',
+			'ga_enhanced_product_impression_enabled',
+			'ga_enhanced_product_click_enabled',
+			'ga_enhanced_product_detail_view_enabled',
+			'ga_enhanced_checkout_process_enabled',
+		];
+		foreach ( $event_toggles as $toggle ) {
+			if ( isset( $params[ $toggle ] ) && in_array( $params[ $toggle ], [ 'yes', 'no' ], true ) ) {
+				$settings[ $toggle ] = $params[ $toggle ];
+			}
+		}
 	}
 
 	update_option( 'woocommerce_google_analytics_settings', $settings );

--- a/tests/e2e/utils/api.js
+++ b/tests/e2e/utils/api.js
@@ -34,11 +34,14 @@ export function apiWP() {
 /**
  * Creates a simple product.
  *
+ * @param {Object} overrides Product fields to merge over the default config
+ *                           (e.g. a `sku` for product identifier tests).
+ *
  * @return {number} Product ID of the created product.
  */
-export async function createSimpleProduct() {
+export async function createSimpleProduct( overrides = {} ) {
 	return await api()
-		.post( 'products', config.products.simple )
+		.post( 'products', { ...config.products.simple, ...overrides } )
 		.then( ( response ) => response.data.id );
 }
 
@@ -139,9 +142,12 @@ export async function deleteTaxRate( taxRateID ) {
 
 /**
  * Set test settings.
+ *
+ * @param {Object} settings Settings overrides to apply on top of the test
+ *                          defaults (e.g. `{ ga_product_identifier: 'product_sku' }`).
  */
-export async function setSettings() {
-	await api().post( 'ga4w-test/settings' );
+export async function setSettings( settings = {} ) {
+	await api().post( 'ga4w-test/settings', settings );
 }
 
 /**

--- a/tests/e2e/utils/customer.js
+++ b/tests/e2e/utils/customer.js
@@ -327,51 +327,37 @@ export async function storeApiBatchDecreaseCartQuantity(
 }
 
 /**
- * Perform checkout steps to purchase a product.
+ * Perform checkout steps to purchase a product through the block checkout on
+ * the default checkout page. For the classic shortcode form, use
+ * classicCheckout() instead.
  *
  * @param {Page} page
  *
- * @return {number} Order number.
+ * @return {string} Order number.
  */
 export async function checkout( page ) {
 	const user = config.addresses.customer.billing;
 
 	await page.goto( 'checkout' );
 
-	if ( await page.locator( '#billing_first_name' ).isVisible() ) {
-		await page.locator( '#billing_first_name' ).fill( user.firstname );
-		await page.locator( '#billing_last_name' ).fill( user.lastname );
-		await page
-			.locator( '#billing_address_1' )
-			.fill( user.addressfirstline );
-		await page.locator( '#billing_city' ).fill( user.city );
-		await page.locator( '#billing_state' ).selectOption( user.state );
-		await page.locator( '#billing_postcode' ).fill( user.postcode );
-		await page.locator( '#billing_phone' ).fill( user.phone );
-		await page.locator( '#billing_email' ).fill( user.email );
+	await page.getByLabel( 'Email address' ).fill( user.email );
+	await page.getByLabel( 'First name' ).fill( user.firstname );
+	await page.getByLabel( 'Last name' ).fill( user.lastname );
+	await page
+		.getByLabel( 'Address', { exact: true } )
+		.fill( user.addressfirstline );
+	await page.getByLabel( 'City' ).fill( user.city );
+	await page.getByLabel( 'ZIP Code' ).fill( user.postcode );
 
-		await page.locator( 'text=Cash on delivery' ).click();
-		await expect( page.locator( 'div.payment_method_cod' ) ).toBeVisible();
+	const stateField = page.getByRole( 'combobox', { name: /State$/ } );
+	const stateFieldTagName = await stateField.evaluate(
+		( element ) => element.tagName
+	);
+	if ( stateFieldTagName === 'SELECT' ) {
+		await stateField.selectOption( user.statename );
 	} else {
-		await page.getByLabel( 'Email address' ).fill( user.email );
-		await page.getByLabel( 'First name' ).fill( user.firstname );
-		await page.getByLabel( 'Last name' ).fill( user.lastname );
-		await page
-			.getByLabel( 'Address', { exact: true } )
-			.fill( user.addressfirstline );
-		await page.getByLabel( 'City' ).fill( user.city );
-		await page.getByLabel( 'ZIP Code' ).fill( user.postcode );
-
-		const stateField = page.getByRole( 'combobox', { name: /State$/ } );
-		const stateFieldTagName = await stateField.evaluate(
-			( element ) => element.tagName
-		);
-		if ( stateFieldTagName === 'SELECT' ) {
-			stateField.selectOption( user.statename );
-		} else {
-			// compatibility-code "WC < 9.2"
-			stateField.fill( user.statename );
-		}
+		// compatibility-code "WC < 9.2"
+		await stateField.fill( user.statename );
 	}
 
 	//TODO: See if there's an alternative method to click the button without relying on waitForTimeout.

--- a/tests/e2e/utils/customer.js
+++ b/tests/e2e/utils/customer.js
@@ -389,3 +389,51 @@ export async function checkout( page ) {
 		( el ) => el.textContent
 	);
 }
+
+/**
+ * Perform checkout steps on the classic shortcode checkout page (created by
+ * createClassicCheckoutPage()).
+ *
+ * Only the form differs from checkout(): the classic `[woocommerce_checkout]`
+ * form posts through wc-ajax=checkout instead of the Store API. The
+ * order-received confirmation is rendered by the block theme's Order
+ * Confirmation template either way, so the same confirmation markup is
+ * asserted here.
+ *
+ * @param {Page} page
+ *
+ * @return {string} Order number.
+ */
+export async function classicCheckout( page ) {
+	const user = config.addresses.customer.billing;
+
+	await page.goto( 'classic-checkout' );
+
+	await page.locator( '#billing_first_name' ).fill( user.firstname );
+	await page.locator( '#billing_last_name' ).fill( user.lastname );
+	await page.locator( '#billing_address_1' ).fill( user.addressfirstline );
+	await page.locator( '#billing_city' ).fill( user.city );
+	await page.locator( '#billing_state' ).selectOption( user.state );
+	await page.locator( '#billing_postcode' ).fill( user.postcode );
+	await page.locator( '#billing_phone' ).fill( user.phone );
+	await page.locator( '#billing_email' ).fill( user.email );
+
+	await page.locator( 'text=Cash on delivery' ).click();
+	await expect( page.locator( 'div.payment_method_cod' ) ).toBeVisible();
+
+	// Address changes trigger update_order_review refreshes that overlay the
+	// form. Waiting on a specific request would race (a pre-selected gateway
+	// fires none on click), so wait for the overlay to be gone instead; the
+	// place-order click's own actionability wait covers any late refresh.
+	await expect( page.locator( '.blockUI.blockOverlay' ) ).toHaveCount( 0 );
+	await page.locator( '#place_order' ).click();
+
+	await expect(
+		page.locator( '.wc-block-order-confirmation-status' )
+	).toContainText( 'order has been received' );
+
+	return await page.$eval(
+		'.wc-block-order-confirmation-summary-list-item__value',
+		( el ) => el.textContent
+	);
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR extends the E2E suite to cover several happy paths that are sensitive to store settings and to WP/WC version changes, plus the test infrastructure needed to drive them.

- Purchase coverage split by checkout form: a new test in the blocks spec places an order through the `woocommerce/checkout` block, and the classic spec's purchase test now drives the order through the `[woocommerce_checkout]` shortcode form (a `wc-ajax=checkout` submission rather than the Store API) via a new `classicCheckout()` helper, so the two purchase tests exercise the two different checkout forms instead of duplicating each other. Both assert the purchase event reports the order's items, quantities, variation, totals, shipping, and transaction ID. The order-received confirmation is rendered by the block theme's Order Confirmation template for both forms; a true classic thankyou template would require a classic theme, which the suite does not use. The now-dead classic form branch inside the `checkout()` helper (unreachable since the default checkout page is the block checkout) is removed, with the classic path owned by `classicCheckout()`.
- SKU product identifier: new tests switch the `ga_product_identifier` setting to SKU and assert that `view_item` reports the product SKU, falls back to the `#id` form when a product has no SKU, and that a Store API add to cart on the block storefront also reports the SKU (a separate, server-resolved identifier path).
- Disabled event tracking: new tests assert that no ecommerce events reach GA when every event toggle is off (while the tracking scripts still load, verified through `window.ga4w.settings.events`), and that disabling only add to cart leaves the other events firing.
- Settings form: a new test asserts the integration settings form renders the product identifier select with its options, the tracking ID field, and every remaining control defined by `init_form_fields()`, so a dropped control or a mislabeled identifier option is caught.
- Test infrastructure: the test settings endpoint (`tests/e2e/test-data`) now accepts a product identifier override, and the per-event tracking toggles through the request body, and `createSimpleProduct()` / `setSettings()` accept overrides. All default to the previous behavior, so existing specs are unaffected.

### Checks:

* [x] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Detailed test instructions:

1. Start the test environment: `npm run wp-env:up`
2. Run the E2E test to confirm all the tests can pass: `npm run test:e2e`
3. View the E2E test run result for this PR to confirm that all tests passed.
   https://github.com/woocommerce/woocommerce-google-analytics-integration/actions/runs/30002235049/job/89189882792

### Changelog entry


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->