### PR TITLE
Run the E2E Tests workflow on every pull request

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -3,10 +3,17 @@ name: E2E Tests
 on:
   push:
     branches:
+      - trunk
       - "release/**"
   pull_request:
-    branches:
-      - "release/**"
+    paths-ignore:
+      - "**.md"
+      - "docs/**"
+      - "wordpress_org_assets/**"
+      - ".github/ISSUE_TEMPLATE/**"
+      - "changelog.txt"
+      - "readme.txt"
+      - "languages/**"
   workflow_dispatch:
     inputs:
       wp-rc-version:


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The E2E Tests workflow previously ran only for pushes and pull requests around `release/**` branches, so the regressions it guards went unnoticed until release time. With the suite now at 85 tests and hardened for CI, this PR turns it into a per-PR check.

Trigger changes:

- `pull_request` now runs for every pull request, with a `paths-ignore` list that skips documentation-only changes.
- `push` now also covers `trunk` for a post-merge signal.
- Pushes to `release/**` keep their trigger. Releases are built from the latest commit on the release branch, but a `pull_request` run does not test that commit; it tests a temporary merge commit that GitHub creates from the PR and its target branch. The push trigger is what tests the exact commit that will be released.

### Checks:

* [x] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Detailed test instructions:

1. Confirm the E2E Tests workflow is triggered on this pull request itself.
2. Confirm the E2E Tests workflow run passes.
3. After merging, confirm the workflow also runs on the push to `trunk`.

### Changelog entry
