### PR TITLE
ci: add job-level timeout-minutes to workflow jobs

### DIFF
--- a/.github/workflows/branch-labels.yml
+++ b/.github/workflows/branch-labels.yml
@@ -10,6 +10,7 @@ jobs:
       contents: read
       pull-requests: write
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Set Labels
         uses: woocommerce/grow/branch-label@3a4249a1fc7e39a987d213e578cbcf32abd55980 # actions-v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,7 @@ jobs:
   BuildExtensionBundle:
     name: Build extension bundle
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     env:
       FORCE_COLOR: 2
     steps:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,6 +57,7 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       # Checkout the private action repository

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -29,6 +29,7 @@ jobs:
   E2ETests:
     name: E2E Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     env:
       FORCE_COLOR: 2
     steps:

--- a/.github/workflows/js-linting.yml
+++ b/.github/workflows/js-linting.yml
@@ -23,6 +23,7 @@ jobs:
   JSLintingCheck:
     name: Lint JavaScript
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Checkout repository
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6

--- a/.github/workflows/php-coding-standards.yml
+++ b/.github/workflows/php-coding-standards.yml
@@ -19,6 +19,7 @@ jobs:
   check-paths:
     name: Check changed files
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       should-run: ${{ steps.changes.outputs.php }}
     steps:
@@ -39,6 +40,7 @@ jobs:
   phpcs:
     name: PHP coding standards
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     needs: check-paths
     if: needs.check-paths.outputs.should-run == 'true'
     steps:

--- a/.github/workflows/php-hook-documentation.yml
+++ b/.github/workflows/php-hook-documentation.yml
@@ -16,6 +16,7 @@ jobs:
   HookDocumentation:
     name: Hook Documentation Generator
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Checkout the repository
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -40,6 +40,7 @@ jobs:
     if: github.event_name != 'workflow_dispatch'
     name: Get WP and WC version Matrix
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       wp-versions: ${{ steps.wp.outputs.versions }}
       wc-versions: ${{ steps.wc.outputs.versions }}
@@ -63,6 +64,7 @@ jobs:
     if: github.event_name != 'workflow_dispatch'
     name: PHP unit tests - PHP ${{ matrix.php }}, WP ${{ matrix.wp-version || 'latest' }}, WC ${{ matrix.wc-versions || 'latest' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     needs: GetMatrix
     strategy:
       matrix:
@@ -119,6 +121,7 @@ jobs:
     if: github.event_name == 'workflow_dispatch'
     name: PHP unit tests (for Release Candidates)
     runs-on: ubuntu-latest
+    timeout-minutes: 5
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/prepare-release-via-deploy.yml
+++ b/.github/workflows/prepare-release-via-deploy.yml
@@ -15,6 +15,7 @@ jobs:
   PrepareRelease:
     name: Prepare Release
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Checkout repository
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -25,6 +25,7 @@ jobs:
   PrepareRelease:
     name: Prepare Release
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Checkout repository
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6


### PR DESCRIPTION
Add a timeout to each job, so a hung job stops in minutes and not after six hours.

| Job | Median (30 d) | Max (30 d) | `timeout-minutes` |
| -- | -- | -- | -- |
| `branch-labels.yml` / SetLabels | 0.10 min | 0.13 min | 5 |
| `build.yml` / BuildExtensionBundle | 1.08 min | 1.77 min | 5 |
| `deploy.yml` / deploy | 10.55 min | 10.67 min | 15 |
| `e2e-tests.yml` / E2ETests | 11.67 min | 12.72 min | 15 |
| `js-linting.yml` / JSLintingCheck | 0.68 min | 0.73 min | 5 |
| `php-coding-standards.yml` / check-paths | 0.08 min | 0.23 min | 5 |
| `php-coding-standards.yml` / phpcs | 0.32 min | 0.43 min | 5 |
| `php-hook-documentation.yml` / HookDocumentation | 0.10 min | 0.13 min | 5 |
| `php-unit-tests.yml` / GetMatrix | 0.08 min | 0.13 min | 5 |
| `php-unit-tests.yml` / UnitTests (all matrix legs) | 0.88 min | 2.23 min | 5 |
| `php-unit-tests.yml` / ReleaseCandidateUnitTests | 0.80 min | 0.82 min | 5 |
| `prepare-release-via-deploy.yml` / PrepareRelease | 0.17 min | 0.17 min | 5 |
| `prepare-release.yml` / PrepareRelease | 0.13 min | 0.13 min | 5 |

Part of TESTOPS-272

### Changelog entry
