### PR TITLE
Bump minimum WordPress version to 7.0, tested up to 7.1

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -3,7 +3,7 @@
 	<description>Generally-applicable sniffs for WordPress plugins</description>
 
 	<!-- Set the minimum WP version -->
-	<config name="minimum_supported_wp_version" value="6.8"/>
+	<config name="minimum_supported_wp_version" value="7.0"/>
 
 	<rule ref="WordPress">
 		<!-- We don't require conforming to WP file naming -->

--- a/readme.txt
+++ b/readme.txt
@@ -1,8 +1,8 @@
 === Google Analytics for WooCommerce ===
 Contributors: woocommerce, automattic, claudiosanches, bor0, royho, laurendavissmith001, cshultz88, mmjones, tomalec, neosinner
 Tags: woocommerce, google analytics
-Requires at least: 6.9
-Tested up to: 7.0
+Requires at least: 7.0
+Tested up to: 7.1
 Stable tag: 2.4.0
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html

--- a/woocommerce-google-analytics-integration.php
+++ b/woocommerce-google-analytics-integration.php
@@ -8,9 +8,9 @@
  * Version: 2.4.0
  * WC requires at least: 10.9
  * WC tested up to: 11.0
- * Requires at least: 6.9
+ * Requires at least: 7.0
  * Requires Plugins: woocommerce
- * Tested up to: 7.0
+ * Tested up to: 7.1
  * Requires PHP: 7.4
  * License: GPLv3
  * License URI: https://www.gnu.org/licenses/gpl-3.0.html


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR bumps the minimum supported WordPress version to 7.0 and the tested up to version to 7.1, keeping the plugin on the L-1 support policy now that WordPress 7.1 is the current release.

### Checks:
<!-- Mark completed items with an [x] -->
* [ ] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changelog entry

> Update - Require WordPress 7.0+.
> Tweak - WordPress 7.1 compatibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->