### PR TITLE
Update GitHub Action references

### DIFF
--- a/.github/workflows/branch-labels.yml
+++ b/.github/workflows/branch-labels.yml
@@ -13,4 +13,4 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Set Labels
-        uses: woocommerce/grow/branch-label@b9c1e59aae9fdbe668b068ebd59c1545a88ea9fa # actions-v3.0.5
+        uses: woocommerce/grow/branch-label@e981c25267d29c39ff6ab1ae4ea09b267efae86c # actions-v3.0.6

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
       FORCE_COLOR: 2
     steps:
       - name: Checkout repository
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Prepare PHP
         uses: woocommerce/grow/prepare-php@e981c25267d29c39ff6ab1ae4ea09b267efae86c # actions-v3.0.6
@@ -46,7 +46,7 @@ jobs:
 
       - name: Publish build artifact
         if: ${{ ! ( github.event_name == 'push' && github.ref_name == 'trunk' ) }}
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: woocommerce-google-analytics-integration.zip
           path: ${{ github.workspace }}/woocommerce-google-analytics-integration.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,12 +22,12 @@ jobs:
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Prepare PHP
-        uses: woocommerce/grow/prepare-php@b9c1e59aae9fdbe668b068ebd59c1545a88ea9fa # actions-v3.0.5
+        uses: woocommerce/grow/prepare-php@e981c25267d29c39ff6ab1ae4ea09b267efae86c # actions-v3.0.6
         with:
           install-deps: "no"
 
       - name: Prepare node
-        uses: woocommerce/grow/prepare-node@b9c1e59aae9fdbe668b068ebd59c1545a88ea9fa # actions-v3.0.5
+        uses: woocommerce/grow/prepare-node@e981c25267d29c39ff6ab1ae4ea09b267efae86c # actions-v3.0.6
         with:
           node-version-file: ".nvmrc"
           ignore-scripts: "no"
@@ -40,7 +40,7 @@ jobs:
 
       - name: Publish dev build to GitHub
         if: ${{ github.event_name == 'push' && github.ref_name == 'trunk' }}
-        uses: woocommerce/grow/publish-extension-dev-build@b9c1e59aae9fdbe668b068ebd59c1545a88ea9fa # actions-v3.0.5
+        uses: woocommerce/grow/publish-extension-dev-build@e981c25267d29c39ff6ab1ae4ea09b267efae86c # actions-v3.0.6
         with:
           extension-asset-path: woocommerce-google-analytics-integration.zip
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -62,7 +62,7 @@ jobs:
     steps:
       # Checkout the private action repository
       - name: Checkout woo-product-deploy action
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           repository: woocommerce/woo-product-deploy
           ref: trunk

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -37,12 +37,12 @@ jobs:
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Prepare PHP
-        uses: woocommerce/grow/prepare-php@b9c1e59aae9fdbe668b068ebd59c1545a88ea9fa # actions-v3.0.5
+        uses: woocommerce/grow/prepare-php@e981c25267d29c39ff6ab1ae4ea09b267efae86c # actions-v3.0.6
         with:
           install-deps: "no"
 
       - name: Prepare node
-        uses: woocommerce/grow/prepare-node@b9c1e59aae9fdbe668b068ebd59c1545a88ea9fa # actions-v3.0.5
+        uses: woocommerce/grow/prepare-node@e981c25267d29c39ff6ab1ae4ea09b267efae86c # actions-v3.0.6
         with:
           node-version-file: ".nvmrc"
           ignore-scripts: "no"

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -34,7 +34,7 @@ jobs:
       FORCE_COLOR: 2
     steps:
       - name: Checkout repository
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Prepare PHP
         uses: woocommerce/grow/prepare-php@e981c25267d29c39ff6ab1ae4ea09b267efae86c # actions-v3.0.6
@@ -80,7 +80,7 @@ jobs:
 
       - name: Archive e2e failure screenshots
         if: ${{ always() }}
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
             name: e2e-screenshots
             path: tests/e2e/test-results/report/**/*.png

--- a/.github/workflows/js-linting.yml
+++ b/.github/workflows/js-linting.yml
@@ -29,12 +29,12 @@ jobs:
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Prepare node
-        uses: woocommerce/grow/prepare-node@b9c1e59aae9fdbe668b068ebd59c1545a88ea9fa # actions-v3.0.5
+        uses: woocommerce/grow/prepare-node@e981c25267d29c39ff6ab1ae4ea09b267efae86c # actions-v3.0.6
         with:
           node-version-file: ".nvmrc"
 
       - name: Prepare annotation formatter
-        uses: woocommerce/grow/eslint-annotation@3a4249a1fc7e39a987d213e578cbcf32abd55980 # actions-v3
+        uses: woocommerce/grow/eslint-annotation@e981c25267d29c39ff6ab1ae4ea09b267efae86c # actions-v3.0.6
 
       - name: Lint JavaScript and annotate linting errors
         run: npm run lint:js -- --quiet --format ./eslintFormatter.cjs

--- a/.github/workflows/js-linting.yml
+++ b/.github/workflows/js-linting.yml
@@ -26,7 +26,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout repository
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Prepare node
         uses: woocommerce/grow/prepare-node@e981c25267d29c39ff6ab1ae4ea09b267efae86c # actions-v3.0.6

--- a/.github/workflows/php-coding-standards.yml
+++ b/.github/workflows/php-coding-standards.yml
@@ -24,7 +24,7 @@ jobs:
       should-run: ${{ steps.changes.outputs.php }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Check for relevant changes
         uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
@@ -45,7 +45,7 @@ jobs:
     if: needs.check-paths.outputs.should-run == 'true'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Prepare PHP
         uses: woocommerce/grow/prepare-php@e981c25267d29c39ff6ab1ae4ea09b267efae86c # actions-v3.0.6

--- a/.github/workflows/php-coding-standards.yml
+++ b/.github/workflows/php-coding-standards.yml
@@ -48,7 +48,7 @@ jobs:
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Prepare PHP
-        uses: woocommerce/grow/prepare-php@b9c1e59aae9fdbe668b068ebd59c1545a88ea9fa # actions-v3.0.5
+        uses: woocommerce/grow/prepare-php@e981c25267d29c39ff6ab1ae4ea09b267efae86c # actions-v3.0.6
         with:
           php-version: 7.4
           tools: cs2pr

--- a/.github/workflows/php-hook-documentation.yml
+++ b/.github/workflows/php-hook-documentation.yml
@@ -19,7 +19,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           # Checks out a branch instead of a commit in detached HEAD state
           ref: ${{ github.head_ref }}

--- a/.github/workflows/php-hook-documentation.yml
+++ b/.github/workflows/php-hook-documentation.yml
@@ -27,7 +27,7 @@ jobs:
         # This generates the documentation string. The `id` property is used to reference the output in the next step.
       - name: Generate hook documentation
         id: generate-hook-docs
-        uses: woocommerce/grow/hook-documentation@3a4249a1fc7e39a987d213e578cbcf32abd55980 # actions-v3
+        uses: woocommerce/grow/hook-documentation@e981c25267d29c39ff6ab1ae4ea09b267efae86c # actions-v3.0.6
         with:
           source-directories: includes/,woocommerce-google-analytics-integration.php
 

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -47,13 +47,13 @@ jobs:
     steps:
       - name: Get Release versions from Wordpress
         id: wp
-        uses: woocommerce/grow/get-plugin-releases@3a4249a1fc7e39a987d213e578cbcf32abd55980 # actions-v3
+        uses: woocommerce/grow/get-plugin-releases@e981c25267d29c39ff6ab1ae4ea09b267efae86c # actions-v3.0.6
         with:
           slug: wordpress
           releases: 2
       - name: Get Release versions from WooCommerce
         id: wc
-        uses: woocommerce/grow/get-plugin-releases@3a4249a1fc7e39a987d213e578cbcf32abd55980 # actions-v3
+        uses: woocommerce/grow/get-plugin-releases@e981c25267d29c39ff6ab1ae4ea09b267efae86c # actions-v3.0.6
         with:
           source: github
           slug: woocommerce/woocommerce
@@ -86,12 +86,12 @@ jobs:
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Prepare PHP
-        uses: woocommerce/grow/prepare-php@b9c1e59aae9fdbe668b068ebd59c1545a88ea9fa # actions-v3.0.5
+        uses: woocommerce/grow/prepare-php@e981c25267d29c39ff6ab1ae4ea09b267efae86c # actions-v3.0.6
         with:
           php-version: "${{ matrix.php }}"
 
       - name: Set up MySQL
-        uses: woocommerce/grow/prepare-mysql@3a4249a1fc7e39a987d213e578cbcf32abd55980 # actions-v3
+        uses: woocommerce/grow/prepare-mysql@e981c25267d29c39ff6ab1ae4ea09b267efae86c # actions-v3.0.6
 
       - name: Install svn (used for installing WP versions)
         run: sudo apt-get -y install subversion
@@ -128,12 +128,12 @@ jobs:
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Prepare PHP
-        uses: woocommerce/grow/prepare-php@b9c1e59aae9fdbe668b068ebd59c1545a88ea9fa # actions-v3.0.5
+        uses: woocommerce/grow/prepare-php@e981c25267d29c39ff6ab1ae4ea09b267efae86c # actions-v3.0.6
         with:
           php-version: "${{ inputs.php-version }}"
 
       - name: Prepare MySQL
-        uses: woocommerce/grow/prepare-mysql@3a4249a1fc7e39a987d213e578cbcf32abd55980 # actions-v3
+        uses: woocommerce/grow/prepare-mysql@e981c25267d29c39ff6ab1ae4ea09b267efae86c # actions-v3.0.6
 
       - name: Install svn (used for installing WP versions)
         run: sudo apt-get -y install subversion

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -83,7 +83,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Prepare PHP
         uses: woocommerce/grow/prepare-php@e981c25267d29c39ff6ab1ae4ea09b267efae86c # actions-v3.0.6
@@ -125,7 +125,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Prepare PHP
         uses: woocommerce/grow/prepare-php@e981c25267d29c39ff6ab1ae4ea09b267efae86c # actions-v3.0.6

--- a/.github/workflows/prepare-release-via-deploy.yml
+++ b/.github/workflows/prepare-release-via-deploy.yml
@@ -18,7 +18,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout repository
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Validate version format
         env:
@@ -47,7 +47,7 @@ jobs:
 
       - name: Create a pull request for the release
         id: prepare-release-pr
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const { default: script } = await import( `${ process.env.GITHUB_WORKSPACE }/.github/workflows/scripts/create-release-pr.mjs` );

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -28,7 +28,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout repository
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Create branch & PR
         uses: woocommerce/grow/prepare-extension-release@e981c25267d29c39ff6ab1ae4ea09b267efae86c # actions-v3.0.6

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Create branch & PR
-        uses: woocommerce/grow/prepare-extension-release@b9c1e59aae9fdbe668b068ebd59c1545a88ea9fa # actions-v3.0.5
+        uses: woocommerce/grow/prepare-extension-release@e981c25267d29c39ff6ab1ae4ea09b267efae86c # actions-v3.0.6
         with:
           version: ${{ github.event.inputs.version }}
           type: ${{ github.event.inputs.type }}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Follow-up to the recent SHA pinning PRs. Two changes, one commit each.

**Move every `woocommerce/grow` reference to the `actions-v3.0.6` release build.** The references were split across two builds. The actions with nested remote action references pinned `actions-v3.0.5`, while the rest still pinned the `actions-v3.0.4` build under a comment that named the moving `actions-v3` tag. In `actions-v3.0.6`, sibling actions resolve through the self repository syntax (`$/`), so `publish-extension-dev-build` no longer calls `get-release-notes` from the previous release. Every reference now points at one build, with a comment that names it.

**Name the exact release in the comments beside the third-party SHAs.** The SHAs are unchanged. A comment like `# v6` names a tag that moves, while the SHA is frozen at one release. Naming the exact release (`# v6.1.0`) makes it possible to tell how far a pin lags upstream without resolving the SHA, and matches how the `actions-v3.0.6` build annotates its own pins.

### Changelog entry