### PR TITLE
Move the wp-env environments to PHP 8.2

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,5 +1,5 @@
 {
-	"phpVersion": "8.0",
+	"phpVersion": "8.2",
 	"port": 8888,
 	"testsEnvironment": false,
 	"plugins": [

--- a/.wp-env.test.json
+++ b/.wp-env.test.json
@@ -1,5 +1,5 @@
 {
-	"phpVersion": "8.0",
+	"phpVersion": "8.2",
 	"port": 8889,
 	"testsEnvironment": false,
 	"plugins": [


### PR DESCRIPTION
### Changes proposed in this Pull Request:

E2E is red on `trunk` and every branch, and wp-env cannot start locally either. The job fails at "Start wp-env container", before a single test runs:

```
E: Release file for http://deb.debian.org/debian-security/dists/bullseye-security/InRelease
   is expired (invalid since 8h 40min 34s).
ERROR: process "/bin/sh -c apt-get -qy update" did not complete successfully: exit code: 100
```

Both `.wp-env.json` and `.wp-env.test.json` pin `"phpVersion": "8.0"`, and the `wordpress:php8.0` image is Debian bullseye. Bullseye reached the end of its LTS on 2026-08-31 and its security `Release` file expired on 2026-09-07, so `apt-get update` inside the image wp-env builds now refuses to run and no environment can be created. Nothing in the plugin changed; the first `trunk` run after the expiry simply happened to be the one that caught it ([run 34192281929](https://github.com/woocommerce/woocommerce-google-analytics-integration/actions/runs/34192281929)).

This moves both environments to PHP 8.2, whose image is bookworm-based.

It only changes the runtime of the local and E2E test site. The plugin still declares `Requires PHP: 7.4`, and the unit test matrix still covers 7.4, because `php-unit-tests.yml` uses `shivammathur/setup-php` rather than wp-env — which is also why PHP Unit Tests, Build, PHP Coding Standards and JavaScript Linting all stayed green on the same commit where E2E failed.

### Checks:
* [x] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Screenshots:

_N/A_

### Detailed test instructions:

1. `npm run wp-env:destroy` to remove any existing environment, so the image is rebuilt from scratch.
2. `npm run wp-env:up` — this is the step that currently fails on `trunk`; it should complete and serve http://localhost:8889.
3. `npx wp-env run cli --config=.wp-env.test.json -- php -v` reports 8.2.
4. `npm run test:php:setup && npm run test:php` and `npm run test:e2e` both pass.

Verified locally on a fresh environment: wp-env starts, PHP reports 8.2.33, PHPUnit is green (119 tests, 348 assertions) and the E2E suite passes apart from two failures that are artifacts of running from a git worktree (the plugin directory name differs from the slug `installation.test.js` hardcodes) and reproduce on `trunk` without this change.

### Additional details:

PHP 8.2 matches the primary version already used by the unit test matrix.

### Changelog entry

_N/A — test environment only, no user-facing change._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
