### PR TITLE
Strip sensitive query parameters from the URLs reported to Google Analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,10 @@ The extension does not provide any UI, like a cookie banner, to let your visitor
 
 Each of those extensions may require additional setup or registration. Usually, the basic default setup works out of the box, but there may be some integration caveats. Here are a couple of the most frequent ones:
 
+##### Visitors who have not answered the banner yet
+
+When the WP Consent API reports that the site is opt-in, a visitor who has not answered the banner is reported to Google as `denied` for every consent type, rather than being left on the regional defaults. Sites the WP Consent API reports as opt-out, and sites where no extension declares a consent type at all, are unaffected: their visitors keep the defaults until they make a choice.
+
 ##### GA4W overwrites the consent mode defaults set by the other extension
 
 If the additional extension you chose sets its own default state of consent modes, different than the one we set, and you would like to make sure we'll not overwrite that, you can use the `woocommerce_ga_gtag_consent_modes` snippet to change or disable our setup:
@@ -135,3 +139,42 @@ add_filter( 'woocommerce_ga_gtag_config', function ( $config ) {
    return $config;
 } );
 ```
+
+### Sensitive query parameters in the page URL
+
+gtag reports the page URL (`page_location`, the `dl` parameter) and the referrer (`page_referrer`, `dr`) with every hit. Before gtag reads them, the extension strips query parameters that must not end up in Google Analytics, such as the WooCommerce order key on the order-received page:
+
+- On every page it removes `key`, `login`, `session`, `email`, `uid`, `_wpnonce`, `_wp_http_referer`, `woo-share`, `moderation-hash`, `unapproved`, `email_link_action_key`, `consumer_key`, `consumer_secret`, `redirect` and `redirect_to`, plus any parameter that carries a WooCommerce order key as its value or inside a URL nested in it.
+- On the order-received and order-pay pages it keeps only the endpoint parameters, `pay_for_order`, the parameters that identify the page on plain permalinks (`page_id`, `p`, `pagename`, `lang`, `currency`), the standard `utm_` parameters, the click identifiers (`gclid`, `gbraid`, `wbraid`, `dclid`, `fbclid`, `msclkid`, `srsltid`) and the cross-domain linker `_gl`.
+
+URLs with nothing to strip are reported exactly as gtag would report them. The lists are filterable; hook the filters before WooCommerce loads its integrations (from your plugin’s main file or `plugins_loaded`):
+
+```php
+add_filter( 'woocommerce_ga_redacted_url_params', function ( $params ) {
+    $params[] = 'token';
+    return $params;
+} );
+
+add_filter( 'woocommerce_ga_order_page_allowed_url_params', function ( $params ) {
+    $params[] = 'ref';
+    return $params;
+} );
+```
+
+To switch the redaction off entirely:
+
+```php
+add_filter( 'woocommerce_ga_url_redaction_enabled', '__return_false' );
+```
+
+If your `woocommerce_ga_gtag_config` filter sets `page_location` or `page_referrer`, those values are used as they are.
+
+The redaction is performed by `window.wcGoogleAnalyticsIntegration.redactGtagConfig( config )`, which is installed before the tag snippet runs. It is registered separately from the snippet, so if you replace the snippet through `woocommerce_gtag_snippet` you can keep the redaction by passing your config through it:
+
+```js
+gtag( 'config', 'G-XXXXXXXXXX', wcGoogleAnalyticsIntegration.redactGtagConfig( { /* … */ } ) );
+```
+
+A replacement snippet that does not call it reports the unredacted URL.
+
+This only changes what the extension reports to Google. Browsers send the page URL in the `Referer` header of the requests the page makes, which for third-party resources means the origin alone under the usual `strict-origin-when-cross-origin` policy, and the full URL if the site relaxes that policy. Other tags on the page report their own `page_location`.

--- a/assets/js/src/integrations/wp-consent-api.js
+++ b/assets/js/src/integrations/wp-consent-api.js
@@ -3,38 +3,73 @@ const consentMap = {
 	marketing: [ 'ad_storage', 'ad_user_data', 'ad_personalization' ],
 };
 
+/**
+ * The consent type in effect, resolved the way the WP Consent API's own
+ * `wp_has_consent()` resolves it: the type declared at runtime first, then the
+ * one the plugin localizes from `wp_get_consent_type()`. An empty string means
+ * no consent management is declared.
+ *
+ * @return {string} The declared consent type, or an empty string.
+ */
+const getConsentType = () => {
+	const { wp_consent_type: type, wp_fallback_consent_type: fallback } =
+		window;
+
+	if ( type !== undefined && type !== null ) {
+		return String( type );
+	}
+
+	return fallback ? String( fallback ) : '';
+};
+
 export const setCurrentConsentState = ( {
 	tracker_function_name: trackerFunctionName,
 } ) => {
 	// eslint-disable-next-line camelcase -- `wp_has_consent` is defined by the WP Consent API plugin.
-	if ( typeof wp_has_consent === 'function' ) {
-		if ( window.wp_consent_type === undefined ) {
-			window.wp_consent_type = 'optin';
+	if ( typeof wp_has_consent !== 'function' ) {
+		return;
+	}
+
+	// Read the declared type before the fallback below defines one, otherwise a site
+	// that declares opt-out through `wp_get_consent_type()` would be read as opt-in.
+	const consentType = getConsentType();
+	const optIn = consentType !== '' && ! consentType.includes( 'optout' );
+
+	if ( consentType === '' ) {
+		// Nothing declares a consent type, so assume opt-in as this integration always
+		// has, which is what makes `wp_has_consent()` honour the cookies a banner sets.
+		window.wp_consent_type = 'optin';
+	}
+
+	const consentState = {};
+
+	for ( const [ category, types ] of Object.entries( consentMap ) ) {
+		// eslint-disable-next-line no-undef -- `consent_api_get_cookie` is defined by the WP Consent API plugin.
+		const decision = consent_api_get_cookie(
+			window.consent_api.cookie_prefix + '_' + category
+		);
+
+		let state;
+		if ( decision !== '' ) {
+			// eslint-disable-next-line no-undef -- `wp_has_consent` is defined by the WP Consent API plugin.
+			state = wp_has_consent( category ) ? 'granted' : 'denied';
+		} else if ( optIn ) {
+			// No decision yet under opt-in means no consent: say so explicitly
+			// instead of leaving gtag on whatever default applies to the region.
+			state = 'denied';
+		} else {
+			// Opt-out, or no consent management at all: the (region-scoped)
+			// defaults stand and an undecided visitor keeps being measured.
+			continue;
 		}
 
-		const consentState = {};
+		types.forEach( ( type ) => {
+			consentState[ type ] = state;
+		} );
+	}
 
-		for ( const [ category, types ] of Object.entries( consentMap ) ) {
-			if (
-				// eslint-disable-next-line no-undef -- `consent_api_get_cookie` is defined by the WP Consent API plugin.
-				consent_api_get_cookie(
-					window.consent_api.cookie_prefix + '_' + category
-				) !== ''
-			) {
-				// eslint-disable-next-line no-undef -- `wp_has_consent` is defined by the WP Consent API plugin.
-				const hasConsent = wp_has_consent( category )
-					? 'granted'
-					: 'denied';
-
-				types.forEach( ( type ) => {
-					consentState[ type ] = hasConsent;
-				} );
-			}
-		}
-
-		if ( Object.keys( consentState ).length > 0 ) {
-			window[ trackerFunctionName ]( 'consent', 'update', consentState );
-		}
+	if ( Object.keys( consentState ).length > 0 ) {
+		window[ trackerFunctionName ]( 'consent', 'update', consentState );
 	}
 };
 

--- a/includes/class-wc-google-gtag-js.php
+++ b/includes/class-wc-google-gtag-js.php
@@ -94,6 +94,91 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 			)
 		);
 
+		// The redaction helper is registered outside the `woocommerce_gtag_snippet` filter, so a
+		// snippet that replaces the default one can still call it. The lists come from PHP; the
+		// URL and referrer can only be read in the browser.
+		wp_add_inline_script(
+			$this->gtag_script_handle,
+			sprintf(
+				'window.wcGoogleAnalyticsIntegration = window.wcGoogleAnalyticsIntegration || {};
+				/* Returns the gtag config with page_location and page_referrer stripped of sensitive query parameters. */
+				window.wcGoogleAnalyticsIntegration.redactGtagConfig = (function ( redaction ) {
+					function lower( value ) {
+						try {
+							return decodeURIComponent( String( value ).replace( /\+/g, " " ) ).toLowerCase();
+						} catch ( e ) {
+							return String( value ).toLowerCase();
+						}
+					}
+					function redact( href ) {
+						try {
+							const url = new URL( href );
+							if ( ! url.search ) {
+								return href;
+							}
+							const pairs = url.search.slice( 1 ).split( "&" );
+							const names = pairs.map( function ( pair ) {
+								const eq = pair.indexOf( "=" );
+								return lower( eq === -1 ? pair : pair.slice( 0, eq ) );
+							} );
+							const segments = url.pathname.split( "/" ).map( lower );
+							const isOrderPage = ( redaction.order_endpoints || [] ).some( function ( endpoint ) {
+								return segments.includes( endpoint ) || names.includes( endpoint );
+							} );
+							const kept = [];
+							let changed = false;
+							pairs.forEach( function ( pair, index ) {
+								const eq = pair.indexOf( "=" );
+								const value = eq === -1 ? "" : pair.slice( eq + 1 );
+								// An order key starts with wc_ (the rest of the prefix is filterable in
+								// WooCommerce) and may sit inside a return URL carried by another parameter.
+								const isOrderKey = /^wc_|wc_order_/i.test( value ) || /^wc_|wc_order_/i.test( lower( value ) );
+								const drop = pair !== "" && ( isOrderKey || ( isOrderPage
+									? ! ( redaction.order_params || [] ).includes( names[ index ] )
+									: redaction.params.includes( names[ index ] ) ) );
+								if ( drop ) {
+									changed = true;
+								} else {
+									kept.push( pair );
+								}
+							} );
+							if ( ! changed ) {
+								return href;
+							}
+							// Reassembled from the original pairs so kept values keep their exact encoding.
+							url.search = kept.join( "&" );
+							return url.href;
+						} catch ( e ) {
+							// Unparsable or unfilterable: drop the query and fragment rather than risk leaking a key.
+							return String( href ).split( /[?#]/ )[ 0 ];
+						}
+					}
+					return function ( config ) {
+						try {
+							if ( ! redaction || ! Array.isArray( redaction.params ) ) {
+								return config;
+							}
+							if ( ! ( "page_location" in config ) ) {
+								const pageLocation = redact( document.location.href );
+								if ( pageLocation !== document.location.href ) {
+									config.page_location = pageLocation;
+								}
+							}
+							if ( ! ( "page_referrer" in config ) && document.referrer ) {
+								const pageReferrer = redact( document.referrer );
+								if ( pageReferrer !== document.referrer ) {
+									config.page_referrer = pageReferrer;
+								}
+							}
+						} catch ( e ) {}
+						return config;
+					};
+				})( %1$s );',
+				wp_json_encode( $this->get_url_redaction_config(), JSON_HEX_TAG | JSON_UNESCAPED_SLASHES )
+			),
+			'before'
+		);
+
 		wp_add_inline_script(
 			$this->gtag_script_handle,
 			apply_filters(
@@ -108,7 +193,8 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 					}
 					%2$s("js", new Date());
 					%2$s("set", "developer_id.%3$s", true);
-					%2$s("config", "%1$s", %5$s);',
+					// Report the page URL and referrer without order keys and other sensitive query parameters.
+					%2$s("config", "%1$s", ( window.wcGoogleAnalyticsIntegration && window.wcGoogleAnalyticsIntegration.redactGtagConfig || function ( config ) { return config; } )( %5$s ));',
 					esc_js( $this->get_setting( 'ga_id' ) ),
 					esc_js( $this->tracker_function_name() ),
 					esc_js( static::DEVELOPER_ID ),
@@ -334,6 +420,163 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 				)
 			)
 		);
+	}
+
+	/**
+	 * Query parameters stripped from the page URL and referrer reported to Google Analytics on every page.
+	 *
+	 * Names are matched case-insensitively. Independently of this list, any parameter whose value
+	 * looks like a WooCommerce order key, or carries one inside a nested URL, is stripped as well.
+	 *
+	 * @return string[]
+	 */
+	public function get_redacted_url_params(): array {
+		$params = [
+			'key',
+			'login',
+			'session',
+			'email',
+			'uid',
+			'_wpnonce',
+			'_wp_http_referer',
+			'woo-share',
+			'moderation-hash',
+			'unapproved',
+			'email_link_action_key',
+			'consumer_key',
+			'consumer_secret',
+			// Nested return URLs: WooCommerce and WordPress put checkout/order URLs in them,
+			// where a `key=wc_order_...` would escape the value check above.
+			'redirect',
+			'redirect_to',
+		];
+
+		/**
+		 * Filters the query parameters stripped from the page URL and referrer reported to Google Analytics.
+		 *
+		 * @param string[] $params Parameter names, matched case-insensitively.
+		 */
+		return self::normalize_url_param_names( apply_filters( 'woocommerce_ga_redacted_url_params', $params ) );
+	}
+
+	/**
+	 * Slugs of the WooCommerce endpoints whose URLs carry an order key: order-received and order-pay.
+	 *
+	 * Read from WooCommerce's configured query vars (which honour the endpoint settings and the
+	 * `woocommerce_get_query_vars` filter), falling back to the stock slugs.
+	 *
+	 * @return string[]
+	 */
+	public function get_order_page_endpoints(): array {
+		$query_vars = [];
+		if ( function_exists( 'WC' ) && WC()->query instanceof WC_Query ) {
+			$query_vars = WC()->query->get_query_vars();
+		}
+
+		$endpoints = [];
+		foreach ( [ 'order-received', 'order-pay' ] as $endpoint ) {
+			$endpoints[] = ! empty( $query_vars[ $endpoint ] ) && is_string( $query_vars[ $endpoint ] ) ? $query_vars[ $endpoint ] : $endpoint;
+		}
+
+		return self::normalize_url_param_names( $endpoints );
+	}
+
+	/**
+	 * Query parameters kept in the page URL reported to Google Analytics on order-received and
+	 * order-pay pages. Every other parameter is stripped there.
+	 *
+	 * @return string[]
+	 */
+	public function get_order_page_allowed_url_params(): array {
+		$endpoints = $this->get_order_page_endpoints();
+		$params    = array_merge(
+			// The endpoint query vars identify the page on plain permalinks (`?order-received=123`).
+			$endpoints,
+			[
+				'pay_for_order',
+				// Page identity on plain permalinks, and the language/currency of the page.
+				'page_id',
+				'p',
+				'pagename',
+				'lang',
+				'currency',
+				// Campaign attribution.
+				'utm_source',
+				'utm_medium',
+				'utm_campaign',
+				'utm_term',
+				'utm_content',
+				'utm_id',
+				'utm_source_platform',
+				'utm_creative_format',
+				'utm_marketing_tactic',
+				'utm_nooverride',
+				'srsltid',
+				'gclid',
+				'gbraid',
+				'wbraid',
+				'dclid',
+				'fbclid',
+				'msclkid',
+				'_gl',
+			]
+		);
+
+		/**
+		 * Filters the query parameters kept in the page URL reported to Google Analytics on the
+		 * order-received and order-pay pages.
+		 *
+		 * @param string[] $params    Parameter names, matched case-insensitively.
+		 * @param string[] $endpoints The order-received and order-pay endpoint slugs.
+		 */
+		return self::normalize_url_param_names( apply_filters( 'woocommerce_ga_order_page_allowed_url_params', $params, $endpoints ) );
+	}
+
+	/**
+	 * Configuration for the client-side URL redaction, passed to the `redactGtagConfig` helper.
+	 *
+	 * Returns an empty array when redaction is disabled, which the helper treats as "do nothing".
+	 *
+	 * @return array
+	 */
+	public function get_url_redaction_config(): array {
+		/**
+		 * Filters whether the gtag snippet strips sensitive query parameters, such as order keys,
+		 * from the page URL and referrer it reports to Google Analytics.
+		 *
+		 * @param bool $enabled Whether redaction is enabled. Default true.
+		 */
+		if ( ! apply_filters( 'woocommerce_ga_url_redaction_enabled', true ) ) {
+			return [];
+		}
+
+		return [
+			'params'          => $this->get_redacted_url_params(),
+			'order_endpoints' => $this->get_order_page_endpoints(),
+			'order_params'    => $this->get_order_page_allowed_url_params(),
+		];
+	}
+
+	/**
+	 * Lower-case, de-duplicate and reindex a list of query parameter names, dropping anything
+	 * that is not a non-empty string.
+	 *
+	 * @param mixed $names Parameter names, typically the output of a filter.
+	 * @return string[]
+	 */
+	private static function normalize_url_param_names( $names ): array {
+		$names = array_filter( (array) $names, 'is_string' );
+		$names = array_map(
+			function ( string $name ): string {
+				// Translated endpoint slugs may be non-ASCII, which strtolower() leaves untouched
+				// while the JS side lowercases by Unicode rules.
+				return function_exists( 'mb_strtolower' ) ? mb_strtolower( $name, 'UTF-8' ) : strtolower( $name );
+			},
+			$names
+		);
+		$names = array_filter( $names, 'strlen' );
+
+		return array_values( array_unique( $names ) );
 	}
 
 	/**

--- a/includes/class-wc-google-gtag-js.php
+++ b/includes/class-wc-google-gtag-js.php
@@ -103,6 +103,10 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 				'window.wcGoogleAnalyticsIntegration = window.wcGoogleAnalyticsIntegration || {};
 				/* Returns the gtag config with page_location and page_referrer stripped of sensitive query parameters. */
 				window.wcGoogleAnalyticsIntegration.redactGtagConfig = (function ( redaction ) {
+					// An order key is wc_ followed by a body WooCommerce lets sites filter, so match
+					// the guaranteed prefix, the stock format anywhere in the value, and a key sitting
+					// in the query string of a URL nested inside the value.
+					const ORDER_KEY = /^wc_|wc_order_|[?&][^=&]*=wc_/i;
 					function lower( value ) {
 						try {
 							return decodeURIComponent( String( value ).replace( /\+/g, " " ) ).toLowerCase();
@@ -130,9 +134,7 @@ class WC_Google_Gtag_JS extends WC_Abstract_Google_Analytics_JS {
 							pairs.forEach( function ( pair, index ) {
 								const eq = pair.indexOf( "=" );
 								const value = eq === -1 ? "" : pair.slice( eq + 1 );
-								// An order key starts with wc_ (the rest of the prefix is filterable in
-								// WooCommerce) and may sit inside a return URL carried by another parameter.
-								const isOrderKey = /^wc_|wc_order_/i.test( value ) || /^wc_|wc_order_/i.test( lower( value ) );
+								const isOrderKey = ORDER_KEY.test( value ) || ORDER_KEY.test( lower( value ) );
 								const drop = pair !== "" && ( isOrderKey || ( isOrderPage
 									? ! ( redaction.order_params || [] ).includes( names[ index ] )
 									: redaction.params.includes( names[ index ] ) ) );

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "makepot": "wpi18n makepot --domain-path languages --pot-file $npm_package_name.pot --type plugin --main-file $npm_package_name.php --exclude node_modules,tests,docs,assets/js/src",
     "lint:js": "eslint .",
     "lint:php": "vendor/bin/phpcs",
+    "test:js": "node --test \"tests/js/**/*.test.js\"",
     "archive": "composer archive --file=$npm_package_name --format=zip",
     "postarchive": "rm -rf $npm_package_name && unzip $npm_package_name.zip -d $npm_package_name && rm $npm_package_name.zip && zip -r $npm_package_name.zip $npm_package_name && rm -rf $npm_package_name",
     "build": "NODE_ENV=production wp-scripts build && npm run makepot &&  npm run archive",

--- a/tests/e2e/specs/gtag-events/url-redaction.test.js
+++ b/tests/e2e/specs/gtag-events/url-redaction.test.js
@@ -1,0 +1,195 @@
+/**
+ * External dependencies
+ */
+const { test, expect } = require( '@playwright/test' );
+
+/**
+ * Internal dependencies
+ */
+import {
+	createSimpleProduct,
+	setSettings,
+	clearSettings,
+} from '../../utils/api';
+import { checkout, simpleProductAddToCart } from '../../utils/customer';
+import { getEventData, trackGtagEvent } from '../../utils/track-event';
+
+/**
+ * Reads the options object the snippet passed to gtag( 'config', … ).
+ *
+ * gtag() pushes its arguments object onto the dataLayer, so entries are
+ * array-like; the config entry is [ 'config', '<measurement id>', { … } ].
+ *
+ * @param {import('@playwright/test').Page} page
+ *
+ * @return {Object} The config options, e.g. `{ track_404: true, page_location: '…' }`.
+ */
+async function getGtagConfig( page ) {
+	return await page.evaluate(
+		() =>
+			( window.dataLayer || [] )
+				.map( ( entry ) => Array.from( entry ) )
+				.find( ( entry ) => entry[ 0 ] === 'config' )?.[ 2 ] ?? {}
+	);
+}
+
+test.describe( 'URL redaction in the page location and referrer', () => {
+	let simpleProductID;
+
+	test.beforeAll( async () => {
+		await setSettings();
+		simpleProductID = await createSimpleProduct();
+	} );
+
+	test.afterAll( async () => {
+		await clearSettings();
+	} );
+
+	test( 'Sensitive query parameters are stripped from the page location on any page', async ( {
+		page,
+	} ) => {
+		const pageView = trackGtagEvent( page, 'page_view', 'shop' );
+		await page.goto(
+			'shop/?utm_source=e2e&key=abc123&order=wc_order_abc&login=bob&foo=bar'
+		);
+		const data = getEventData( await pageView, 'page_view' );
+		const sent = new URL( data.dl );
+
+		expect( sent.pathname ).toEqual( '/shop/' );
+		expect( sent.searchParams.get( 'utm_source' ) ).toEqual( 'e2e' );
+		expect( sent.searchParams.get( 'foo' ) ).toEqual( 'bar' );
+		expect( sent.searchParams.has( 'key' ) ).toBe( false );
+		expect( sent.searchParams.has( 'login' ) ).toBe( false );
+		// `order` is not on the name list: it goes because its value is an order key.
+		expect( sent.searchParams.has( 'order' ) ).toBe( false );
+		expect( data.dl ).not.toContain( 'wc_order_' );
+
+		// The browser URL keeps the parameters; only what gtag reports changes.
+		expect( page.url() ).toContain( 'order=wc_order_abc' );
+		const config = await getGtagConfig( page );
+		expect( config.page_location ).toContain(
+			'/shop/?utm_source=e2e&foo=bar'
+		);
+	} );
+
+	test( 'Only allowlisted parameters survive on the order-received page', async ( {
+		page,
+	} ) => {
+		await simpleProductAddToCart( page, simpleProductID );
+
+		// Both the config hit and the server-side purchase event are sent from
+		// the order-received page; neither may carry the order key.
+		const pageView = trackGtagEvent(
+			page,
+			'page_view',
+			'checkout/order-received'
+		);
+		const purchase = trackGtagEvent( page, 'purchase', 'checkout' );
+		const orderID = await checkout( page );
+
+		expect( page.url() ).toContain(
+			`/checkout/order-received/${ orderID }/?key=wc_order_`
+		);
+
+		for ( const [ request, eventName ] of [
+			[ await pageView, 'page_view' ],
+			[ await purchase, 'purchase' ],
+		] ) {
+			const sent = new URL( getEventData( request, eventName ).dl );
+			expect( sent.pathname ).toEqual(
+				`/checkout/order-received/${ orderID }/`
+			);
+			expect( sent.searchParams.has( 'key' ) ).toBe( false );
+			expect( sent.href ).not.toContain( 'wc_order_' );
+		}
+
+		const config = await getGtagConfig( page );
+		expect( config.page_location ).toContain(
+			`/checkout/order-received/${ orderID }/`
+		);
+		expect( config.page_location ).not.toContain( 'key=' );
+
+		// Reloading the confirmation with extra parameters shows the allowlist
+		// at work: campaign parameters stay, unknown ones and the key go.
+		const reload = trackGtagEvent(
+			page,
+			'page_view',
+			'checkout/order-received'
+		);
+		await page.goto(
+			`${ page.url() }&utm_source=e2e&_gl=1abc&pay_for_order=true&foo=bar`
+		);
+		const reloaded = new URL(
+			getEventData( await reload, 'page_view' ).dl
+		);
+
+		expect( reloaded.searchParams.get( 'utm_source' ) ).toEqual( 'e2e' );
+		expect( reloaded.searchParams.get( '_gl' ) ).toEqual( '1abc' );
+		expect( reloaded.searchParams.get( 'pay_for_order' ) ).toEqual(
+			'true'
+		);
+		expect( reloaded.searchParams.has( 'foo' ) ).toBe( false );
+		expect( reloaded.searchParams.has( 'key' ) ).toBe( false );
+	} );
+
+	test( 'Order key is stripped from the referrer reported on the next page', async ( {
+		page,
+	} ) => {
+		await simpleProductAddToCart( page, simpleProductID );
+		await checkout( page );
+		expect( page.url() ).toContain( 'key=wc_order_' );
+
+		const pageView = trackGtagEvent( page, 'page_view', 'shop' );
+		// A script-initiated navigation carries the order-received URL as the
+		// referrer; page.goto() would not set one.
+		await page.evaluate( () => {
+			window.location.assign( '/shop/' );
+		} );
+		await page.waitForURL( '**/shop/**' );
+		const data = getEventData( await pageView, 'page_view' );
+
+		expect( data.dr ).toContain( '/checkout/order-received/' );
+		expect( data.dr ).not.toContain( 'key=' );
+		expect( data.dr ).not.toContain( 'wc_order_' );
+
+		const config = await getGtagConfig( page );
+		expect( config.page_referrer ).toContain( '/checkout/order-received/' );
+		expect( config.page_referrer ).not.toContain( 'key=' );
+		// The shop URL itself had nothing to redact.
+		expect( config ).not.toHaveProperty( 'page_location' );
+	} );
+
+	test( 'A page location without sensitive parameters is sent untouched', async ( {
+		page,
+	} ) => {
+		const pageView = trackGtagEvent( page, 'page_view', 'shop' );
+		await page.goto( 'shop/?color=red%20blue&utm_source=e2e' );
+		const data = getEventData( await pageView, 'page_view' );
+
+		// Query string byte-identical to the browser URL: `color` is on no
+		// list, and the %20 was not re-encoded as `+`.
+		expect( new URL( data.dl ).search ).toEqual(
+			new URL( page.url() ).search
+		);
+		expect( data.dl ).toContain( '/shop/?color=red%20blue&utm_source=e2e' );
+
+		const config = await getGtagConfig( page );
+		expect( config ).not.toHaveProperty( 'page_location' );
+		expect( config ).not.toHaveProperty( 'page_referrer' );
+	} );
+
+	test( 'A page location set by the merchant is left alone', async ( {
+		page,
+	} ) => {
+		const pageView = trackGtagEvent( page, 'page_view' );
+		await page.goto(
+			'shop/?ga4w_e2e_page_location=http://example.test/custom/&key=wc_order_abc'
+		);
+		const data = getEventData( await pageView, 'page_view' );
+
+		expect( data.dl ).toEqual( 'http://example.test/custom/' );
+
+		const config = await getGtagConfig( page );
+		expect( config.page_location ).toEqual( 'http://example.test/custom/' );
+	} );
+} );

--- a/tests/e2e/specs/js-scripts/wp-consent-api.test.js
+++ b/tests/e2e/specs/js-scripts/wp-consent-api.test.js
@@ -279,4 +279,90 @@ test.describe( 'WP Consent API Integration', () => {
 			getEventData( await revokedStatsAddEvent, 'add_to_cart' ).gcs
 		).toEqual( 'G100' );
 	} );
+
+	test( 'Consent update denying every type is sent while an opt-in site has no decision yet', async ( {
+		page,
+	} ) => {
+		await page.goto( 'shop?ga4w_e2e_consent_type=optin' );
+
+		const dataLayer = await page.evaluate( () => window.dataLayer );
+		const consentState = dataLayer.filter( ( i ) => i[ 0 ] === 'consent' );
+
+		await expect( consentState.length ).toEqual( 2 );
+		await expect( consentState[ 0 ][ 1 ] ).toEqual( 'default' );
+		await expect( consentState[ 1 ] ).toEqual( {
+			0: 'consent',
+			1: 'update',
+			2: {
+				analytics_storage: 'denied',
+				ad_storage: 'denied',
+				ad_user_data: 'denied',
+				ad_personalization: 'denied',
+			},
+		} );
+	} );
+
+	test( 'Event hits from an undecided opt-in visitor carry the denied state', async ( {
+		page,
+	} ) => {
+		const productID = await createSimpleProduct();
+
+		// The test defaults grant everything, so without the denied baseline this
+		// hit would read `G111`.
+		await page.goto( 'shop?ga4w_e2e_consent_type=optin' );
+
+		const addEvent = trackGtagEvent( page, 'add_to_cart' );
+		await storeApiAddToCart( page, productID );
+
+		expect( getEventData( await addEvent, 'add_to_cart' ).gcs ).toEqual(
+			'G100'
+		);
+	} );
+
+	test( 'No consent update is sent for undecided categories on an opt-out site', async ( {
+		page,
+	} ) => {
+		await page.goto( 'shop?ga4w_e2e_consent_type=optout' );
+
+		const dataLayer = await page.evaluate( () => window.dataLayer );
+		const consentState = dataLayer.filter( ( i ) => i[ 0 ] === 'consent' );
+
+		await expect( consentState.length ).toEqual( 1 );
+		await expect( consentState[ 0 ][ 1 ] ).toEqual( 'default' );
+	} );
+
+	test( 'Decided categories are still reported on an opt-out site', async ( {
+		page,
+	} ) => {
+		await page.goto( 'shop?ga4w_e2e_consent_type=optout' );
+		await page.evaluate( () =>
+			window.wp_set_consent( 'statistics', 'deny' )
+		);
+		await page.goto( 'shop?ga4w_e2e_consent_type=optout' );
+
+		const dataLayer = await page.evaluate( () => window.dataLayer );
+		const consentState = dataLayer.filter( ( i ) => i[ 0 ] === 'consent' );
+
+		// The undecided marketing category stays absent; only the decision is sent.
+		await expect( consentState.length ).toEqual( 2 );
+		await expect( consentState[ 1 ] ).toEqual( {
+			0: 'consent',
+			1: 'update',
+			2: { analytics_storage: 'denied' },
+		} );
+	} );
+
+	test( 'Consent state is unchanged when no consent type is declared', async ( {
+		page,
+	} ) => {
+		// The WP Consent API without a banner declares no type, so an undecided
+		// visitor keeps the region-scoped defaults instead of a denied baseline.
+		await page.goto( 'shop' );
+
+		const dataLayer = await page.evaluate( () => window.dataLayer );
+		const consentState = dataLayer.filter( ( i ) => i[ 0 ] === 'consent' );
+
+		await expect( consentState.length ).toEqual( 1 );
+		await expect( consentState[ 0 ][ 1 ] ).toEqual( 'default' );
+	} );
 } );

--- a/tests/e2e/test-snippets/test-snippets.php
+++ b/tests/e2e/test-snippets/test-snippets.php
@@ -168,3 +168,21 @@ add_filter(
 		return $cart_item;
 	}
 );
+
+/*
+ * Test-only consent type declaration. A consent management plugin declares
+ * whether the site is opt-in or opt-out through this filter; pass
+ * `ga4w_e2e_consent_type` to mimic one without installing a banner.
+ */
+add_filter(
+	'wp_get_consent_type',
+	function ( $type ) {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( ! isset( $_GET['ga4w_e2e_consent_type'] ) ) {
+			return $type;
+		}
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		return sanitize_text_field( wp_unslash( $_GET['ga4w_e2e_consent_type'] ) );
+	}
+);

--- a/tests/e2e/test-snippets/test-snippets.php
+++ b/tests/e2e/test-snippets/test-snippets.php
@@ -186,3 +186,21 @@ add_filter(
 		return sanitize_text_field( wp_unslash( $_GET['ga4w_e2e_consent_type'] ) );
 	}
 );
+
+/*
+ * Test-only page location override, mimicking a merchant that sets
+ * `page_location` themselves. Pass `ga4w_e2e_page_location` to check that the
+ * redaction leaves their value alone.
+ */
+add_filter(
+	'woocommerce_ga_gtag_config',
+	function ( $config ) {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( isset( $_GET['ga4w_e2e_page_location'] ) ) {
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$config['page_location'] = sanitize_text_field( wp_unslash( $_GET['ga4w_e2e_page_location'] ) );
+		}
+
+		return $config;
+	}
+);

--- a/tests/e2e/utils/track-event.js
+++ b/tests/e2e/utils/track-event.js
@@ -50,11 +50,36 @@ function withProductData( data ) {
 }
 
 /**
+ * Whether the `dl` (page_location) of a hit points at the given path on the
+ * current site. Only hostname and path are compared: the plugin sets
+ * page_location from document.location.href, which keeps the port, while
+ * gtag's own default omits it.
+ *
+ * @param {string|null} pageLocation The `dl` parameter of the hit.
+ * @param {string}      pageUrl      The current page URL.
+ * @param {string}      urlPath      Path prefix without the leading slash, e.g. `checkout`.
+ *
+ * @return {boolean} Whether the hit was sent from that path.
+ */
+function pageLocationMatches( pageLocation, pageUrl, urlPath ) {
+	try {
+		const sent = new URL( pageLocation );
+		return (
+			sent.hostname === new URL( pageUrl ).hostname &&
+			( sent.pathname === `/${ urlPath }` ||
+				sent.pathname.startsWith( `/${ urlPath }/` ) )
+		);
+	} catch {
+		return false;
+	}
+}
+
+/**
  * Tracks when the Gtag Event request matching a specific name is sent.
  *
  * @param {Page}        page
  * @param {string}      eventName Event name to match.
- * @param {string|null} urlPath   The starting path to match where the event should be triggered.
+ * @param {string|null} urlPath   Path prefix (without leading slash) the hit's page location must start with.
  *
  * @return {Promise<Request>} Matching request.
  */
@@ -70,13 +95,8 @@ export function trackGtagEvent( page, eventName, urlPath = null ) {
 		}
 
 		const params = new URL( url ).searchParams;
-		const pageUrl = new URL( page.url() );
 		const urlPathMatches = urlPath
-			? params
-					.get( 'dl' )
-					?.includes(
-						`${ pageUrl.protocol }//${ pageUrl.hostname }/${ urlPath }`
-					)
+			? pageLocationMatches( params.get( 'dl' ), page.url(), urlPath )
 			: true;
 
 		// Match a single event sent in query parameters.

--- a/tests/js/url-redaction.test.js
+++ b/tests/js/url-redaction.test.js
@@ -1,0 +1,258 @@
+/**
+ * Unit tests for the URL redaction helper the gtag snippet installs.
+ *
+ * The helper ships as JavaScript embedded in a PHP string, so the test reads it
+ * straight out of the source file and runs it against a stubbed `document`.
+ * Run with `npm run test:js`.
+ */
+
+/**
+ * External dependencies
+ */
+const { test } = require( 'node:test' );
+const assert = require( 'node:assert' );
+const fs = require( 'fs' );
+const path = require( 'path' );
+
+const SOURCE = path.join(
+	__dirname,
+	'..',
+	'..',
+	'includes',
+	'class-wc-google-gtag-js.php'
+);
+const FACTORY_START = 'window.wcGoogleAnalyticsIntegration.redactGtagConfig = ';
+const FACTORY_END = '( %1$s );';
+
+/**
+ * The `(function ( redaction ) { … })` factory, read from the PHP source.
+ *
+ * @return {string} The factory source.
+ */
+function readFactorySource() {
+	const php = fs.readFileSync( SOURCE, 'utf8' );
+	const start = php.indexOf( FACTORY_START );
+	const end = php.indexOf( FACTORY_END, start );
+
+	if ( start === -1 || end === -1 ) {
+		throw new Error(
+			`Could not find the redaction helper in ${ SOURCE }. If it was renamed or moved, update FACTORY_START/FACTORY_END here.`
+		);
+	}
+
+	return php.slice( start + FACTORY_START.length, end );
+}
+
+const factorySource = readFactorySource();
+
+const DEFAULT_REDACTION = {
+	params: [ 'key', 'login', 'session', 'redirect' ],
+	order_endpoints: [ 'order-received', 'order-pay' ],
+	order_params: [
+		'order-received',
+		'order-pay',
+		'page_id',
+		'pay_for_order',
+		'utm_source',
+		'_gl',
+	],
+};
+
+/**
+ * Build the helper with a stubbed browser environment.
+ *
+ * @param {Object}   options           Test options.
+ * @param {string}   options.href      The page URL the stubbed document reports.
+ * @param {string}   options.referrer  The referrer the stubbed document reports.
+ * @param {Object}   options.redaction The redaction lists passed to the factory.
+ * @param {Function} options.urlImpl   The `URL` implementation the helper sees.
+ *
+ * @return {Function} The `redactGtagConfig( config )` helper.
+ */
+function createHelper( {
+	href = 'http://example.test/shop/',
+	referrer = '',
+	redaction = DEFAULT_REDACTION,
+	urlImpl = URL,
+} = {} ) {
+	const documentStub = { location: { href }, referrer };
+
+	const factory = new Function(
+		'document',
+		'URL',
+		`return ${ factorySource };`
+	);
+
+	return factory( documentStub, urlImpl )( redaction );
+}
+
+/**
+ * Run the helper against a URL and return the resulting page_location.
+ *
+ * @param {string} href      The page URL.
+ * @param {Object} redaction Optional redaction lists.
+ *
+ * @return {string|undefined} The page_location the helper set, if any.
+ */
+function locationFor( href, redaction ) {
+	return createHelper( { href, redaction } )( {} ).page_location;
+}
+
+test( 'strips denylisted parameters and keeps the rest', () => {
+	assert.strictEqual(
+		locationFor(
+			'http://example.test/shop/?utm_source=e2e&key=wc_order_abc&login=bob&foo=bar'
+		),
+		'http://example.test/shop/?utm_source=e2e&foo=bar'
+	);
+} );
+
+test( 'strips an order key by value under any parameter name', () => {
+	assert.strictEqual(
+		locationFor( 'http://example.test/shop/?order=wc_order_abc&foo=1' ),
+		'http://example.test/shop/?foo=1'
+	);
+} );
+
+test( 'strips an order key whose format was filtered away from wc_order_', () => {
+	assert.strictEqual(
+		locationFor( 'http://example.test/shop/?order=wc_abc123&foo=1' ),
+		'http://example.test/shop/?foo=1'
+	);
+} );
+
+test( 'strips an order key nested in another URL', () => {
+	const nested = encodeURIComponent(
+		'http://example.test/checkout/order-received/5/?key=wc_order_abc'
+	);
+
+	assert.strictEqual(
+		locationFor( `http://example.test/shop/?return_url=${ nested }&foo=1` ),
+		'http://example.test/shop/?foo=1'
+	);
+} );
+
+test( 'matches parameter names case-insensitively and keeps the original case of the rest', () => {
+	assert.strictEqual(
+		locationFor( 'http://example.test/shop/?KEY=1&Login=2&Foo=Bar' ),
+		'http://example.test/shop/?Foo=Bar'
+	);
+} );
+
+test( 'keeps only allowlisted parameters on an order-received path', () => {
+	assert.strictEqual(
+		locationFor(
+			'http://example.test/checkout/order-received/5/?key=wc_order_a&utm_source=e2e&_gl=1x&pay_for_order=true&foo=bar'
+		),
+		'http://example.test/checkout/order-received/5/?utm_source=e2e&_gl=1x&pay_for_order=true'
+	);
+} );
+
+test( 'detects an order page from the query string on plain permalinks', () => {
+	assert.strictEqual(
+		locationFor(
+			'http://example.test/?page_id=8&order-received=5&key=wc_order_a&foo=bar'
+		),
+		'http://example.test/?page_id=8&order-received=5'
+	);
+} );
+
+test( 'follows a custom endpoint slug', () => {
+	const redaction = {
+		...DEFAULT_REDACTION,
+		order_endpoints: [ 'thank-you', 'order-pay' ],
+		order_params: [ 'thank-you', 'utm_source' ],
+	};
+
+	assert.strictEqual(
+		locationFor(
+			'http://example.test/checkout/thank-you/5/?key=wc_order_a&foo=bar&utm_source=e2e',
+			redaction
+		),
+		'http://example.test/checkout/thank-you/5/?utm_source=e2e'
+	);
+} );
+
+test( 'keeps the encoding of the parameters it does not strip', () => {
+	assert.strictEqual(
+		locationFor( 'http://example.test/shop/?color=red%20blue&q=a~b&key=1' ),
+		'http://example.test/shop/?color=red%20blue&q=a~b'
+	);
+} );
+
+test( 'keeps repeated parameters', () => {
+	assert.strictEqual(
+		locationFor( 'http://example.test/shop/?a=1&a=2&key=1' ),
+		'http://example.test/shop/?a=1&a=2'
+	);
+} );
+
+test( 'preserves the fragment', () => {
+	assert.strictEqual(
+		locationFor( 'http://example.test/shop/?key=1&a=b#reviews' ),
+		'http://example.test/shop/?a=b#reviews'
+	);
+} );
+
+test( 'leaves no empty query string behind', () => {
+	assert.strictEqual(
+		locationFor( 'http://example.test/shop/?key=wc_order_a' ),
+		'http://example.test/shop/'
+	);
+} );
+
+test( 'sets nothing when there is nothing to strip', () => {
+	const config = createHelper( {
+		href: 'http://example.test/shop/?color=red%20blue&utm_source=e2e',
+	} )( {} );
+
+	assert.deepStrictEqual( config, {} );
+} );
+
+test( 'redacts the referrer independently of the page URL', () => {
+	const config = createHelper( {
+		href: 'http://example.test/shop/',
+		referrer:
+			'http://example.test/checkout/order-received/5/?key=wc_order_a&utm_source=e2e',
+	} )( {} );
+
+	assert.deepStrictEqual( config, {
+		page_referrer:
+			'http://example.test/checkout/order-received/5/?utm_source=e2e',
+	} );
+} );
+
+test( 'leaves a page_location supplied by the merchant untouched', () => {
+	const config = createHelper( {
+		href: 'http://example.test/shop/?key=wc_order_a',
+	} )( { page_location: 'http://example.test/custom/' } );
+
+	assert.strictEqual( config.page_location, 'http://example.test/custom/' );
+} );
+
+test( 'does nothing when redaction is disabled', () => {
+	const config = createHelper( {
+		href: 'http://example.test/shop/?key=wc_order_a',
+		redaction: [],
+	} )( { track_404: true } );
+
+	assert.deepStrictEqual( config, { track_404: true } );
+} );
+
+test( 'returns a config it cannot inspect unchanged', () => {
+	assert.strictEqual(
+		createHelper( { href: 'http://example.test/shop/?key=1' } )( null ),
+		null
+	);
+} );
+
+test( 'falls back to the path when the URL cannot be parsed', () => {
+	const config = createHelper( {
+		href: 'http://example.test/shop/?key=wc_order_a#x',
+		urlImpl: function BrokenUrl() {
+			throw new Error( 'unparsable' );
+		},
+	} )( {} );
+
+	assert.strictEqual( config.page_location, 'http://example.test/shop/' );
+} );

--- a/tests/js/url-redaction.test.js
+++ b/tests/js/url-redaction.test.js
@@ -132,6 +132,27 @@ test( 'strips an order key nested in another URL', () => {
 	);
 } );
 
+test( 'strips a nested order key whose format was filtered away from wc_order_', () => {
+	const nested = encodeURIComponent(
+		'http://example.test/checkout/order-received/5/?key=wc_abc123'
+	);
+
+	assert.strictEqual(
+		locationFor( `http://example.test/shop/?return_url=${ nested }&foo=1` ),
+		'http://example.test/shop/?foo=1'
+	);
+} );
+
+test( 'keeps a value that merely contains wc_ in ordinary text', () => {
+	// Nothing is stripped, so the helper leaves the config alone.
+	assert.strictEqual(
+		locationFor(
+			'http://example.test/shop/?utm_campaign=summer_wc_sale&foo=1'
+		),
+		undefined
+	);
+} );
+
 test( 'matches parameter names case-insensitively and keeps the original case of the rest', () => {
 	assert.strictEqual(
 		locationFor( 'http://example.test/shop/?KEY=1&Login=2&Foo=Bar' ),

--- a/tests/unit-tests/Configuration.php
+++ b/tests/unit-tests/Configuration.php
@@ -162,6 +162,140 @@ class Configuration extends EventsDataTest {
 	}
 
 	/**
+	 * Default denylist for the page URL / referrer redaction.
+	 *
+	 * @return void
+	 */
+	public function test_get_redacted_url_params_defaults() {
+		$gtag = new WC_Google_Gtag_JS();
+
+		$this->assertEquals(
+			[ 'key', 'login', 'session', 'email', 'uid', '_wpnonce', '_wp_http_referer', 'woo-share', 'moderation-hash', 'unapproved', 'email_link_action_key', 'consumer_key', 'consumer_secret', 'redirect', 'redirect_to' ],
+			$gtag->get_redacted_url_params()
+		);
+	}
+
+	/**
+	 * The denylist filter output is lower-cased, de-duplicated and cleaned of non-strings.
+	 *
+	 * @return void
+	 */
+	public function test_get_redacted_url_params_filter_output_is_normalized() {
+		$callback = function () {
+			return [ 'KEY', 'Token', 'token', '', 123, null, [ 'nested' ] ];
+		};
+		add_filter( 'woocommerce_ga_redacted_url_params', $callback );
+
+		try {
+			$gtag = new WC_Google_Gtag_JS();
+			$this->assertEquals( [ 'key', 'token' ], $gtag->get_redacted_url_params() );
+		} finally {
+			remove_filter( 'woocommerce_ga_redacted_url_params', $callback );
+		}
+	}
+
+	/**
+	 * Endpoint slugs come from WooCommerce's query vars, so renamed endpoints are honoured.
+	 *
+	 * @return void
+	 */
+	public function test_get_order_page_endpoints_follow_woocommerce_query_vars() {
+		$gtag = new WC_Google_Gtag_JS();
+		$this->assertEquals( [ 'order-received', 'order-pay' ], $gtag->get_order_page_endpoints() );
+
+		$callback = function ( $vars ) {
+			$vars['order-received'] = 'Thank-You';
+			return $vars;
+		};
+		add_filter( 'woocommerce_get_query_vars', $callback );
+
+		try {
+			$this->assertEquals( [ 'thank-you', 'order-pay' ], $gtag->get_order_page_endpoints(), 'Custom slugs are read and lower-cased' );
+			$this->assertContains( 'thank-you', $gtag->get_order_page_allowed_url_params(), 'The custom slug is kept on order pages' );
+		} finally {
+			remove_filter( 'woocommerce_get_query_vars', $callback );
+		}
+	}
+
+	/**
+	 * Without WC()->query the stock slugs are used.
+	 *
+	 * @return void
+	 */
+	public function test_get_order_page_endpoints_fall_back_to_stock_slugs_without_wc_query() {
+		$gtag       = new WC_Google_Gtag_JS();
+		$query      = WC()->query;
+		WC()->query = null;
+
+		try {
+			$this->assertEquals( [ 'order-received', 'order-pay' ], $gtag->get_order_page_endpoints() );
+		} finally {
+			WC()->query = $query;
+		}
+	}
+
+	/**
+	 * Default allowlist for order pages: the endpoint vars, pay_for_order, campaign and click ids, the linker param.
+	 *
+	 * @return void
+	 */
+	public function test_get_order_page_allowed_url_params_defaults() {
+		$gtag = new WC_Google_Gtag_JS();
+
+		$this->assertEquals(
+			[ 'order-received', 'order-pay', 'pay_for_order', 'page_id', 'p', 'pagename', 'lang', 'currency', 'utm_source', 'utm_medium', 'utm_campaign', 'utm_term', 'utm_content', 'utm_id', 'utm_source_platform', 'utm_creative_format', 'utm_marketing_tactic', 'utm_nooverride', 'srsltid', 'gclid', 'gbraid', 'wbraid', 'dclid', 'fbclid', 'msclkid', '_gl' ],
+			$gtag->get_order_page_allowed_url_params()
+		);
+	}
+
+	/**
+	 * The allowlist filter receives the endpoint slugs and its output is normalized.
+	 *
+	 * @return void
+	 */
+	public function test_get_order_page_allowed_url_params_filter_receives_endpoints() {
+		$received = null;
+		$callback = function ( $params, $endpoints ) use ( &$received ) {
+			$received = $endpoints;
+			$params[] = 'REF';
+			return $params;
+		};
+		add_filter( 'woocommerce_ga_order_page_allowed_url_params', $callback, 10, 2 );
+
+		try {
+			$gtag   = new WC_Google_Gtag_JS();
+			$params = $gtag->get_order_page_allowed_url_params();
+
+			$this->assertEquals( [ 'order-received', 'order-pay' ], $received );
+			$this->assertContains( 'ref', $params );
+		} finally {
+			remove_filter( 'woocommerce_ga_order_page_allowed_url_params', $callback );
+		}
+	}
+
+	/**
+	 * The snippet config carries the three lists, or nothing when disabled.
+	 *
+	 * @return void
+	 */
+	public function test_get_url_redaction_config_shape_and_off_switch() {
+		$gtag   = new WC_Google_Gtag_JS();
+		$config = $gtag->get_url_redaction_config();
+
+		$this->assertEquals( [ 'params', 'order_endpoints', 'order_params' ], array_keys( $config ) );
+		$this->assertEquals( $gtag->get_redacted_url_params(), $config['params'] );
+		$this->assertEquals( $gtag->get_order_page_endpoints(), $config['order_endpoints'] );
+		$this->assertEquals( $gtag->get_order_page_allowed_url_params(), $config['order_params'] );
+
+		add_filter( 'woocommerce_ga_url_redaction_enabled', '__return_false' );
+		try {
+			$this->assertEquals( [], $gtag->get_url_redaction_config() );
+		} finally {
+			remove_filter( 'woocommerce_ga_url_redaction_enabled', '__return_false' );
+		}
+	}
+
+	/**
 	 * Test that get_consent_modes returns an array with one mode.
 	 *
 	 * @return void

--- a/tests/unit-tests/RegisterScripts.php
+++ b/tests/unit-tests/RegisterScripts.php
@@ -132,6 +132,104 @@ class RegisterScripts extends WP_UnitTestCase {
 
 		$this->assertStringContainsString( '/* replaced snippet */', $snippet );
 		$this->assertStringNotContainsString( 'gtag("config"', $snippet, 'The default snippet should be replaced, not appended' );
+		$this->assertStringContainsString(
+			'window.wcGoogleAnalyticsIntegration.redactGtagConfig',
+			$this->get_inline_snippet( $gtag->gtag_script_handle, 'before' ),
+			'The redaction helper stays available to a replacement snippet'
+		);
+	}
+
+	/**
+	 * The config call must go through the redaction helper, and the helper must be
+	 * installed with the lists PHP resolved.
+	 *
+	 * @return void
+	 */
+	public function test_inline_snippet_redacts_the_page_url_before_configuring_the_property() {
+		$gtag    = new WC_Google_Gtag_JS( [ 'ga_id' => 'G-TEST123' ] );
+		$snippet = $this->get_inline_snippet( $gtag->gtag_script_handle );
+		$helper  = $this->get_inline_snippet( $gtag->gtag_script_handle, 'before' );
+
+		$this->assertStringContainsString(
+			'window.wcGoogleAnalyticsIntegration.redactGtagConfig',
+			$helper,
+			'The redaction helper should be installed before the snippet runs'
+		);
+		$this->assertStringContainsString(
+			'redactGtagConfig || function ( config ) { return config; } )( {',
+			$snippet,
+			'The config call should pass its config through the helper'
+		);
+		$this->assertStringContainsString(
+			wp_json_encode( $gtag->get_url_redaction_config(), JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ),
+			$helper,
+			'The helper should receive the redaction lists as JSON'
+		);
+	}
+
+	/**
+	 * The lists are filterable and the filtered values must reach the helper.
+	 *
+	 * @return void
+	 */
+	public function test_inline_snippet_embeds_filtered_redaction_lists() {
+		$deny  = function () {
+			return [ 'key', 'token' ];
+		};
+		$allow = function ( $params ) {
+			$params[] = 'ref';
+			return $params;
+		};
+		add_filter( 'woocommerce_ga_redacted_url_params', $deny );
+		add_filter( 'woocommerce_ga_order_page_allowed_url_params', $allow );
+
+		$gtag   = new WC_Google_Gtag_JS( [ 'ga_id' => 'G-TEST123' ] );
+		$helper = $this->get_inline_snippet( $gtag->gtag_script_handle, 'before' );
+
+		remove_filter( 'woocommerce_ga_redacted_url_params', $deny );
+		remove_filter( 'woocommerce_ga_order_page_allowed_url_params', $allow );
+
+		$this->assertStringContainsString( '"params":["key","token"]', $helper );
+		$this->assertStringNotContainsString( '"login"', $helper, 'Replaced denylist entries should be gone' );
+		$this->assertStringContainsString( ',"ref"]', $helper, 'Appended allowlist entries should be embedded' );
+	}
+
+	/**
+	 * Disabling redaction must leave the helper without lists, which makes it
+	 * return the config untouched.
+	 *
+	 * @return void
+	 */
+	public function test_inline_snippet_carries_no_redaction_lists_when_disabled() {
+		add_filter( 'woocommerce_ga_url_redaction_enabled', '__return_false' );
+
+		$gtag   = new WC_Google_Gtag_JS( [ 'ga_id' => 'G-TEST123' ] );
+		$helper = $this->get_inline_snippet( $gtag->gtag_script_handle, 'before' );
+
+		remove_filter( 'woocommerce_ga_url_redaction_enabled', '__return_false' );
+
+		$this->assertStringNotContainsString( '"order_endpoints"', $helper );
+		$this->assertStringContainsString( '})( [] );', $helper, 'An empty configuration should be passed to the helper' );
+	}
+
+	/**
+	 * Filter-supplied names are printed inside a script tag, so markup must be escaped.
+	 *
+	 * @return void
+	 */
+	public function test_inline_snippet_escapes_markup_in_redaction_lists() {
+		$callback = function () {
+			return [ 'key', '</script><script>alert(1)</script>' ];
+		};
+		add_filter( 'woocommerce_ga_redacted_url_params', $callback );
+
+		$gtag   = new WC_Google_Gtag_JS( [ 'ga_id' => 'G-TEST123' ] );
+		$helper = $this->get_inline_snippet( $gtag->gtag_script_handle, 'before' );
+
+		remove_filter( 'woocommerce_ga_redacted_url_params', $callback );
+
+		$this->assertStringNotContainsString( '</script>', $helper );
+		$this->assertStringContainsString( '\u003C/script\u003E', $helper, 'JSON_HEX_TAG should encode the angle brackets' );
 	}
 
 	/**
@@ -151,18 +249,19 @@ class RegisterScripts extends WP_UnitTestCase {
 	/**
 	 * Read the concatenated inline "after" data attached to a script handle.
 	 *
-	 * @param string $handle The registered script handle.
+	 * @param string $handle   The registered script handle.
+	 * @param string $position  Which inline scripts to read, `before` or `after`.
 	 *
 	 * @return string
 	 */
-	private function get_inline_snippet( $handle ) {
+	private function get_inline_snippet( $handle, $position = 'after' ) {
 		// query() returns false for an unregistered handle instead of raising an
 		// undefined-array-key warning like a direct registered[] access would.
 		$registered = wp_scripts()->query( $handle );
 		$this->assertNotFalse( $registered, "Script handle '{$handle}' should be registered" );
 
-		$after = $registered->extra['after'] ?? [];
-		return implode( "\n", array_filter( (array) $after, 'is_string' ) );
+		$scripts = $registered->extra[ $position ] ?? [];
+		return implode( "\n", array_filter( (array) $scripts, 'is_string' ) );
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes [STORMA-180](https://linear.app/a8c/issue/STORMA-180/sec-1-redact-sensitive-url-params-before-analytics-dispatch-2-1).

The order-received URL carries the order key (`?key=wc_order_…`), a bearer token for the order. gtag sent it to Google in `dl` with every hit and in `dr` on the next page, where anyone with access to the GA4 property could replay it.

The page URL and referrer are now filtered in the browser before gtag reads them: a filterable denylist plus a value rule on every page, and an allowlist on the order-received and order-pay pages. The value rule matches `wc_` rather than `wc_order_`, since WooCommerce only guarantees that half of the prefix, and matches anywhere in the value so a key nested in a return URL is caught too. Filtering runs client-side because the snippet is built before the main query is parsed and full-page caches would otherwise serve one URL for every query string. The helper is registered outside the `woocommerce_gtag_snippet` filter, so replacing the snippet does not silently drop the protection. URLs with nothing to strip pass through untouched, and `page_location`/`page_referrer` set through `woocommerce_ga_gtag_config` win.

On a site the WP Consent API reports as opt-in, a visitor who has not answered the banner is now sent an explicit `denied` instead of being left on the regional defaults. Sites reported as opt-out, and sites where nothing declares a consent type, keep the defaults, so they do not lose measurement they have today.

Not covered: browsers still send the page URL in the `Referer` header of the requests the page makes, and other tags on the page report their own `page_location`.

### Checks:
* [x] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Screenshots:

n/a

### Detailed test instructions:

1. Run `npm run test:js`, `npm run test:php` and `npm run test:e2e`.
2. Place an order. In DevTools → Network, filter `collect`: `dl` on the `page_view` and `purchase` hits has no `key=`. Go to the shop: `dr` has no `key=`.
3. Open `/shop/?utm_source=x&foo=bar`: `dl` matches the browser URL and the `config` entry in `window.dataLayer` has no `page_location`.

### Additional details:

New filters: `woocommerce_ga_redacted_url_params`, `woocommerce_ga_order_page_allowed_url_params`, `woocommerce_ga_url_redaction_enabled`, documented in the README along with `wcGoogleAnalyticsIntegration.redactGtagConfig()`, which a replacement snippet can call to keep the redaction.

The redaction helper is JavaScript embedded in a PHP string, so `npm run test:js` reads it out of the source file and runs its branches on the node test runner. The E2E helper now compares hostname and path of `dl`, because an explicit `page_location` keeps the port that gtag's default omits.

### Changelog entry

> Fix - Strip the order key and other sensitive query parameters from the page URL and referrer sent to Google Analytics, and send an explicit denied consent state for undecided visitors on opt-in sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
No issues found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->