### PR TITLE
Declare compatibility with WooCommerce 11.1.0

### DIFF
--- a/woocommerce-google-analytics-integration.php
+++ b/woocommerce-google-analytics-integration.php
@@ -6,8 +6,8 @@
  * Author: WooCommerce
  * Author URI: https://woocommerce.com
  * Version: 2.4.1
- * WC requires at least: 10.9
- * WC tested up to: 11.0
+ * WC requires at least: 11.0
+ * WC tested up to: 11.1
  * Requires at least: 7.0
  * Requires Plugins: woocommerce
  * Tested up to: 7.1
@@ -27,7 +27,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 if ( ! class_exists( 'WC_Google_Analytics_Integration' ) ) {
 
 	define( 'WC_GOOGLE_ANALYTICS_INTEGRATION_VERSION', '2.4.1' ); // WRCS: DEFINED_VERSION.
-	define( 'WC_GOOGLE_ANALYTICS_INTEGRATION_MIN_WC_VER', '10.9' );
+	define( 'WC_GOOGLE_ANALYTICS_INTEGRATION_MIN_WC_VER', '11.0' );
 
 	// Maybe show the GA Pro notice on plugin activation.
 	register_activation_hook(


### PR DESCRIPTION
### Changes proposed in this Pull Request

Declares the plugin compatible with WooCommerce 11.1.0.

Sets `WC tested up to` to 11.1 and `WC requires at least` to 11.0, and bumps `WC_GOOGLE_ANALYTICS_INTEGRATION_MIN_WC_VER` from 10.9 to 11.0 so the constant matches the header. The minimum stays one minor version behind the tested version.

Only the main plugin file changed. The WordPress headers are left as they are.

### Detailed test instructions

1. Run the plugin on a store with WooCommerce 11.1 and confirm no version warning shows.
2. Confirm Google Analytics events still fire on a test purchase.
3. Downgrade WooCommerce to 10.9 and confirm the "requires WooCommerce version 11.0 or higher" notice appears.

### Additional details

Update - Bump the minimum required WooCommerce version to 11.0 and the compatibility version to 11.1.
