### PR TITLE
Pin GitHub Actions to full commit SHAs

### DIFF
--- a/.github/workflows/branch-labels.yml
+++ b/.github/workflows/branch-labels.yml
@@ -12,4 +12,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set Labels
-        uses: woocommerce/grow/branch-label@actions-v3
+        uses: woocommerce/grow/branch-label@3a4249a1fc7e39a987d213e578cbcf32abd55980 # actions-v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,15 +18,15 @@ jobs:
       FORCE_COLOR: 2
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Prepare PHP
-        uses: woocommerce/grow/prepare-php@actions-v3
+        uses: woocommerce/grow/prepare-php@3a4249a1fc7e39a987d213e578cbcf32abd55980 # actions-v3
         with:
           install-deps: "no"
 
       - name: Prepare node
-        uses: woocommerce/grow/prepare-node@actions-v3
+        uses: woocommerce/grow/prepare-node@3a4249a1fc7e39a987d213e578cbcf32abd55980 # actions-v3
         with:
           node-version-file: ".nvmrc"
           ignore-scripts: "no"
@@ -39,13 +39,13 @@ jobs:
 
       - name: Publish dev build to GitHub
         if: ${{ github.event_name == 'push' && github.ref_name == 'trunk' }}
-        uses: woocommerce/grow/publish-extension-dev-build@actions-v3
+        uses: woocommerce/grow/publish-extension-dev-build@3a4249a1fc7e39a987d213e578cbcf32abd55980 # actions-v3
         with:
           extension-asset-path: woocommerce-google-analytics-integration.zip
 
       - name: Publish build artifact
         if: ${{ ! ( github.event_name == 'push' && github.ref_name == 'trunk' ) }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: woocommerce-google-analytics-integration.zip
           path: ${{ github.workspace }}/woocommerce-google-analytics-integration.zip

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,7 +61,7 @@ jobs:
     steps:
       # Checkout the private action repository
       - name: Checkout woo-product-deploy action
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           repository: woocommerce/woo-product-deploy
           ref: trunk

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -33,15 +33,15 @@ jobs:
       FORCE_COLOR: 2
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Prepare PHP
-        uses: woocommerce/grow/prepare-php@actions-v3
+        uses: woocommerce/grow/prepare-php@3a4249a1fc7e39a987d213e578cbcf32abd55980 # actions-v3
         with:
           install-deps: "no"
 
       - name: Prepare node
-        uses: woocommerce/grow/prepare-node@actions-v3
+        uses: woocommerce/grow/prepare-node@3a4249a1fc7e39a987d213e578cbcf32abd55980 # actions-v3
         with:
           node-version-file: ".nvmrc"
           ignore-scripts: "no"
@@ -79,7 +79,7 @@ jobs:
 
       - name: Archive e2e failure screenshots
         if: ${{ always() }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
             name: e2e-screenshots
             path: tests/e2e/test-results/report/**/*.png

--- a/.github/workflows/js-linting.yml
+++ b/.github/workflows/js-linting.yml
@@ -25,15 +25,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Prepare node
-        uses: woocommerce/grow/prepare-node@actions-v3
+        uses: woocommerce/grow/prepare-node@3a4249a1fc7e39a987d213e578cbcf32abd55980 # actions-v3
         with:
           node-version-file: ".nvmrc"
 
       - name: Prepare annotation formatter
-        uses: woocommerce/grow/eslint-annotation@actions-v3
+        uses: woocommerce/grow/eslint-annotation@3a4249a1fc7e39a987d213e578cbcf32abd55980 # actions-v3
 
       - name: Lint JavaScript and annotate linting errors
         run: npm run lint:js -- --quiet --format ./eslintFormatter.cjs

--- a/.github/workflows/php-coding-standards.yml
+++ b/.github/workflows/php-coding-standards.yml
@@ -23,7 +23,7 @@ jobs:
       should-run: ${{ steps.changes.outputs.php }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Check for relevant changes
         uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
@@ -43,10 +43,10 @@ jobs:
     if: needs.check-paths.outputs.should-run == 'true'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Prepare PHP
-        uses: woocommerce/grow/prepare-php@actions-v3
+        uses: woocommerce/grow/prepare-php@3a4249a1fc7e39a987d213e578cbcf32abd55980 # actions-v3
         with:
           php-version: 7.4
           tools: cs2pr

--- a/.github/workflows/php-hook-documentation.yml
+++ b/.github/workflows/php-hook-documentation.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           # Checks out a branch instead of a commit in detached HEAD state
           ref: ${{ github.head_ref }}
@@ -26,7 +26,7 @@ jobs:
         # This generates the documentation string. The `id` property is used to reference the output in the next step.
       - name: Generate hook documentation
         id: generate-hook-docs
-        uses: woocommerce/grow/hook-documentation@actions-v3
+        uses: woocommerce/grow/hook-documentation@3a4249a1fc7e39a987d213e578cbcf32abd55980 # actions-v3
         with:
           source-directories: includes/,woocommerce-google-analytics-integration.php
 

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -46,13 +46,13 @@ jobs:
     steps:
       - name: Get Release versions from Wordpress
         id: wp
-        uses: woocommerce/grow/get-plugin-releases@actions-v3
+        uses: woocommerce/grow/get-plugin-releases@3a4249a1fc7e39a987d213e578cbcf32abd55980 # actions-v3
         with:
           slug: wordpress
           releases: 2
       - name: Get Release versions from WooCommerce
         id: wc
-        uses: woocommerce/grow/get-plugin-releases@actions-v3
+        uses: woocommerce/grow/get-plugin-releases@3a4249a1fc7e39a987d213e578cbcf32abd55980 # actions-v3
         with:
           source: github
           slug: woocommerce/woocommerce
@@ -81,15 +81,15 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Prepare PHP
-        uses: woocommerce/grow/prepare-php@actions-v3
+        uses: woocommerce/grow/prepare-php@3a4249a1fc7e39a987d213e578cbcf32abd55980 # actions-v3
         with:
           php-version: "${{ matrix.php }}"
 
       - name: Set up MySQL
-        uses: woocommerce/grow/prepare-mysql@actions-v3
+        uses: woocommerce/grow/prepare-mysql@3a4249a1fc7e39a987d213e578cbcf32abd55980 # actions-v3
 
       - name: Install svn (used for installing WP versions)
         run: sudo apt-get -y install subversion
@@ -122,15 +122,15 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Prepare PHP
-        uses: woocommerce/grow/prepare-php@actions-v3
+        uses: woocommerce/grow/prepare-php@3a4249a1fc7e39a987d213e578cbcf32abd55980 # actions-v3
         with:
           php-version: "${{ inputs.php-version }}"
 
       - name: Prepare MySQL
-        uses: woocommerce/grow/prepare-mysql@actions-v3
+        uses: woocommerce/grow/prepare-mysql@3a4249a1fc7e39a987d213e578cbcf32abd55980 # actions-v3
 
       - name: Install svn (used for installing WP versions)
         run: sudo apt-get -y install subversion

--- a/.github/workflows/prepare-release-via-deploy.yml
+++ b/.github/workflows/prepare-release-via-deploy.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Validate version format
         env:
@@ -46,7 +46,7 @@ jobs:
 
       - name: Create a pull request for the release
         id: prepare-release-pr
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const { default: script } = await import( `${ process.env.GITHUB_WORKSPACE }/.github/workflows/scripts/create-release-pr.mjs` );

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -27,10 +27,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Create branch & PR
-        uses: woocommerce/grow/prepare-extension-release@actions-v3
+        uses: woocommerce/grow/prepare-extension-release@3a4249a1fc7e39a987d213e578cbcf32abd55980 # actions-v3
         with:
           version: ${{ github.event.inputs.version }}
           type: ${{ github.event.inputs.type }}


### PR DESCRIPTION
### Changes proposed in this Pull Request

The WooCommerce GitHub organization intends to enforce full-commit-SHA pinning for GitHub Actions. This change replaces every mutable external Action tag or branch used by this repository with the current 40-character commit SHA and preserves the original human-readable ref in a trailing comment.

Immutable pins reduce supply-chain compromise risk if an upstream tag or branch is moved or an Action repository is compromised. Local actions and reusable workflows remain unchanged.

### Verification

- [x] Re-audited the current default branch and pinned every mutable external Action reference.
- [x] Independently re-resolved each distinct tag or branch and confirmed it matches the pinned SHA.
- [x] Confirmed the post-change scan reports zero mutable external Action references.
- [x] Parsed every changed workflow and composite-action YAML file successfully.
- [x] Ran git diff --check.
- [x] Confirmed the diff contains only intended uses: reference changes.

### Backward compatibility impact

No backward-compatibility impact. This changes CI and automation configuration only.

### Test steps

1. Inspect each changed uses: reference and confirm it is a full 40-character SHA with the original ref in a trailing comment.
2. Confirm repository workflows and composite actions load successfully in GitHub Actions.
3. Confirm the post-change SHA-pin scan reports zero findings.

### Changelog entry
