### PR TITLE
Pin nested GitHub Action dependencies to full SHAs

### DIFF
--- a/.github/workflows/branch-labels.yml
+++ b/.github/workflows/branch-labels.yml
@@ -13,4 +13,4 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Set Labels
-        uses: woocommerce/grow/branch-label@a81d3fca0166a02a4c25953d250d80d3612db4b8 # actions-v3
+        uses: woocommerce/grow/branch-label@b9c1e59aae9fdbe668b068ebd59c1545a88ea9fa # actions-v3.0.5

--- a/.github/workflows/branch-labels.yml
+++ b/.github/workflows/branch-labels.yml
@@ -13,4 +13,4 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Set Labels
-        uses: woocommerce/grow/branch-label@3a4249a1fc7e39a987d213e578cbcf32abd55980 # actions-v3
+        uses: woocommerce/grow/branch-label@a81d3fca0166a02a4c25953d250d80d3612db4b8 # actions-v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,12 +22,12 @@ jobs:
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Prepare PHP
-        uses: woocommerce/grow/prepare-php@3a4249a1fc7e39a987d213e578cbcf32abd55980 # actions-v3
+        uses: woocommerce/grow/prepare-php@a81d3fca0166a02a4c25953d250d80d3612db4b8 # actions-v3
         with:
           install-deps: "no"
 
       - name: Prepare node
-        uses: woocommerce/grow/prepare-node@3a4249a1fc7e39a987d213e578cbcf32abd55980 # actions-v3
+        uses: woocommerce/grow/prepare-node@a81d3fca0166a02a4c25953d250d80d3612db4b8 # actions-v3
         with:
           node-version-file: ".nvmrc"
           ignore-scripts: "no"
@@ -40,7 +40,7 @@ jobs:
 
       - name: Publish dev build to GitHub
         if: ${{ github.event_name == 'push' && github.ref_name == 'trunk' }}
-        uses: woocommerce/grow/publish-extension-dev-build@3a4249a1fc7e39a987d213e578cbcf32abd55980 # actions-v3
+        uses: woocommerce/grow/publish-extension-dev-build@a81d3fca0166a02a4c25953d250d80d3612db4b8 # actions-v3
         with:
           extension-asset-path: woocommerce-google-analytics-integration.zip
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,12 +22,12 @@ jobs:
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Prepare PHP
-        uses: woocommerce/grow/prepare-php@a81d3fca0166a02a4c25953d250d80d3612db4b8 # actions-v3
+        uses: woocommerce/grow/prepare-php@b9c1e59aae9fdbe668b068ebd59c1545a88ea9fa # actions-v3.0.5
         with:
           install-deps: "no"
 
       - name: Prepare node
-        uses: woocommerce/grow/prepare-node@a81d3fca0166a02a4c25953d250d80d3612db4b8 # actions-v3
+        uses: woocommerce/grow/prepare-node@b9c1e59aae9fdbe668b068ebd59c1545a88ea9fa # actions-v3.0.5
         with:
           node-version-file: ".nvmrc"
           ignore-scripts: "no"
@@ -40,7 +40,7 @@ jobs:
 
       - name: Publish dev build to GitHub
         if: ${{ github.event_name == 'push' && github.ref_name == 'trunk' }}
-        uses: woocommerce/grow/publish-extension-dev-build@a81d3fca0166a02a4c25953d250d80d3612db4b8 # actions-v3
+        uses: woocommerce/grow/publish-extension-dev-build@b9c1e59aae9fdbe668b068ebd59c1545a88ea9fa # actions-v3.0.5
         with:
           extension-asset-path: woocommerce-google-analytics-integration.zip
 

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -37,12 +37,12 @@ jobs:
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Prepare PHP
-        uses: woocommerce/grow/prepare-php@a81d3fca0166a02a4c25953d250d80d3612db4b8 # actions-v3
+        uses: woocommerce/grow/prepare-php@b9c1e59aae9fdbe668b068ebd59c1545a88ea9fa # actions-v3.0.5
         with:
           install-deps: "no"
 
       - name: Prepare node
-        uses: woocommerce/grow/prepare-node@a81d3fca0166a02a4c25953d250d80d3612db4b8 # actions-v3
+        uses: woocommerce/grow/prepare-node@b9c1e59aae9fdbe668b068ebd59c1545a88ea9fa # actions-v3.0.5
         with:
           node-version-file: ".nvmrc"
           ignore-scripts: "no"

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -37,12 +37,12 @@ jobs:
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Prepare PHP
-        uses: woocommerce/grow/prepare-php@3a4249a1fc7e39a987d213e578cbcf32abd55980 # actions-v3
+        uses: woocommerce/grow/prepare-php@a81d3fca0166a02a4c25953d250d80d3612db4b8 # actions-v3
         with:
           install-deps: "no"
 
       - name: Prepare node
-        uses: woocommerce/grow/prepare-node@3a4249a1fc7e39a987d213e578cbcf32abd55980 # actions-v3
+        uses: woocommerce/grow/prepare-node@a81d3fca0166a02a4c25953d250d80d3612db4b8 # actions-v3
         with:
           node-version-file: ".nvmrc"
           ignore-scripts: "no"

--- a/.github/workflows/js-linting.yml
+++ b/.github/workflows/js-linting.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Prepare node
-        uses: woocommerce/grow/prepare-node@a81d3fca0166a02a4c25953d250d80d3612db4b8 # actions-v3
+        uses: woocommerce/grow/prepare-node@b9c1e59aae9fdbe668b068ebd59c1545a88ea9fa # actions-v3.0.5
         with:
           node-version-file: ".nvmrc"
 

--- a/.github/workflows/js-linting.yml
+++ b/.github/workflows/js-linting.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Prepare node
-        uses: woocommerce/grow/prepare-node@3a4249a1fc7e39a987d213e578cbcf32abd55980 # actions-v3
+        uses: woocommerce/grow/prepare-node@a81d3fca0166a02a4c25953d250d80d3612db4b8 # actions-v3
         with:
           node-version-file: ".nvmrc"
 

--- a/.github/workflows/php-coding-standards.yml
+++ b/.github/workflows/php-coding-standards.yml
@@ -48,7 +48,7 @@ jobs:
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Prepare PHP
-        uses: woocommerce/grow/prepare-php@a81d3fca0166a02a4c25953d250d80d3612db4b8 # actions-v3
+        uses: woocommerce/grow/prepare-php@b9c1e59aae9fdbe668b068ebd59c1545a88ea9fa # actions-v3.0.5
         with:
           php-version: 7.4
           tools: cs2pr

--- a/.github/workflows/php-coding-standards.yml
+++ b/.github/workflows/php-coding-standards.yml
@@ -48,7 +48,7 @@ jobs:
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Prepare PHP
-        uses: woocommerce/grow/prepare-php@3a4249a1fc7e39a987d213e578cbcf32abd55980 # actions-v3
+        uses: woocommerce/grow/prepare-php@a81d3fca0166a02a4c25953d250d80d3612db4b8 # actions-v3
         with:
           php-version: 7.4
           tools: cs2pr

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -86,7 +86,7 @@ jobs:
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Prepare PHP
-        uses: woocommerce/grow/prepare-php@a81d3fca0166a02a4c25953d250d80d3612db4b8 # actions-v3
+        uses: woocommerce/grow/prepare-php@b9c1e59aae9fdbe668b068ebd59c1545a88ea9fa # actions-v3.0.5
         with:
           php-version: "${{ matrix.php }}"
 
@@ -128,7 +128,7 @@ jobs:
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Prepare PHP
-        uses: woocommerce/grow/prepare-php@a81d3fca0166a02a4c25953d250d80d3612db4b8 # actions-v3
+        uses: woocommerce/grow/prepare-php@b9c1e59aae9fdbe668b068ebd59c1545a88ea9fa # actions-v3.0.5
         with:
           php-version: "${{ inputs.php-version }}"
 

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -86,7 +86,7 @@ jobs:
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Prepare PHP
-        uses: woocommerce/grow/prepare-php@3a4249a1fc7e39a987d213e578cbcf32abd55980 # actions-v3
+        uses: woocommerce/grow/prepare-php@a81d3fca0166a02a4c25953d250d80d3612db4b8 # actions-v3
         with:
           php-version: "${{ matrix.php }}"
 
@@ -128,7 +128,7 @@ jobs:
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Prepare PHP
-        uses: woocommerce/grow/prepare-php@3a4249a1fc7e39a987d213e578cbcf32abd55980 # actions-v3
+        uses: woocommerce/grow/prepare-php@a81d3fca0166a02a4c25953d250d80d3612db4b8 # actions-v3
         with:
           php-version: "${{ inputs.php-version }}"
 

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Create branch & PR
-        uses: woocommerce/grow/prepare-extension-release@3a4249a1fc7e39a987d213e578cbcf32abd55980 # actions-v3
+        uses: woocommerce/grow/prepare-extension-release@a81d3fca0166a02a4c25953d250d80d3612db4b8 # actions-v3
         with:
           version: ${{ github.event.inputs.version }}
           type: ${{ github.event.inputs.type }}

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Create branch & PR
-        uses: woocommerce/grow/prepare-extension-release@a81d3fca0166a02a4c25953d250d80d3612db4b8 # actions-v3
+        uses: woocommerce/grow/prepare-extension-release@b9c1e59aae9fdbe668b068ebd59c1545a88ea9fa # actions-v3.0.5
         with:
           version: ${{ github.event.inputs.version }}
           type: ${{ github.event.inputs.type }}


### PR DESCRIPTION
### Changes proposed in this Pull Request

Tracking: STORMA-186

- Updates the affected parent actions or reusable workflows to immutable commits whose own remote action dependencies are pinned to full-length SHAs.
- Keeps human-readable version comments beside the SHAs.

This is part of the WooCommerce organization audit for transitive GitHub Action pinning. Shared Grow actions are pinned to the published [actions-v3.0.5 release](https://github.com/woocommerce/grow/releases/tag/actions-v3.0.5) build commit `b9c1e59aae9fdbe668b068ebd59c1545a88ea9fa`. The action trees used here are identical to the reviewed test build from woocommerce/grow#265.

### Detailed test instructions

1. Inspect the changed `uses:` references and confirm every remote action ref is a 40-character commit SHA.
2. Confirm the adjacent comments identify the intended version or upstream pinning PR.
3. Let the affected workflows run through this PR's hosted checks.

Validation already completed:

- Parsed every GitHub workflow and composite action in this repository as YAML.
- Ran `git diff --check`.
- Verified the replacement parent commits resolve through their canonical GitHub repositories.
- Verified their nested remote action dependencies are pinned to full-length SHAs.

### Documentation

- [x] No documentation changes are required.

### Changelog entry

> Dev - Pin GitHub Actions and their nested dependencies to immutable commit SHAs.

**left by Biff (AI agent) on behalf of Darren*

