### PR TITLE
Fix purchase item discount and value tax/quantity basis

### DIFF
--- a/assets/js/src/tracker/data-formatting.js
+++ b/assets/js/src/tracker/data-formatting.js
@@ -207,7 +207,7 @@ export const purchase = ( { order } ) => {
 		return false;
 	}
 
-	const items = order.items.map( getProductFieldObject );
+	const items = order.items.map( ( item ) => getProductFieldObject( item ) );
 	const minorUnit = order.totals.currency_minor_unit;
 
 	return {

--- a/assets/js/src/tracker/data-formatting.js
+++ b/assets/js/src/tracker/data-formatting.js
@@ -207,23 +207,27 @@ export const purchase = ( { order } ) => {
 		return false;
 	}
 
+	const items = order.items.map( getProductFieldObject );
+	const minorUnit = order.totals.currency_minor_unit;
+
 	return {
 		transaction_id: order.id,
 		affiliation: order.affiliation,
 		currency: order.totals.currency_code,
+		// GA4 defines purchase value as the sum of price × quantity for the
+		// items, excluding tax and shipping.
+		// https://developers.google.com/analytics/devguides/collection/ga4/reference/events#purchase
 		value: formatPrice(
-			order.totals.total_price,
-			order.totals.currency_minor_unit
+			items.reduce(
+				( sum, { price = 0, quantity = 1 } ) =>
+					sum + Math.round( price * 10 ** minorUnit ) * quantity,
+				0
+			),
+			minorUnit
 		),
-		tax: formatPrice(
-			order.totals.tax_total,
-			order.totals.currency_minor_unit
-		),
-		shipping: formatPrice(
-			order.totals.shipping_total,
-			order.totals.currency_minor_unit
-		),
-		items: order.items.map( getProductFieldObject ),
+		tax: formatPrice( order.totals.tax_total, minorUnit ),
+		shipping: formatPrice( order.totals.shipping_total, minorUnit ),
+		items,
 	};
 };
 

--- a/assets/js/src/tracker/data-formatting.js
+++ b/assets/js/src/tracker/data-formatting.js
@@ -219,8 +219,12 @@ export const purchase = ( { order } ) => {
 		// https://developers.google.com/analytics/devguides/collection/ga4/reference/events#purchase
 		value: formatPrice(
 			items.reduce(
+				// Round each line to whole minor units: quantity may be decimal.
 				( sum, { price = 0, quantity = 1 } ) =>
-					sum + Math.round( price * 10 ** minorUnit ) * quantity,
+					sum +
+					Math.round(
+						Math.round( price * 10 ** minorUnit ) * quantity
+					),
 				0
 			),
 			minorUnit

--- a/includes/class-wc-abstract-google-analytics-js.php
+++ b/includes/class-wc-abstract-google-analytics-js.php
@@ -577,13 +577,22 @@ abstract class WC_Abstract_Google_Analytics_JS {
 				continue;
 			}
 
+			// Both amounts are per-unit and tax-exclusive so the client-side
+			// discount calculation compares values on the same basis. The
+			// catalog price from get_formatted_product() is not suitable here:
+			// it includes tax when the store enters prices inclusive of tax.
+			// A zero-quantity line has a zero total, so dividing by 1 keeps it at 0.
+			$unit_divisor = max( 1, (int) $item->get_quantity() );
+
 			$items[] = array_merge(
 				$this->get_formatted_product( $product ),
 				array(
 					'quantity'                    => $item->get_quantity(),
-					// The method get_total() will return the price after coupon discounts.
-					// https://github.com/woocommerce/woocommerce/blob/54eba223b8dec015c91a13423f9eced09e96f399/plugins/woocommerce/includes/class-wc-order-item-product.php#L308-L310
-					'price_after_coupon_discount' => $this->get_formatted_price( $item->get_total() ),
+					'prices'                      => array(
+						'price'               => $this->get_formatted_price( (float) $item->get_subtotal() / $unit_divisor ),
+						'currency_minor_unit' => wc_get_price_decimals(),
+					),
+					'price_after_coupon_discount' => $this->get_formatted_price( (float) $item->get_total() / $unit_divisor ),
 				)
 			);
 		}

--- a/includes/class-wc-abstract-google-analytics-js.php
+++ b/includes/class-wc-abstract-google-analytics-js.php
@@ -581,8 +581,10 @@ abstract class WC_Abstract_Google_Analytics_JS {
 			// discount calculation compares values on the same basis. The
 			// catalog price from get_formatted_product() is not suitable here:
 			// it includes tax when the store enters prices inclusive of tax.
-			// A zero-quantity line has a zero total, so dividing by 1 keeps it at 0.
-			$unit_divisor = max( 1, (int) $item->get_quantity() );
+			// Quantities may be decimal (woocommerce_stock_amount filter), so do not
+			// cast to int. A zero-quantity line has a zero total, so dividing by 1 keeps it at 0.
+			$quantity     = (float) $item->get_quantity();
+			$unit_divisor = $quantity > 0 ? $quantity : 1;
 
 			$items[] = array_merge(
 				$this->get_formatted_product( $product ),

--- a/tests/e2e/specs/gtag-events/blocks-pages.test.js
+++ b/tests/e2e/specs/gtag-events/blocks-pages.test.js
@@ -871,9 +871,7 @@ test.describe( 'GTag events on block pages', () => {
 			// excluding tax and shipping.
 			const itemsTotal = simpleProductPrice + simpleProductPrice + 18.99;
 			expect( data.cu ).toEqual( 'USD' );
-			expect( data[ 'epn.value' ] ).toEqual(
-				itemsTotal.toFixed( 2 ).toString()
-			);
+			expect( data[ 'epn.value' ] ).toEqual( itemsTotal.toFixed( 2 ) );
 			expect( data[ 'epn.tax' ] ).toEqual( '0' );
 			expect( data[ 'epn.shipping' ] ).toEqual( shipping.toString() );
 		} );

--- a/tests/e2e/specs/gtag-events/blocks-pages.test.js
+++ b/tests/e2e/specs/gtag-events/blocks-pages.test.js
@@ -867,11 +867,12 @@ test.describe( 'GTag events on block pages', () => {
 			);
 
 			const shipping = 10;
-			const total =
-				simpleProductPrice + simpleProductPrice + 18.99 + shipping;
+			// GA4 purchase value is the sum of item price × quantity,
+			// excluding tax and shipping.
+			const itemsTotal = simpleProductPrice + simpleProductPrice + 18.99;
 			expect( data.cu ).toEqual( 'USD' );
 			expect( data[ 'epn.value' ] ).toEqual(
-				total.toFixed( 2 ).toString()
+				itemsTotal.toFixed( 2 ).toString()
 			);
 			expect( data[ 'epn.tax' ] ).toEqual( '0' );
 			expect( data[ 'epn.shipping' ] ).toEqual( shipping.toString() );

--- a/tests/e2e/specs/gtag-events/classic-pages.test.js
+++ b/tests/e2e/specs/gtag-events/classic-pages.test.js
@@ -903,6 +903,47 @@ test.describe( 'GTag events on classic pages', () => {
 		}
 	} );
 
+	test( 'Purchase event reports no discount when prices are entered inclusive of tax', async ( {
+		page,
+	} ) => {
+		await setOptions( {
+			woocommerce_calc_taxes: 'yes',
+			woocommerce_prices_include_tax: 'yes',
+			woocommerce_tax_based_on: 'billing',
+		} );
+		const taxRateID = await createCaliforniaTaxRate();
+
+		try {
+			await simpleProductAddToCart( page, simpleProductID );
+
+			const event = trackGtagEvent( page, 'purchase', 'checkout' );
+			await checkout( page );
+
+			await event.then( ( request ) => {
+				const data = getEventData( request, 'purchase' );
+				// The item price is the tax-exclusive unit price (9.99 incl. 10%
+				// tax), and there is no coupon, so no `ds` (discount) field may be
+				// present — toEqual asserts the exact key set.
+				expect( data.product1 ).toEqual( {
+					id: simpleProductID.toString(),
+					nm: 'Simple product',
+					ca: 'Uncategorized',
+					qt: '1',
+					pr: '9.08',
+				} );
+				expect( data[ 'epn.tax' ] ).toEqual( '0.91' );
+				expect( data[ 'epn.shipping' ] ).toEqual( '10' );
+				expect( data[ 'epn.value' ] ).toEqual( '9.08' );
+			} );
+		} finally {
+			await deleteTaxRate( taxRateID );
+			await setOptions( {
+				woocommerce_calc_taxes: 'no',
+				woocommerce_prices_include_tax: 'no',
+			} );
+		}
+	} );
+
 	test( 'Begin checkout and purchase events use discounted item price', async ( {
 		page,
 	} ) => {

--- a/tests/e2e/specs/gtag-events/classic-pages.test.js
+++ b/tests/e2e/specs/gtag-events/classic-pages.test.js
@@ -859,9 +859,7 @@ test.describe( 'GTag events on classic pages', () => {
 			// excluding tax and shipping.
 			const itemsTotal = simpleProductPrice + simpleProductPrice + 18.99;
 			expect( data.cu ).toEqual( 'USD' );
-			expect( data[ 'epn.value' ] ).toEqual(
-				itemsTotal.toFixed( 2 ).toString()
-			);
+			expect( data[ 'epn.value' ] ).toEqual( itemsTotal.toFixed( 2 ) );
 			expect( data[ 'epn.tax' ] ).toEqual( '0' );
 			expect( data[ 'epn.shipping' ] ).toEqual( shipping.toString() );
 		} );

--- a/tests/e2e/specs/gtag-events/classic-pages.test.js
+++ b/tests/e2e/specs/gtag-events/classic-pages.test.js
@@ -855,11 +855,12 @@ test.describe( 'GTag events on classic pages', () => {
 			);
 
 			const shipping = 10;
-			const total =
-				simpleProductPrice + simpleProductPrice + 18.99 + shipping;
+			// GA4 purchase value is the sum of item price × quantity,
+			// excluding tax and shipping.
+			const itemsTotal = simpleProductPrice + simpleProductPrice + 18.99;
 			expect( data.cu ).toEqual( 'USD' );
 			expect( data[ 'epn.value' ] ).toEqual(
-				total.toFixed( 2 ).toString()
+				itemsTotal.toFixed( 2 ).toString()
 			);
 			expect( data[ 'epn.tax' ] ).toEqual( '0' );
 			expect( data[ 'epn.shipping' ] ).toEqual( shipping.toString() );
@@ -893,6 +894,10 @@ test.describe( 'GTag events on classic pages', () => {
 				} );
 				expect( data[ 'epn.tax' ] ).toEqual( '1' );
 				expect( data[ 'epn.shipping' ] ).toEqual( '10' );
+				// Value excludes both the tax and the shipping totals.
+				expect( data[ 'epn.value' ] ).toEqual(
+					simpleProductPrice.toString()
+				);
 			} );
 		} finally {
 			await deleteTaxRate( taxRateID );
@@ -960,6 +965,8 @@ test.describe( 'GTag events on classic pages', () => {
 				pr: discountedPrice,
 				ds: '2',
 			} );
+			// Value uses the discounted item price.
+			expect( data[ 'epn.value' ] ).toEqual( discountedPrice );
 		} );
 	} );
 } );

--- a/tests/unit-tests/DataFormatting.php
+++ b/tests/unit-tests/DataFormatting.php
@@ -497,9 +497,87 @@ class DataFormatting extends EventsDataTest {
 
 		$this->assertEquals( $order_item->get_quantity(), $item['quantity'] );
 		$this->assertEquals(
-			$this->gtag->get_formatted_price( $order_item->get_total() ),
+			$this->gtag->get_formatted_price( $order_item->get_subtotal() / $order_item->get_quantity() ),
+			$item['prices']['price']
+		);
+		$this->assertEquals(
+			$this->gtag->get_formatted_price( $order_item->get_total() / $order_item->get_quantity() ),
 			$item['price_after_coupon_discount']
 		);
+	}
+
+	/**
+	 * Create an order containing one line item with explicit subtotal/total values.
+	 *
+	 * @param float $catalog_price Product catalog price (may be tax-inclusive in the simulated store).
+	 * @param int   $quantity      Line item quantity.
+	 * @param float $subtotal      Tax-exclusive line subtotal (before coupon discounts).
+	 * @param float $total         Tax-exclusive line total (after coupon discounts).
+	 *
+	 * @return \WC_Order
+	 */
+	private function create_order_with_line_values( $catalog_price, $quantity, $subtotal, $total ) {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_regular_price( $catalog_price );
+		$product->set_price( $catalog_price );
+		$product->save();
+
+		$order = wc_create_order();
+		$order->add_product(
+			$product,
+			$quantity,
+			[
+				'subtotal' => $subtotal,
+				'total'    => $total,
+			]
+		);
+		$order->save();
+
+		return $order;
+	}
+
+	/**
+	 * Test that item prices come from the tax-exclusive order line, not the
+	 * catalog price. With prices entered inclusive of tax, using the catalog
+	 * price produced a false discount equal to the tax (ticket case 1:
+	 * 95 incl. 6% tax, line subtotal 89.62).
+	 *
+	 * @return void
+	 */
+	public function test_get_formatted_order_item_price_is_per_unit_tax_exclusive() {
+		$order = $this->create_order_with_line_values( 95, 1, 89.62, 89.62 );
+		$item  = $this->gtag->get_formatted_order( $order )['items'][0];
+
+		$this->assertEquals( 8962, $item['prices']['price'] );
+		$this->assertEquals( 8962, $item['price_after_coupon_discount'] );
+	}
+
+	/**
+	 * Test that with a coupon both amounts stay per-unit and tax-exclusive
+	 * (ticket case 3: 10% coupon on a 89.62 line).
+	 *
+	 * @return void
+	 */
+	public function test_get_formatted_order_item_price_after_coupon_is_per_unit() {
+		$order = $this->create_order_with_line_values( 95, 1, 89.62, 80.66 );
+		$item  = $this->gtag->get_formatted_order( $order )['items'][0];
+
+		$this->assertEquals( 8962, $item['prices']['price'] );
+		$this->assertEquals( 8066, $item['price_after_coupon_discount'] );
+	}
+
+	/**
+	 * Test that a line total not evenly divisible by quantity rounds to the
+	 * nearest minor unit (179.25 / 2 = 89.625 -> 89.63).
+	 *
+	 * @return void
+	 */
+	public function test_get_formatted_order_item_price_rounds_per_unit_amounts() {
+		$order = $this->create_order_with_line_values( 95, 2, 179.25, 179.25 );
+		$item  = $this->gtag->get_formatted_order( $order )['items'][0];
+
+		$this->assertEquals( 8963, $item['prices']['price'] );
+		$this->assertEquals( 8963, $item['price_after_coupon_discount'] );
 	}
 
 	/**

--- a/tests/unit-tests/DataFormatting.php
+++ b/tests/unit-tests/DataFormatting.php
@@ -510,7 +510,7 @@ class DataFormatting extends EventsDataTest {
 	 * Create an order containing one line item with explicit subtotal/total values.
 	 *
 	 * @param float $catalog_price Product catalog price (may be tax-inclusive in the simulated store).
-	 * @param int   $quantity      Line item quantity.
+	 * @param float $quantity      Line item quantity (decimal if woocommerce_stock_amount allows it).
 	 * @param float $subtotal      Tax-exclusive line subtotal (before coupon discounts).
 	 * @param float $total         Tax-exclusive line total (after coupon discounts).
 	 *
@@ -578,6 +578,32 @@ class DataFormatting extends EventsDataTest {
 
 		$this->assertEquals( 8963, $item['prices']['price'] );
 		$this->assertEquals( 8963, $item['price_after_coupon_discount'] );
+	}
+
+	/**
+	 * Test that decimal quantities (enabled by extensions via the
+	 * woocommerce_stock_amount filter) produce the correct per-unit price
+	 * instead of being truncated to an integer.
+	 *
+	 * @return void
+	 */
+	public function test_get_formatted_order_item_price_supports_decimal_quantity() {
+		// Core registers intval on this filter; decimal-quantity extensions swap it for floatval.
+		remove_filter( 'woocommerce_stock_amount', 'intval' );
+		add_filter( 'woocommerce_stock_amount', 'floatval' );
+
+		try {
+			// 0.5 units of a 10.00 product: line subtotal and total are 5.00.
+			$order = $this->create_order_with_line_values( 10, 0.5, 5, 5 );
+			$item  = $this->gtag->get_formatted_order( $order )['items'][0];
+
+			$this->assertEquals( 0.5, $item['quantity'] );
+			$this->assertEquals( 1000, $item['prices']['price'] );
+			$this->assertEquals( 1000, $item['price_after_coupon_discount'] );
+		} finally {
+			remove_filter( 'woocommerce_stock_amount', 'floatval' );
+			add_filter( 'woocommerce_stock_amount', 'intval' );
+		}
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR fixes two related problems in the data the plugin sends to Google Analytics for the `purchase` event.

#### Issue 1 — false or inflated item discounts (#641)

To report a discount on a purchased item, the plugin compared two prices: the product's catalog price and the amount actually paid for the order line. Those two numbers were not comparable — the catalog price is **per unit** and, in stores that enter prices *including* tax, it **includes tax**; the paid amount is the **whole line** (all units) **without tax**. Any difference between them was reported to GA as a "discount".

In a store with a product priced 95 including 6% tax, this is what GA received:

| Order | What GA received | What is wrong |
|---|---|---|
| 1 unit, no coupon | `price: 89.62`, **`discount: 5.38`** | There was no discount — the 5.38 is the tax. |
| 2 units, no coupon | **`price: 95`**, no discount | Price is now the tax-inclusive catalog price, because the two-unit line total happens to be larger than the single-unit catalog price. |
| 1 unit, 10% coupon | `price: 80.66`, **`discount: 14.34`** | The real discount is 8.96; the reported one is the discount plus the tax. |

Stores that enter prices *excluding* tax were affected too, just less visibly: with a coupon and more than one unit, the discount was silently dropped (`price: 95`, no discount, instead of `price: 85.50`, `discount: 9.50`).

#### Issue 2 — purchase revenue included tax and shipping (#642)

The event-level `value` (the revenue GA attributes to the purchase) was taken from the WooCommerce order total, which includes tax and shipping. Google's GA4 reference defines `value` as the sum of item price × quantity, explicitly **excluding** tax and shipping — and the plugin already followed that definition for the checkout events (`begin_checkout`, `add_shipping_info`, `add_payment_info`), so `purchase` disagreed with the rest of the funnel.

For the same 95 product (1 unit, no coupon), GA received `value: 95` alongside `tax: 5.38` — the tax counted twice; the expected value is 89.62.

#### The fix

Every amount for a purchased item is now taken from the **order line** rather than the catalog, and expressed on one consistent basis: **per unit, excluding tax**. The pre-coupon and post-coupon unit prices then compare like for like, so `discount` is reported only when a coupon actually reduced the price, and `price` is always the tax-exclusive unit price the customer paid.

The purchase `value` is calculated from those item prices (price × quantity, summed), so it excludes tax and shipping as GA4 expects and matches the checkout events.

Result for the three orders above: `price: 89.62` with no discount / `value: 89.62`; `price: 89.62`, qty 2 / `value: 179.24`; `price: 80.66`, `discount: 8.96` / `value: 80.66`.

Closes #641, STORMA-174
Closes #642, STORMA-175

#### Screenshots

|Usecase|Before|After|
|---|---|---|
|1 unit, no coupon|<img width="1200" height="1348" alt="before-case1-qty1-2-thankyou" src="https://github.com/user-attachments/assets/399aa62e-94d5-4957-8ea1-f3d5bc42a8b0" />|<img width="1200" height="1348" alt="case1-qty1-2-thankyou" src="https://github.com/user-attachments/assets/7438c9fb-dfb8-4cf1-9720-c3616f4f26d8" />|
|2 units, no coupon|<img width="1200" height="1348" alt="before-case2-qty2-2-thankyou" src="https://github.com/user-attachments/assets/5bf9c438-f84b-4bfc-be4d-db0c6cb962ab" />|<img width="1200" height="1348" alt="case2-qty2-2-thankyou" src="https://github.com/user-attachments/assets/01f1b557-9fb1-467a-8d7a-645b3184e306" />|
|1 unit, 10% coupon|<img width="1200" height="1411" alt="before-case3-qty1-coupon-2-thankyou" src="https://github.com/user-attachments/assets/b7fb1eba-8d6a-4026-b951-f1a2c96a22b9" />|<img width="1200" height="1411" alt="case3-qty1-coupon-2-thankyou" src="https://github.com/user-attachments/assets/ae281c2e-05fc-4a26-b34f-e326d6705921" />|

#### Things reviewers should be aware of

* **Reported GA revenue changes.** `value` drops from the gross order total to net item revenue (no tax, no shipping). This is what GA4 prescribes, but stores comparing GA revenue with WooCommerce reports will see the difference.
* **Order fees are not part of `value`.** Payment surcharges, or plugins that implement discounts as negative fees instead of coupons, are no longer reflected in `value`. GA4 has no concept of fees, and the checkout events already excluded them. Coupon discounts are unaffected — WooCommerce spreads them into the line totals we now read.

### Checks:
* [x] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Detailed test instructions:

Setup: enable taxes, set WooCommerce > Settings > Tax to "Yes, I will enter prices inclusive of tax", add a standard tax rate (e.g. 6%), create a simple product priced 95, a 10% coupon, and make sure a zero-cost shipping method and a payment method are available. Inspect the `purchase` event with Google Tag Assistant, or by reading `window.dataLayer` on the order-received page.

1. Buy 1 unit without a coupon → item `price: 89.62`, **no** `discount`; event `value: 89.62`, `tax: 5.38`.
2. Buy 1 unit with the 10% coupon → item `price: 80.66`, `discount: 8.96`; event `value: 80.66`, `tax: 4.84`.
3. Buy 2 units without a coupon → item `price: 89.62`, `quantity: 2`, no `discount`; event `value: 179.24` (not the tax-inclusive `95` per unit that 2.3.0 sent).
4. Switch to prices *excluding* tax (or disable taxes) and buy 2 units with the 10% coupon → item `price: 85.50`, `discount: 9.50`; event `value: 171`.

Automated coverage: three new PHPUnit tests for the per-unit, tax-exclusive item amounts, plus updated and new E2E assertions checking that `value` excludes tax and shipping and uses the discounted item price.

### Changelog entry

> Fix - Purchase event no longer reports a false item discount in stores that enter prices inclusive of tax, and no longer drops coupon discounts for quantities above one; item price and discount are now per unit and tax-exclusive.
> Fix - Purchase event value now sums the item prices × quantity, excluding tax and shipping as GA4 expects, instead of the gross order total.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
No issues found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->