### PR TITLE
Fix PHPCS deprecation warnings and update obsolete ruleset directives

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -34,15 +34,9 @@
 	</rule>
 
 	<!-- Include some other sniffs we want to enforce. -->
-	<rule ref="Generic.VersionControl.GitMergeConflict"/>
-	<rule ref="Generic.WhiteSpace.SpreadOperatorSpacingAfter"/>
 	<rule ref="PSR12.Classes.AnonClassDeclaration"/>
-	<rule ref="PSR12.Classes.ClassInstantiation"/>
 	<rule ref="PSR12.Files.ImportStatement"/>
-	<rule ref="PSR12.Functions.NullableTypeDeclaration"/>
-	<rule ref="PSR12.Functions.ReturnTypeDeclaration"/>
 	<rule ref="PSR12.Properties.ConstantVisibility"/>
-	<rule ref="PSR12.Traits.UseDeclaration"/>
 	<rule ref="Squiz.Classes.ClassDeclaration">
 		<exclude name="Squiz.Classes.ClassDeclaration.OpenBraceNewLine"/>
 		<exclude name="Squiz.Classes.ClassDeclaration.CloseBraceSameLine"/>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -3,7 +3,7 @@
 	<description>Generally-applicable sniffs for WordPress plugins</description>
 
 	<!-- Set the minimum WP version -->
-	<config name="minimum_supported_wp_version" value="7.0"/>
+	<config name="minimum_wp_version" value="7.0"/>
 
 	<rule ref="WordPress">
 		<!-- We don't require conforming to WP file naming -->
@@ -15,7 +15,6 @@
 		<exclude name="Squiz.Commenting.FunctionComment.MissingParamComment"/>
 		<exclude name="Squiz.Commenting.FunctionComment.ParamCommentFullStop"/>
 		<exclude name="Squiz.Commenting.InlineComment.InvalidEndChar"/>
-		<exclude name="Squiz.Commenting.LongConditionClosingComment"/>
 
 		<!-- No thanks -->
 		<exclude name="Universal.Operators.DisallowShortTernary"/>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -44,20 +44,20 @@
 	<rule ref="PSR12.Functions.ReturnTypeDeclaration"/>
 	<rule ref="PSR12.Properties.ConstantVisibility"/>
 	<rule ref="PSR12.Traits.UseDeclaration"/>
-	<rule ref="Squiz.Classes">
+	<rule ref="Squiz.Classes.ClassDeclaration">
 		<exclude name="Squiz.Classes.ClassDeclaration.OpenBraceNewLine"/>
 		<exclude name="Squiz.Classes.ClassDeclaration.CloseBraceSameLine"/>
 		<exclude name="Squiz.Classes.ClassDeclaration.SpaceBeforeKeyword"/>
 		<exclude name="Squiz.Classes.ClassDeclaration.SpaceBeforeCloseBrace"/>
-		<exclude name="Squiz.Classes.ClassFileName.NoMatch"/>
-		<exclude name="Squiz.Classes.ValidClassName.NotCamelCaps"/>
 	</rule>
 	<rule ref="Squiz.WhiteSpace.FunctionOpeningBraceSpace"/>
 
 	<!-- Set the appropriate text domain. -->
 	<rule ref="WordPress.WP.I18n">
 		<properties>
-			<property name="text_domain" type="array" value="woocommerce-google-analytics-integration"/>
+			<property name="text_domain" type="array">
+				<element value="woocommerce-google-analytics-integration"/>
+			</property>
 		</properties>
 	</rule>
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This issue was discovered while bumping the supported versions of WordPress.

`./vendor/bin/phpcs` printed a DEPRECATED notice and a WARNING before every scan. Fixing those surfaced two more directives in `phpcs.xml.dist` that had silently stopped doing anything, so this PR also brings the ruleset back in line with what WPCS 3.x provides.

1. **Fix deprecated syntax.** `text_domain` now uses `<element>` nodes, and `<rule ref="Squiz.Classes">` is replaced by a direct reference to the one sniff in that category the ruleset actually needs. The category reference was dragging in `DuplicateProperty`, a JavaScript-only sniff deprecated in PHPCS 3.9.0, which produced the WARNING. Excluding that sniff by name would also have silenced it, but an exclude naming a sniff that does not exist aborts PHPCS with exit code 3, so it would break the moment PHPCS 4.0 removes it.
2. **Update renamed and obsolete directives.** WPCS 3.0.0 renamed `minimum_supported_wp_version` to `minimum_wp_version` and silently ignores the old name, so the deprecation sniffs have been comparing against the WPCS default of 6.7 rather than the 7.0 this plugin declares. Also drops the exclusion for `Squiz.Commenting.LongConditionClosingComment`, which WPCS removed from `WordPress-Core` back in 0.12.0.
3. **Drop redundant references.** Six sniffs listed under "Include some other sniffs we want to enforce" have since been added to the WordPress standard, so referencing them again enforces nothing.

Worth knowing when reviewing: item 2 changes lint strictness, not just syntax. Findings for APIs deprecated between 6.7 and 7.0 now surface as errors rather than warnings. Nothing in the plugin triggers that today, so the scan is clean either way, but a future WPCS bump could surface as an error what would previously have been a warning. That is the intended behavior.

### Checks:
<!-- Mark completed items with an [x] -->
* [ ] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Detailed test instructions:

1. On `trunk`, run `./vendor/bin/phpcs` and note the DEPRECATED notice about `text_domain` and the WARNING about `Squiz.Classes.DuplicateProperty`.
2. Check out this branch and run `./vendor/bin/phpcs` again.
3. Confirm both messages are gone and the scan still reports no violations.

### Changelog entry
