### PR TITLE
Add E2E coverage for admin, consent, and event flows

### DIFF
--- a/tests/e2e/specs/gtag-events/blocks-pages.test.js
+++ b/tests/e2e/specs/gtag-events/blocks-pages.test.js
@@ -1058,4 +1058,67 @@ test.describe( 'GTag events on block pages', () => {
 			} );
 		} );
 	} );
+
+	test( 'Select content event is sent from the shop page', async ( {
+		page,
+	} ) => {
+		const listEvent = trackGtagEvent( page, 'view_item_list' );
+		await page.goto( 'shop?orderby=date' );
+		await listEvent;
+
+		const event = trackGtagEvent( page, 'select_content' );
+		// Target the known product so the content id can be asserted exactly.
+		const productLink = page
+			.locator(
+				`li.post-${ simpleProductID } .wc-block-components-product-image a`
+			)
+			.first();
+		// A readable failure when tests added above push the product off the
+		// catalog's first page, instead of a click timeout.
+		await expect( productLink ).toBeVisible();
+
+		await Promise.all( [ event, productLink.click() ] );
+
+		await event.then( ( request ) => {
+			const data = getEventData( request, 'select_content' );
+			expect( data[ 'ep.content_type' ] ).toEqual( 'product' );
+			expect( data[ 'ep.content_id' ] ).toEqual(
+				simpleProductID.toString()
+			);
+		} );
+	} );
+
+	test( 'Select content event is sent when opening a related product by name', async ( {
+		page,
+	} ) => {
+		await createSimpleProduct(); // Create an additional product for related to show up.
+		await page.goto( `?p=${ simpleProductID }` );
+
+		// The title link inside the related Product Collection carries the
+		// viewProduct interactivity action, so clicking the product name
+		// fires the event before the browser navigates away.
+		const relatedTitleLink = page
+			.locator(
+				'[data-collection="woocommerce/product-collection/related"] .wp-block-post-title a'
+			)
+			.first();
+
+		// Skip on the click target itself, so a WC setup rendering the
+		// related section with an older markup variant skips instead of
+		// timing out on the click.
+		test.skip(
+			! ( await relatedTitleLink.count() ),
+			'This WC setup does not render a related Product Collection product link on the single product page.'
+		);
+
+		const event = trackGtagEvent( page, 'select_content' );
+
+		await Promise.all( [ event, relatedTitleLink.click() ] );
+
+		await event.then( ( request ) => {
+			const data = getEventData( request, 'select_content' );
+			expect( data[ 'ep.content_type' ] ).toEqual( 'product' );
+			expect( data[ 'ep.content_id' ] ).toBeTruthy();
+		} );
+	} );
 } );

--- a/tests/e2e/specs/gtag-events/disabled-events.test.js
+++ b/tests/e2e/specs/gtag-events/disabled-events.test.js
@@ -13,6 +13,7 @@ import {
 } from '../../utils/api';
 import {
 	blockProductAddToCart,
+	checkout,
 	storeApiAddToCart,
 	storeApiBatchDecreaseCartQuantity,
 } from '../../utils/customer';
@@ -54,6 +55,31 @@ function collectGtagEventNames( page ) {
 	return names;
 }
 
+// Every event the plugin can send. Absence is asserted against this list
+// rather than a whitelist of the collected names, because gtag emits automatic
+// events of its own (page_view, session_start, user_engagement).
+const PLUGIN_EVENTS = [
+	'purchase',
+	'add_to_cart',
+	'remove_from_cart',
+	'view_item_list',
+	'select_content',
+	'view_item',
+	'begin_checkout',
+	'add_shipping_info',
+	'add_payment_info',
+];
+
+const ALL_DISABLED_SETTINGS = {
+	ga_ecommerce_tracking_enabled: 'no',
+	ga_event_tracking_enabled: 'no',
+	ga_enhanced_remove_from_cart_enabled: 'no',
+	ga_enhanced_product_impression_enabled: 'no',
+	ga_enhanced_product_click_enabled: 'no',
+	ga_enhanced_product_detail_view_enabled: 'no',
+	ga_enhanced_checkout_process_enabled: 'no',
+};
+
 test.describe( 'Disabled event tracking', () => {
 	let productID;
 
@@ -68,15 +94,7 @@ test.describe( 'Disabled event tracking', () => {
 	test( 'No ecommerce events fire when all event tracking is disabled', async ( {
 		page,
 	} ) => {
-		await setSettings( {
-			ga_ecommerce_tracking_enabled: 'no',
-			ga_event_tracking_enabled: 'no',
-			ga_enhanced_remove_from_cart_enabled: 'no',
-			ga_enhanced_product_impression_enabled: 'no',
-			ga_enhanced_product_click_enabled: 'no',
-			ga_enhanced_product_detail_view_enabled: 'no',
-			ga_enhanced_checkout_process_enabled: 'no',
-		} );
+		await setSettings( ALL_DISABLED_SETTINGS );
 
 		const eventNames = collectGtagEventNames( page );
 
@@ -100,22 +118,47 @@ test.describe( 'Disabled event tracking', () => {
 		await page.goto( 'shop' );
 		await pageView;
 
-		// Assert against every event the plugin can send rather than a
-		// whitelist of the collected names, because gtag emits automatic
-		// events of its own (page_view, session_start, user_engagement).
-		const pluginEvents = [
-			'purchase',
-			'add_to_cart',
-			'remove_from_cart',
-			'view_item_list',
-			'select_content',
-			'view_item',
-			'begin_checkout',
-			'add_shipping_info',
-			'add_payment_info',
-		];
 		expect(
-			eventNames.filter( ( name ) => pluginEvents.includes( name ) )
+			eventNames.filter( ( name ) => PLUGIN_EVENTS.includes( name ) )
+		).toEqual( [] );
+	} );
+
+	// Walks the whole shopper journey with every toggle off so each surface
+	// (product click-through, product page, cart mutations, checkout, and the
+	// order confirmation where the server-side purchase capture runs) proves
+	// silent, not just the shop page interactions of the test above.
+	test( 'No events fire across a full purchase journey when all tracking is disabled', async ( {
+		page,
+	} ) => {
+		await setSettings( ALL_DISABLED_SETTINGS );
+
+		const eventNames = collectGtagEventNames( page );
+
+		// Clicking through from the shop exercises the select_content surface;
+		// the landing product page covers the view_item surface.
+		await page.goto( 'shop?orderby=date' );
+		await page
+			.getByRole( 'link', { name: 'Simple product' } )
+			.first()
+			.click();
+		// Wait for the product page before the Store API calls, both to avoid
+		// evaluating on the dying shop document and to guarantee the
+		// view_item surface was actually reached (a later goto would silently
+		// cancel an uncommitted navigation).
+		await expect(
+			page.locator( '.single_add_to_cart_button' ).first()
+		).toBeVisible();
+
+		await storeApiAddToCart( page, productID, 2 );
+		await storeApiBatchDecreaseCartQuantity( page, productID, 1 );
+		await checkout( page );
+
+		const pageView = trackGtagEvent( page, 'page_view' );
+		await page.goto( 'shop' );
+		await pageView;
+
+		expect(
+			eventNames.filter( ( name ) => PLUGIN_EVENTS.includes( name ) )
 		).toEqual( [] );
 	} );
 

--- a/tests/e2e/specs/installation.test.js
+++ b/tests/e2e/specs/installation.test.js
@@ -1,0 +1,67 @@
+/**
+ * External dependencies
+ */
+const { test, expect } = require( '@playwright/test' );
+
+/**
+ * Internal dependencies
+ */
+import { apiWP } from '../utils/api';
+
+test.use( { storageState: process.env.ADMINSTATE } );
+
+const PLUGIN_SLUG = 'woocommerce-google-analytics-integration';
+const PLUGIN_REST_ROUTE = `plugins/${ PLUGIN_SLUG }/${ PLUGIN_SLUG }`;
+
+// A fatal during (de)activation surfaces as an error notice on the plugins
+// screen, so asserting no error notice after each action is the observable
+// signal. The suite runs with a single worker, so no other test runs while the
+// plugin is briefly deactivated; the REST calls pin the starting state (an
+// earlier failed run may have left the plugin off) and restore it on the way
+// out even when an assertion fails.
+test( 'Plugin deactivates and reactivates without errors', async ( {
+	page,
+} ) => {
+	await apiWP().put( PLUGIN_REST_ROUTE, { status: 'active' } );
+
+	try {
+		await page.goto( '/wp-admin/plugins.php' );
+
+		// The row's data-plugin attribute is always the plugin file path. The
+		// action links' id attributes are avoided because their slug half
+		// comes from the wp.org updates API and falls back to a different
+		// value when the environment is offline.
+		const pluginRow = page.locator(
+			`tr[data-plugin="${ PLUGIN_SLUG }/${ PLUGIN_SLUG }.php"]`
+		);
+		const deactivateLink = pluginRow.getByRole( 'link', {
+			name: /^Deactivate/,
+		} );
+		await expect( deactivateLink ).toBeVisible();
+		await deactivateLink.click();
+
+		await expect( page.getByText( 'Plugin deactivated.' ) ).toBeVisible();
+		// Hidden notice templates ship with the admin markup, so only a
+		// visible error notice counts.
+		await expect( page.locator( '.notice-error:visible' ) ).toHaveCount(
+			0
+		);
+
+		const activateLink = pluginRow.getByRole( 'link', {
+			name: /^Activate/,
+		} );
+		await expect( activateLink ).toBeVisible();
+		// Async admin notices keep shifting the layout after the deactivation
+		// reload, which can keep the click's stability check from settling.
+		// Navigating to the link's URL performs the same nonce-carrying
+		// activation request without depending on layout stability.
+		await page.goto( await activateLink.evaluate( ( el ) => el.href ) );
+
+		await expect( page.getByText( 'Plugin activated.' ) ).toBeVisible();
+		await expect( page.locator( '.notice-error:visible' ) ).toHaveCount(
+			0
+		);
+	} finally {
+		await apiWP().put( PLUGIN_REST_ROUTE, { status: 'active' } );
+	}
+} );

--- a/tests/e2e/specs/integration-settings.test.js
+++ b/tests/e2e/specs/integration-settings.test.js
@@ -3,7 +3,18 @@
  */
 const { test, expect } = require( '@playwright/test' );
 
+/**
+ * Internal dependencies
+ */
+import { clearSettings } from '../utils/api';
+
 test.use( { storageState: process.env.ADMINSTATE } );
+
+// The save test below writes real settings through the form; remove them so
+// later specs start from their own setSettings() baseline.
+test.afterAll( async () => {
+	await clearSettings();
+} );
 
 const SETTINGS_URL =
 	'/wp-admin/admin.php?page=wc-settings&tab=integration&section=google_analytics';
@@ -20,8 +31,8 @@ test( 'Able to setup in WooCommerce > Settings > Integration', async ( {
 
 // The settings form is defined by the plugin's init_form_fields(). Asserting the
 // controls render guards against a control being dropped (and the identifier
-// select against mislabeled options). The save mechanism itself is WooCommerce
-// core and is not exercised here.
+// select against mislabeled options). The save round-trip is covered by the
+// test below.
 test( 'Settings form renders the plugin controls', async ( { page } ) => {
 	await page.goto( SETTINGS_URL );
 
@@ -57,4 +68,76 @@ test( 'Settings form renders the plugin controls', async ( { page } ) => {
 			page.locator( `#woocommerce_google_analytics_${ control }` )
 		).toBeVisible();
 	}
+} );
+
+// Complements the render test above by exercising the full save round-trip.
+test( 'Settings can be saved and persist across a reload', async ( {
+	page,
+} ) => {
+	await page.goto( SETTINGS_URL );
+
+	// A unique, clearly fake id: a value used elsewhere in the suite could
+	// false-pass the persistence assertion if earlier state leaked through.
+	await page
+		.locator( '#woocommerce_google_analytics_ga_id' )
+		.fill( 'G-E2ETEST01' );
+	// The non-default option, so a save that silently falls back to the
+	// field default would fail the assertion below.
+	await page
+		.locator( '#woocommerce_google_analytics_ga_product_identifier' )
+		.selectOption( 'product_id' );
+	await page
+		.locator( '#woocommerce_google_analytics_ga_linker_cross_domains' )
+		.fill( 'example.com' );
+
+	const checkedBoxes = [
+		'ga_support_display_advertising',
+		'ga_linker_allow_incoming_enabled',
+		'ga_ecommerce_tracking_enabled',
+		'ga_event_tracking_enabled',
+		'ga_enhanced_remove_from_cart_enabled',
+		'ga_enhanced_product_impression_enabled',
+		'ga_enhanced_product_click_enabled',
+		'ga_enhanced_product_detail_view_enabled',
+		'ga_enhanced_checkout_process_enabled',
+	];
+	for ( const checkbox of checkedBoxes ) {
+		await page
+			.locator( `#woocommerce_google_analytics_${ checkbox }` )
+			.check();
+	}
+	// Unchecked persistence is the error-prone direction for checkboxes (a
+	// key missing from the POST must be stored as "no"), so one default-on
+	// toggle is saved unchecked.
+	await page
+		.locator( '#woocommerce_google_analytics_ga_404_tracking_enabled' )
+		.uncheck();
+
+	await page.getByRole( 'button', { name: 'Save changes' } ).click();
+	await expect(
+		page.getByText( 'Your settings have been saved.' )
+	).toBeVisible();
+
+	// A fresh GET forces the fields to re-render from the database; the save
+	// request itself re-renders from the same in-memory instance and would
+	// mask a persistence failure.
+	await page.goto( SETTINGS_URL );
+
+	await expect(
+		page.locator( '#woocommerce_google_analytics_ga_id' )
+	).toHaveValue( 'G-E2ETEST01' );
+	await expect(
+		page.locator( '#woocommerce_google_analytics_ga_product_identifier' )
+	).toHaveValue( 'product_id' );
+	await expect(
+		page.locator( '#woocommerce_google_analytics_ga_linker_cross_domains' )
+	).toHaveValue( 'example.com' );
+	for ( const checkbox of checkedBoxes ) {
+		await expect(
+			page.locator( `#woocommerce_google_analytics_${ checkbox }` )
+		).toBeChecked();
+	}
+	await expect(
+		page.locator( '#woocommerce_google_analytics_ga_404_tracking_enabled' )
+	).not.toBeChecked();
 } );

--- a/tests/e2e/specs/js-scripts/consent-defaults.test.js
+++ b/tests/e2e/specs/js-scripts/consent-defaults.test.js
@@ -1,0 +1,79 @@
+/**
+ * External dependencies
+ */
+const { test, expect } = require( '@playwright/test' );
+
+/**
+ * Internal dependencies
+ */
+import { setSettings, clearSettings } from '../../utils/api';
+
+/**
+ * Reads the consent default entries that reached the browser's dataLayer.
+ *
+ * gtag() pushes its arguments object onto the dataLayer, so entries are
+ * array-like; entries pushed as plain objects (gtm events) convert to empty
+ * arrays and fall out of the filter.
+ *
+ * @param {import('@playwright/test').Page} page
+ *
+ * @return {Object[]} The consent mode objects, in push order.
+ */
+async function getConsentDefaults( page ) {
+	return await page.evaluate( () =>
+		( window.dataLayer || [] )
+			.map( ( entry ) => Array.from( entry ) )
+			.filter(
+				( entry ) =>
+					entry[ 0 ] === 'consent' && entry[ 1 ] === 'default'
+			)
+			.map( ( entry ) => entry[ 2 ] )
+	);
+}
+
+test.describe( 'Consent mode defaults', () => {
+	test.beforeAll( async () => {
+		await setSettings();
+	} );
+
+	test.afterAll( async () => {
+		await clearSettings();
+	} );
+
+	// The test environment's snippet rewrites the default statuses (granting
+	// everything unless `consent_default` says otherwise), so the region list
+	// is the part that proves the plugin's EEA default reached the browser.
+	test( 'Default consent for the EEA regions reaches the dataLayer', async ( {
+		page,
+	} ) => {
+		await page.goto( 'shop?consent_default=denied' );
+
+		const defaults = await getConsentDefaults( page );
+		expect( defaults.length ).toBeGreaterThanOrEqual( 1 );
+
+		const eeaDefault = defaults[ 0 ];
+		expect( eeaDefault.analytics_storage ).toEqual( 'denied' );
+		expect( eeaDefault.ad_storage ).toEqual( 'denied' );
+		expect( eeaDefault.ad_user_data ).toEqual( 'denied' );
+		expect( eeaDefault.ad_personalization ).toEqual( 'denied' );
+		expect( eeaDefault.wait_for_update ).toEqual( 500 );
+		expect( eeaDefault.region ).toHaveLength( 32 );
+		expect( eeaDefault.region ).toEqual(
+			expect.arrayContaining( [ 'DE', 'FR', 'GB', 'CH', 'NO', 'IS' ] )
+		);
+	} );
+
+	test( 'A consent mode appended through the filter reaches the dataLayer', async ( {
+		page,
+	} ) => {
+		await page.goto( 'shop?ga4w_e2e_extra_consent_region=ES' );
+
+		const defaults = await getConsentDefaults( page );
+		expect( defaults.length ).toBeGreaterThanOrEqual( 2 );
+
+		const appended = defaults[ defaults.length - 1 ];
+		expect( appended.region ).toEqual( [ 'ES' ] );
+		expect( appended.analytics_storage ).toEqual( 'granted' );
+		expect( appended.ad_storage ).toEqual( 'granted' );
+	} );
+} );

--- a/tests/e2e/specs/js-scripts/wp-consent-api.test.js
+++ b/tests/e2e/specs/js-scripts/wp-consent-api.test.js
@@ -6,7 +6,13 @@ const { test, expect } = require( '@playwright/test' );
 /**
  * Internal dependencies
  */
-import { setSettings, clearSettings } from '../../utils/api';
+import {
+	createSimpleProduct,
+	setSettings,
+	clearSettings,
+} from '../../utils/api';
+import { storeApiAddToCart } from '../../utils/customer';
+import { getEventData, trackGtagEvent } from '../../utils/track-event';
 
 test.describe( 'WP Consent API Integration', () => {
 	test.beforeAll( async () => {
@@ -213,5 +219,64 @@ test.describe( 'WP Consent API Integration', () => {
 				analytics_storage: 'denied',
 			},
 		} );
+	} );
+
+	// The `gcs` parameter on each collect hit is the consent state Google's
+	// tooling (e.g. Tag Assistant) decodes: "G1" followed by the ad_storage
+	// and analytics_storage digits. Asserting it proves the events themselves
+	// carry the updated consent, not only that the update was dispatched.
+	// Every stage sets both categories explicitly because the plugin's
+	// defaults are region-scoped to the EEA: outside that region no default
+	// applies and the digits read "-".
+	test( 'Event hits carry the consent state in the `gcs` parameter', async ( {
+		page,
+	} ) => {
+		const firstProductID = await createSimpleProduct();
+		const secondProductID = await createSimpleProduct();
+		const thirdProductID = await createSimpleProduct();
+		const fourthProductID = await createSimpleProduct();
+
+		await page.goto( 'shop' );
+
+		await page.evaluate( () => {
+			window.wp_set_consent( 'statistics', 'allow' );
+			window.wp_set_consent( 'marketing', 'deny' );
+		} );
+		const deniedAdsAddEvent = trackGtagEvent( page, 'add_to_cart' );
+		await storeApiAddToCart( page, firstProductID );
+		expect(
+			getEventData( await deniedAdsAddEvent, 'add_to_cart' ).gcs
+		).toEqual( 'G101' );
+
+		// Granting marketing flips the ad_storage digit.
+		await page.evaluate( () =>
+			window.wp_set_consent( 'marketing', 'allow' )
+		);
+		const grantedAdsAddEvent = trackGtagEvent( page, 'add_to_cart' );
+		await storeApiAddToCart( page, secondProductID );
+		expect(
+			getEventData( await grantedAdsAddEvent, 'add_to_cart' ).gcs
+		).toEqual( 'G111' );
+
+		// Denying it again flips the digit back on subsequent hits.
+		await page.evaluate( () =>
+			window.wp_set_consent( 'marketing', 'deny' )
+		);
+		const revokedAdsAddEvent = trackGtagEvent( page, 'add_to_cart' );
+		await storeApiAddToCart( page, thirdProductID );
+		expect(
+			getEventData( await revokedAdsAddEvent, 'add_to_cart' ).gcs
+		).toEqual( 'G101' );
+
+		// Denying statistics flips the analytics_storage digit; the hit is
+		// still sent as a consent-restricted ping.
+		await page.evaluate( () =>
+			window.wp_set_consent( 'statistics', 'deny' )
+		);
+		const revokedStatsAddEvent = trackGtagEvent( page, 'add_to_cart' );
+		await storeApiAddToCart( page, fourthProductID );
+		expect(
+			getEventData( await revokedStatsAddEvent, 'add_to_cart' ).gcs
+		).toEqual( 'G100' );
 	} );
 } );

--- a/tests/e2e/test-snippets/test-snippets.php
+++ b/tests/e2e/test-snippets/test-snippets.php
@@ -34,6 +34,31 @@ add_filter(
 	}
 );
 
+/*
+ * Test-only consent mode appender. Pass `ga4w_e2e_extra_consent_region` to
+ * append an extra consent mode for that region, mirroring how merchants
+ * customize consent defaults through the documented filter. Runs after the
+ * grant-all snippet above so the appended mode is not rewritten by it.
+ */
+add_filter(
+	'woocommerce_ga_gtag_consent_modes',
+	function ( $modes ) {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( isset( $_GET['ga4w_e2e_extra_consent_region'] ) ) {
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$region  = sanitize_text_field( wp_unslash( $_GET['ga4w_e2e_extra_consent_region'] ) );
+			$modes[] = array(
+				'analytics_storage' => 'granted',
+				'ad_storage'        => 'granted',
+				'region'            => array( $region ),
+			);
+		}
+
+		return $modes;
+	},
+	20
+);
+
 /**
  * Snippet to allow the main.js file to be moved either to the page head or to
  * late in the footer after the extension inline data has been added to the page.

--- a/tests/e2e/test-snippets/test-snippets.php
+++ b/tests/e2e/test-snippets/test-snippets.php
@@ -47,11 +47,11 @@ add_filter(
 		if ( isset( $_GET['ga4w_e2e_extra_consent_region'] ) ) {
 			// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			$region  = sanitize_text_field( wp_unslash( $_GET['ga4w_e2e_extra_consent_region'] ) );
-			$modes[] = array(
+			$modes[] = [
 				'analytics_storage' => 'granted',
 				'ad_storage'        => 'granted',
-				'region'            => array( $region ),
-			);
+				'region'            => [ $region ],
+			];
 		}
 
 		return $modes;
@@ -91,10 +91,10 @@ add_action(
 					wp_enqueue_script(
 						WC_Google_Gtag_JS::get_instance()->script_handle . '-head',
 						WC_Google_Analytics_Integration::get_instance()->get_js_asset_url( 'main.js' ),
-						array(
+						[
 							...WC_Google_Analytics_Integration::get_instance()->get_js_asset_dependencies( 'main' ),
 							'google-tag-manager',
-						),
+						],
 						WC_Google_Analytics_Integration::get_instance()->get_js_asset_version( 'main' ),
 						false
 					);


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds E2E coverage for admin flows, consent mode delivery, and the remaining event tracking surfaces, so manual testing can focus on what automation cannot observe.

- Plugin activation: a new spec deactivates and reactivates the plugin through the plugins screen and asserts each action completes with its success notice and no visible error notice. REST calls pin the plugin to active before and after, so a failure cannot leave the rest of the suite running without the plugin. The row is located through its `data-plugin` attribute because the action links' id attributes depend on data from the wp.org updates API and change when the environment is offline.
- Settings saving: a new test fills every control with non-default values, saves through WooCommerce's settings handler, and asserts the values re-render from the database on a fresh GET.
- Consent mode delivery: new tests assert the EEA default consent entry reaches the browser's dataLayer, and that a consent mode appended through the `woocommerce_ga_gtag_consent_modes` filter is delivered as well. A new test additionally asserts the `gcs` parameter on event hits reflects `wp_set_consent()` updates in both directions for both `ad_storage` and `analytics_storage`, which is the wire-level data Tag Assistant decodes. One empirical constraint is documented in the test: the plugin's defaults are region-scoped to the EEA, so every stage sets both categories explicitly. Hits sent while a category is denied still arrive as consent-restricted pings.
- Select content: new tests cover the default shop page and opening a related product by its name, completing the click-through coverage across the storefront pages.
- Disabled tracking journey: a new test walks a product click-through, the product page, cart mutations, checkout, and the order confirmation with every event toggle off and asserts none of the plugin's events reach GA, extending the disabled coverage to every event surface, including the server-side purchase capture.
- Test infrastructure: the test snippets plugin gains a query-gated filter that appends a consent mode for a given region, mirroring the documented customization contract.

### Checks:

* [x] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Detailed test instructions:

1. Start the test environment: `npm run wp-env:up`
2. Run the E2E test to confirm all the tests can pass: `npm run test:e2e`
3. View the E2E test run result for this PR to confirm that all tests passed.
   https://github.com/woocommerce/woocommerce-google-analytics-integration/actions/runs/30073401752/job/89418847214

### Changelog entry


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
No issues found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->