### PR TITLE
Harden the release and test pipelines

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,14 +1,17 @@
 name: Deploy Product
 
 # **What it does**: Builds and publishes a release to WordPress.org, Woo.com and GitHub.
-# **How to use it**: Run it from the `release/x.y.z` branch (or the `x.y.z` tag) that
-# matches the `version` input. Dry runs need no approval and never see the WP.org
-# publishing password. Production runs wait for approval on the `production` environment
-# and ship the exact commit that was approved.
+# **How to use it**: Run it from the `release/x.y.z` or `hotfix/x.y.z` branch that matches
+# the `version` input. Dry runs need no approval and never see the WP.org publishing
+# password. Production runs wait for approval on the `production` environment and refuse
+# to start if the branch moved since the approved commit. The action itself resolves the
+# branch by name, so the branch must also be protected against force pushes.
 #
 # The `woocommerce/woo-product-deploy` action is pinned to a commit SHA. Dependabot does
 # not track `repository:` refs in `actions/checkout`, so bump `WOO_PRODUCT_DEPLOY_SHA`
 # through a reviewed PR after checking the upstream diff.
+
+run-name: Deploy ${{ inputs.version }} from ${{ github.ref_name }}${{ inputs.simulate && ' (dry run)' || '' }}
 
 on:
   workflow_dispatch:
@@ -41,6 +44,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 env:
   # woocommerce/woo-product-deploy trunk @ 2026-08-31
   WOO_PRODUCT_DEPLOY_SHA: 5f5b49d49b8a3681a7a99efec089187666885759
@@ -63,12 +70,14 @@ jobs:
           SHA: ${{ github.sha }}
           SIMULATE: ${{ inputs.simulate }}
         run: |
-          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
-            echo "::error::Invalid version format '$VERSION'. Expected X.Y.Z or X.Y.Z-suffix."
+          # Same pattern as validate-inputs.sh in woo-product-deploy, so a version that
+          # passes here also passes inside the action.
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)?$ ]]; then
+            echo "::error::Invalid version format '$VERSION'. Expected X.Y.Z or X.Y.Z-suffix (no dots in the suffix)."
             exit 1
           fi
-          if [[ "$REF" != "refs/heads/release/${VERSION}" && "$REF" != "refs/tags/${VERSION}" ]]; then
-            echo "::error::Refusing to deploy '${REF}'. Run this workflow from 'release/${VERSION}' or the '${VERSION}' tag."
+          if [[ "$REF" != "refs/heads/release/${VERSION}" && "$REF" != "refs/heads/hotfix/${VERSION}" ]]; then
+            echo "::error::Refusing to deploy '${REF}'. Run this workflow from 'release/${VERSION}' or 'hotfix/${VERSION}'."
             exit 1
           fi
           echo "ref_name=${REF_NAME}" >> "$GITHUB_OUTPUT"
@@ -99,6 +108,8 @@ jobs:
 
       # Dry runs do not publish, so they never receive the WP.org SVN password.
       # Partner credentials are kept so QIT tests still run against the built zip.
+      # wporg_release is forced on because the action needs at least one release
+      # target enabled to set up woorelease, and simulate mode never commits.
       - name: Simulate deploy
         uses: ./.github/actions/woo-product-deploy
         with:
@@ -108,7 +119,7 @@ jobs:
           node_version: '24'
           npm_version: '11'
           simulate: true
-          wporg_release: ${{ inputs.deploy_wporg }}
+          wporg_release: true
           wccom_release: ${{ inputs.deploy_woo }}
           github_release: ${{ inputs.deploy_github }}
           deploy_pat: ${{ secrets.ORG_DEPLOY_SECRET }}
@@ -126,8 +137,8 @@ jobs:
     timeout-minutes: 15
     environment: production
     steps:
-      # The approval can happen long after the run was queued. Make sure the ref still
-      # points at the commit the reviewer saw in the summary.
+      # The approval can happen long after the run was queued. Refuse to start if the
+      # ref no longer points at the commit the reviewer saw in the summary.
       - name: Check that the approved commit is still the head of the ref
         env:
           REF: ${{ github.ref }}
@@ -167,8 +178,8 @@ jobs:
           wccom_release: ${{ inputs.deploy_woo }}
           github_release: ${{ inputs.deploy_github }}
           deploy_pat: ${{ secrets.ORG_DEPLOY_SECRET }}
-          wporg_username: ${{ secrets.WPORG_SVN_USERNAME }}
-          wporg_password: ${{ secrets.WPORG_SVN_PASSWORD }}
+          wporg_username: ${{ inputs.deploy_wporg && secrets.WPORG_SVN_USERNAME || '' }}
+          wporg_password: ${{ inputs.deploy_wporg && secrets.WPORG_SVN_PASSWORD || '' }}
           partner_user: ${{ secrets.ORG_PARTNER_USER }}
           partner_secret: ${{ secrets.ORG_PARTNER_DEPLOY_SECRET }}
           wccom_product_id: 1442927

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,15 @@
 name: Deploy Product
 
+# **What it does**: Builds and publishes a release to WordPress.org, Woo.com and GitHub.
+# **How to use it**: Run it from the `release/x.y.z` branch (or the `x.y.z` tag) that
+# matches the `version` input. Dry runs need no approval and never see the WP.org
+# publishing password. Production runs wait for approval on the `production` environment
+# and ship the exact commit that was approved.
+#
+# The `woocommerce/woo-product-deploy` action is pinned to a commit SHA. Dependabot does
+# not track `repository:` refs in `actions/checkout`, so bump `WOO_PRODUCT_DEPLOY_SHA`
+# through a reviewed PR after checking the upstream diff.
+
 on:
   workflow_dispatch:
     inputs:
@@ -27,58 +37,132 @@ on:
         required: false
         default: true
         type: boolean
-  workflow_call:
-    inputs:
-      version:
-        description: 'Version to deploy (e.g., 2.1.21)'
-        required: true
-        type: string
-      deploy_wporg:
-        description: 'Deploy to WordPress.org'
-        required: false
-        default: true
-        type: boolean
-      deploy_woo:
-        description: 'Deploy to Woo.com'
-        required: false
-        default: true
-        type: boolean
-      deploy_github:
-        description: 'Deploy to GitHub'
-        required: false
-        default: true
-        type: boolean
-      simulate:
-        description: 'Dry run mode'
-        required: false
-        default: true
-        type: boolean
+
+permissions:
+  contents: read
+
+env:
+  # woocommerce/woo-product-deploy trunk @ 2026-08-31
+  WOO_PRODUCT_DEPLOY_SHA: 5f5b49d49b8a3681a7a99efec089187666885759
 
 jobs:
-  deploy:
+  validate:
+    name: Validate release ref
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      ref_name: ${{ steps.check.outputs.ref_name }}
+      sha: ${{ steps.check.outputs.sha }}
+    steps:
+      - name: Check that the ref matches the version
+        id: check
+        env:
+          VERSION: ${{ inputs.version }}
+          REF: ${{ github.ref }}
+          REF_NAME: ${{ github.ref_name }}
+          SHA: ${{ github.sha }}
+          SIMULATE: ${{ inputs.simulate }}
+        run: |
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+            echo "::error::Invalid version format '$VERSION'. Expected X.Y.Z or X.Y.Z-suffix."
+            exit 1
+          fi
+          if [[ "$REF" != "refs/heads/release/${VERSION}" && "$REF" != "refs/tags/${VERSION}" ]]; then
+            echo "::error::Refusing to deploy '${REF}'. Run this workflow from 'release/${VERSION}' or the '${VERSION}' tag."
+            exit 1
+          fi
+          echo "ref_name=${REF_NAME}" >> "$GITHUB_OUTPUT"
+          echo "sha=${SHA}" >> "$GITHUB_OUTPUT"
+          {
+            echo "### Release ${VERSION}"
+            echo "- Ref: \`${REF}\`"
+            echo "- Commit: \`${SHA}\`"
+            echo "- Dry run: \`${SIMULATE}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  dry-run:
+    name: Dry run
+    if: inputs.simulate
+    needs: validate
     runs-on: ubuntu-latest
     timeout-minutes: 15
-
     steps:
-      # Checkout the private action repository
+      # The action lives in a private repository, so a PAT is needed to check it out.
       - name: Checkout woo-product-deploy action
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           repository: woocommerce/woo-product-deploy
-          ref: trunk
+          ref: ${{ env.WOO_PRODUCT_DEPLOY_SHA }}
           path: ./.github/actions/woo-product-deploy
-          token: ${{ secrets.ORG_DEPLOY_SECRET }}  # Need PAT with access to the action repository
+          token: ${{ secrets.ORG_DEPLOY_SECRET }}
+          persist-credentials: false
 
-      # Use the action we checked out
+      # Dry runs do not publish, so they never receive the WP.org SVN password.
+      # Partner credentials are kept so QIT tests still run against the built zip.
+      - name: Simulate deploy
+        uses: ./.github/actions/woo-product-deploy
+        with:
+          repo_url: https://github.com/woocommerce/woocommerce-google-analytics-integration
+          branch: ${{ needs.validate.outputs.ref_name }}
+          version: ${{ inputs.version }}
+          node_version: '24'
+          npm_version: '11'
+          simulate: true
+          wporg_release: ${{ inputs.deploy_wporg }}
+          wccom_release: ${{ inputs.deploy_woo }}
+          github_release: ${{ inputs.deploy_github }}
+          deploy_pat: ${{ secrets.ORG_DEPLOY_SECRET }}
+          wporg_username: ''
+          wporg_password: ''
+          partner_user: ${{ secrets.ORG_PARTNER_USER }}
+          partner_secret: ${{ secrets.ORG_PARTNER_DEPLOY_SECRET }}
+          wccom_product_id: 1442927
+
+  deploy:
+    name: Deploy
+    if: ${{ ! inputs.simulate }}
+    needs: validate
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment: production
+    steps:
+      # The approval can happen long after the run was queued. Make sure the ref still
+      # points at the commit the reviewer saw in the summary.
+      - name: Check that the approved commit is still the head of the ref
+        env:
+          REF: ${{ github.ref }}
+          EXPECTED_SHA: ${{ needs.validate.outputs.sha }}
+          REPO_URL: https://github.com/${{ github.repository }}
+        run: |
+          CURRENT_SHA=$(git ls-remote "$REPO_URL" "$REF" | cut -f1)
+          if [[ -z "$CURRENT_SHA" ]]; then
+            echo "::error::Could not resolve '${REF}' on ${REPO_URL}."
+            exit 1
+          fi
+          if [[ "$CURRENT_SHA" != "$EXPECTED_SHA" ]]; then
+            echo "::error::'${REF}' moved from ${EXPECTED_SHA} to ${CURRENT_SHA} since this run was approved. Start a new run."
+            exit 1
+          fi
+          echo "Deploying ${REF} at ${CURRENT_SHA}."
+
+      - name: Checkout woo-product-deploy action
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          repository: woocommerce/woo-product-deploy
+          ref: ${{ env.WOO_PRODUCT_DEPLOY_SHA }}
+          path: ./.github/actions/woo-product-deploy
+          token: ${{ secrets.ORG_DEPLOY_SECRET }}
+          persist-credentials: false
+
       - name: Deploy Product
         uses: ./.github/actions/woo-product-deploy
         with:
           repo_url: https://github.com/woocommerce/woocommerce-google-analytics-integration
-          branch: ${{ github.ref_name }}
+          branch: ${{ needs.validate.outputs.ref_name }}
           version: ${{ inputs.version }}
           node_version: '24'
           npm_version: '11'
-          simulate: ${{ inputs.simulate }}
+          simulate: false
           wporg_release: ${{ inputs.deploy_wporg }}
           wccom_release: ${{ inputs.deploy_woo }}
           github_release: ${{ inputs.deploy_github }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,8 @@
 name: Deploy Product
 
-# **What it does**: Builds and publishes a release to WordPress.org, Woo.com and GitHub.
+# **What it does**: Builds and publishes a release to WordPress.org and GitHub.
+# This plugin is hosted on WordPress.org, so the action skips its WooCommerce.com
+# step; that channel is served from the WordPress.org release, not from this run.
 # **How to use it**: Run it from the `release/x.y.z` or `hotfix/x.y.z` branch that matches
 # the `version` input. Dry runs need no approval and never see the WP.org publishing
 # password. Production runs wait for approval on the `production` environment and refuse
@@ -22,11 +24,6 @@ on:
         type: string
       deploy_wporg:
         description: 'Deploy to WordPress.org'
-        required: false
-        default: true
-        type: boolean
-      deploy_woo:
-        description: 'Deploy to Woo.com'
         required: false
         default: true
         type: boolean
@@ -120,14 +117,14 @@ jobs:
           npm_version: '11'
           simulate: true
           wporg_release: true
-          wccom_release: ${{ inputs.deploy_woo }}
+          # Hosted on WordPress.org, so the action's WooCommerce.com step never runs.
+          wccom_release: false
           github_release: ${{ inputs.deploy_github }}
           deploy_pat: ${{ secrets.ORG_DEPLOY_SECRET }}
           wporg_username: ''
           wporg_password: ''
           partner_user: ${{ secrets.ORG_PARTNER_USER }}
           partner_secret: ${{ secrets.ORG_PARTNER_DEPLOY_SECRET }}
-          wccom_product_id: 1442927
 
   deploy:
     name: Deploy
@@ -175,11 +172,11 @@ jobs:
           npm_version: '11'
           simulate: false
           wporg_release: ${{ inputs.deploy_wporg }}
-          wccom_release: ${{ inputs.deploy_woo }}
+          # Hosted on WordPress.org, so the action's WooCommerce.com step never runs.
+          wccom_release: false
           github_release: ${{ inputs.deploy_github }}
           deploy_pat: ${{ secrets.ORG_DEPLOY_SECRET }}
           wporg_username: ${{ inputs.deploy_wporg && secrets.WPORG_SVN_USERNAME || '' }}
           wporg_password: ${{ inputs.deploy_wporg && secrets.WPORG_SVN_PASSWORD || '' }}
           partner_user: ${{ secrets.ORG_PARTNER_USER }}
           partner_secret: ${{ secrets.ORG_PARTNER_DEPLOY_SECRET }}
-          wccom_product_id: 1442927

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -67,10 +67,10 @@ jobs:
           SHA: ${{ github.sha }}
           SIMULATE: ${{ inputs.simulate }}
         run: |
-          # Same pattern as validate-inputs.sh in woo-product-deploy, so a version that
-          # passes here also passes inside the action.
-          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)?$ ]]; then
-            echo "::error::Invalid version format '$VERSION'. Expected X.Y.Z or X.Y.Z-suffix (no dots in the suffix)."
+          # Stricter than validate-inputs.sh in woo-product-deploy, which allows leading
+          # zeros. Anything accepted here is therefore also accepted inside the action.
+          if [[ ! "$VERSION" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[a-zA-Z0-9]+)?$ ]]; then
+            echo "::error::Invalid version format '$VERSION'. Expected X.Y.Z or X.Y.Z-suffix, with no leading zeros and no dots in the suffix."
             exit 1
           fi
           if [[ "$REF" != "refs/heads/release/${VERSION}" && "$REF" != "refs/heads/hotfix/${VERSION}" ]]; then

--- a/.github/workflows/php-hook-documentation.yml
+++ b/.github/workflows/php-hook-documentation.yml
@@ -34,18 +34,19 @@ jobs:
       - name: Commit hook documentation
         env:
           HEAD_REF: ${{ github.head_ref }}
+          HOOK_DOCS: ${{ steps.generate-hook-docs.outputs.hook-docs }}
         shell: bash
         # Use the github-actions bot account to commit.
         # https://api.github.com/users/github-actions%5Bbot%5D
         run: |
           git config user.name github-actions[bot]
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
-          echo "${{ steps.generate-hook-docs.outputs.hook-docs }}" > docs/Hooks.md
+          printf '%s\n' "$HOOK_DOCS" > docs/Hooks.md
           git add docs/Hooks.md
           if git diff --cached --quiet; then
-            echo "*No documentation changes to commit.*" >> $GITHUB_STEP_SUMMARY
+            echo "*No documentation changes to commit.*" >> "$GITHUB_STEP_SUMMARY"
           else
-            echo "*Committing documentation changes.*" >> $GITHUB_STEP_SUMMARY
+            echo "*Committing documentation changes.*" >> "$GITHUB_STEP_SUMMARY"
             git commit -q -m "Update hooks documentation from ${HEAD_REF} branch."
             git push
           fi

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -99,20 +99,22 @@ jobs:
         run: sudo apt-get -y install subversion
 
       - name: Run PHP unit tests
+        env:
+          WP_VERSION: ${{ matrix.wp-version }}
+          MATRIX_WC_VERSIONS: ${{ matrix.wc-versions }}
         run: |
-          WC_VERSIONS=$(echo "${{ matrix.wc-versions }}" | sed -r "s/ *, */ /g")
-          WC_VERSIONS=($WC_VERSIONS)
+          read -ra WC_VERSIONS <<< "$(echo "$MATRIX_WC_VERSIONS" | sed -r "s/ *, */ /g")"
 
           INIT_INSTALL=true
 
           for WC_VERSION in "${WC_VERSIONS[@]}"; do
             if [ "$INIT_INSTALL" = true ]; then
-              echo "::group::Install WP ${{ matrix.wp-version }} and WC ${WC_VERSION}"
-              ./bin/install-unit-tests.sh wordpress_test root root localhost ${{ matrix.wp-version }} $WC_VERSION
+              echo "::group::Install WP ${WP_VERSION} and WC ${WC_VERSION}"
+              ./bin/install-unit-tests.sh wordpress_test root root localhost "${WP_VERSION}" "${WC_VERSION}"
               INIT_INSTALL=false
             else
-              echo "::group::Switch to WP ${{ matrix.wp-version }} and WC ${WC_VERSION}"
-              ./bin/switch-wp-wc-in-unit-tests.sh wordpress_test root root localhost ${{ matrix.wp-version }} $WC_VERSION
+              echo "::group::Switch to WP ${WP_VERSION} and WC ${WC_VERSION}"
+              ./bin/switch-wp-wc-in-unit-tests.sh wordpress_test root root localhost "${WP_VERSION}" "${WC_VERSION}"
             fi
             echo "::endgroup::"
 

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -11,6 +11,7 @@ on:
       - package.json
       - package-lock.json
       - .github/workflows/php-unit-tests.yml
+      - "bin/*.sh"
   pull_request:
     paths:
       - "**.php"
@@ -19,6 +20,7 @@ on:
       - package.json
       - package-lock.json
       - .github/workflows/php-unit-tests.yml
+      - "bin/*.sh"
   workflow_dispatch:
     inputs:
       php-version:

--- a/.github/workflows/prepare-release-via-deploy.yml
+++ b/.github/workflows/prepare-release-via-deploy.yml
@@ -24,8 +24,10 @@ jobs:
         env:
           VERSION: ${{ github.event.inputs.version }}
         run: |
-          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
-            echo "::error::Invalid version format '$VERSION'. Expected format: X.Y.Z (e.g., 2.1.22) or X.Y.Z-suffix (e.g., 2.1.22-beta.1)"
+          # Same pattern as the Deploy workflow and woo-product-deploy, so the release
+          # branch created here can actually be deployed.
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)?$ ]]; then
+            echo "::error::Invalid version format '$VERSION'. Expected format: X.Y.Z (e.g., 2.1.22) or X.Y.Z-suffix (e.g., 2.1.22-beta1)"
             exit 1
           fi
 
@@ -33,7 +35,7 @@ jobs:
         id: release-vars
         env:
           VERSION: ${{ github.event.inputs.version }}
-        run: echo "branch=release/${VERSION}" >> $GITHUB_OUTPUT
+        run: echo "branch=release/${VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Create release branch
         env:
@@ -60,5 +62,7 @@ jobs:
           VERSION: ${{ github.event.inputs.version }}
 
       - name: Generate summary
+        env:
+          PR_URL: ${{ fromJSON(steps.prepare-release-pr.outputs.result).html_url }}
         run: |
-          echo "Release PR created at ${{ fromJSON(steps.prepare-release-pr.outputs.result).html_url }}" >> $GITHUB_STEP_SUMMARY
+          echo "Release PR created at ${PR_URL}" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/prepare-release-via-deploy.yml
+++ b/.github/workflows/prepare-release-via-deploy.yml
@@ -24,10 +24,11 @@ jobs:
         env:
           VERSION: ${{ github.event.inputs.version }}
         run: |
-          # Same pattern as the Deploy workflow and woo-product-deploy, so the release
-          # branch created here can actually be deployed.
-          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)?$ ]]; then
-            echo "::error::Invalid version format '$VERSION'. Expected format: X.Y.Z (e.g., 2.1.22) or X.Y.Z-suffix (e.g., 2.1.22-beta1)"
+          # Same pattern as the Deploy workflow, so the release branch created here can
+          # actually be deployed. Leading zeros are rejected: 01.2.3 would create a
+          # branch the Deploy workflow refuses.
+          if [[ ! "$VERSION" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[a-zA-Z0-9]+)?$ ]]; then
+            echo "::error::Invalid version format '$VERSION'. Expected format: X.Y.Z (e.g., 2.1.22) or X.Y.Z-suffix (e.g., 2.1.22-beta1), with no leading zeros"
             exit 1
           fi
 

--- a/.github/workflows/scripts/create-release-pr.mjs
+++ b/.github/workflows/scripts/create-release-pr.mjs
@@ -22,7 +22,7 @@ export default async ( { context, github, version } ) => {
    woorelease cl:generate --release --product_version=${ version } ${ repoURL }
    \`\`\`
 1. [ ] Automated tests are passing.
-1. [ ] Wait for the automated hooks documentation commit on this branch (it runs after the changelog changes). A production run fails if the branch moves after approval.
+1. [ ] Wait for the automated hooks documentation commit on this branch (it is triggered by the \`changelog.txt\` commit that \`cl:generate\` makes above). A production run fails if the branch moves after approval.
 1. [ ] Run [Woo Deploy Action](${ context.payload.repository.html_url }/actions/workflows/deploy.yml) — select branch \`release/${ version }\`, version \`${ version }\`, and **Dry run** mode.
 1. [ ] Test the package
    1. [ ] Install the .zip package from the artifact from the dry run on a test site

--- a/.github/workflows/scripts/create-release-pr.mjs
+++ b/.github/workflows/scripts/create-release-pr.mjs
@@ -22,6 +22,7 @@ export default async ( { context, github, version } ) => {
    woorelease cl:generate --release --product_version=${ version } ${ repoURL }
    \`\`\`
 1. [ ] Automated tests are passing.
+1. [ ] Wait for the automated hooks documentation commit on this branch (it runs after the changelog changes). A production run fails if the branch moves after approval.
 1. [ ] Run [Woo Deploy Action](${ context.payload.repository.html_url }/actions/workflows/deploy.yml) — select branch \`release/${ version }\`, version \`${ version }\`, and **Dry run** mode.
 1. [ ] Test the package
    1. [ ] Install the .zip package from the artifact from the dry run on a test site

--- a/.github/workflows/scripts/create-release-pr.mjs
+++ b/.github/workflows/scripts/create-release-pr.mjs
@@ -30,7 +30,7 @@ export default async ( { context, github, version } ) => {
 
 ## Next steps
 1. [ ] Do the final release
-   1. [ ] Run [Woo Deploy Action](${ context.payload.repository.html_url }/actions/workflows/deploy.yml) — select branch \`release/${ version }\`, version \`${ version }\`, and **production** mode (disable **Dry run**).
+   1. [ ] Run [Woo Deploy Action](${ context.payload.repository.html_url }/actions/workflows/deploy.yml) — select branch \`release/${ version }\`, version \`${ version }\`, and **production** mode (disable **Dry run**). The run waits for approval on the \`production\` environment; the summary of the \`Validate release ref\` job shows the commit that will ship.
 1. [ ] Confirm the release using the activation link from your email.
    When releasing to WordPress.org, _"release notifications"_ have been enabled, so each committer will be sent an email with an action link to confirm the release. This must be done after committing in SVN before the release becomes available. See the following page for releases pending notifications: https://wordpress.org/plugins/developers/releases/
 1. [ ] Go to ${ context.payload.repository.html_url }/releases/${ version }, generate GitHub release notes, and paste them as a comment here.

--- a/.wp-env.test.json
+++ b/.wp-env.test.json
@@ -3,7 +3,7 @@
 	"port": 8889,
 	"testsEnvironment": false,
 	"plugins": [
-		"https://github.com/WP-API/Basic-Auth/archive/master.zip",
+		"https://github.com/WP-API/Basic-Auth/archive/9e9d5267c7805c024f141d115b224cdee5a10008.zip",
 		"./tests/e2e/test-data",
 		"./tests/e2e/test-snippets",
 		"."

--- a/bin/unit-tests-functions.sh
+++ b/bin/unit-tests-functions.sh
@@ -10,16 +10,16 @@ PLUGINS_DIR="${WP_CORE_DIR}/wp-content/plugins"
 
 download() {
   if [ $(which curl) ]; then
-    curl -s "$1" >"$2"
+    curl -fsSL "$1" -o "$2"
   elif [ $(which wget) ]; then
     wget -nv -O "$2" "$1"
   fi
 }
 
 get_latest_wp_version() {
-  # http serves a single offer, whereas https serves multiple. we only want one
-  download http://api.wordpress.org/core/version-check/1.7/ "${TMPDIR}/wp-latest.json"
-  local LATEST_VERSION=$(grep -o '"version":"[^"]*' "${TMPDIR}/wp-latest.json" | sed 's/"version":"//')
+  # https serves multiple offers; the first one is the latest release.
+  download https://api.wordpress.org/core/version-check/1.7/ "${TMPDIR}/wp-latest.json"
+  local LATEST_VERSION=$(grep -o '"version":"[^"]*' "${TMPDIR}/wp-latest.json" | sed 's/"version":"//' | head -1)
   if [[ -z "$LATEST_VERSION" ]]; then
     echo "Latest WordPress version could not be found"
     exit 1

--- a/bin/unit-tests-functions.sh
+++ b/bin/unit-tests-functions.sh
@@ -87,8 +87,6 @@ install_wp() {
     tar --strip-components=1 -zxmf "$TMPDIR"/wordpress.tar.gz -C "$WP_CORE_DIR"
     touch "$WP_VERSION_FILE"
   fi
-
-  download https://raw.github.com/markoheijnen/wp-mysqli/master/db.php "$WP_CORE_DIR"/wp-content/db.php
 }
 
 install_test_suite() {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes STORMA-181 (findings #3, #0, #4 from the v2.4.0 security triage). CI/CD only, no change to installed sites.

**Deploy workflow (findings #3 and #0)**
- Split `deploy.yml` into `validate`, `dry-run` and `deploy` jobs. Validation refuses any ref that is not `release/<version>` or `hotfix/<version>` matching the version input, and records the commit in the step summary.
- Production runs use the protected `production` environment and refuse to start if the branch moved since the approved commit.
- Dry runs need no approval and never receive the WordPress.org SVN password. Partner credentials stay so QIT still runs.
- The private `woo-product-deploy` action is pinned to a commit SHA and checked out without persisted credentials. The unused `workflow_call` trigger is removed.
- Concurrency group per ref, a descriptive run name, and the version pattern aligned with the action's own check.

**Test setup (finding #4)**
- Removed the unpinned `db.php` download from `markoheijnen/wp-mysqli@master`. The file only defined `WP_USE_EXT_MYSQL` as false, which WordPress ignores on PHP 7+.
- The PHP unit test workflow now runs when `bin/*.sh` changes, and the version check is fetched over HTTPS with curl failing on errors.

**Same patterns found in the sweep**
- `.wp-env.test.json` pinned WP‑API/Basic‑Auth to a commit instead of `master.zip`.
- Hook documentation output, PHP unit test matrix values and the release PR URL are read from env instead of being expanded into shell scripts.

**Repo settings done separately (all verified):** the `production` environment exists with the `ballade` team as required reviewer, self‑review prevented, admin bypass off, and `release/*` plus `hotfix/*` branch policies. The WP.org SVN secrets moved from repo secrets into that environment. A ruleset blocks force pushes and deletion on `release/*` and `hotfix/*`. Unused `QIT_PARTNER_*` repo secrets removed.

**Upstream follow‑up:** woocommerce/woo-product-deploy#7 pins the `qit-action` checkout, stops persisting the PAT in the target checkout, and adds a `commit` input so the approved commit is the one woorelease builds. Until it merges, dry runs still expose the org PAT to code on the branch. After it merges, a small follow‑up here bumps `WOO_PRODUCT_DEPLOY_SHA` and passes `commit: ${{ needs.validate.outputs.sha }}` in the deploy job.

### Checks:
* [x] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Screenshots:

_N/A_

### Detailed test instructions:

1. Confirm the `PHP Unit Tests` and `E2E Tests` checks run on this PR and pass. The unit test job exercises the install script without `db.php`; the E2E job installs Basic‑Auth from the pinned zip.
2. Negative test of the gate, from this branch: run the Deploy Product workflow with `version=2.4.1` and dry run on. Expected: `Validate release ref` fails with "Refusing to deploy", the other jobs are skipped, no approval request appears.
3. Before the next release, run a dry run from a real `release/x.y.z` branch and confirm the run title shows "(dry run)", the action checkout uses the pinned SHA, and QIT runs.
4. On the first production run, confirm the `ballade` approval prompt appears and the summary of `Validate release ref` shows the commit that will ship.

### Additional details:

Removing `db.php` is stricter than the pin the issue asked for: the drop‑in was dead code for every PHP and WordPress version in the matrix, so there is nothing left to pin.

### Changelog entry

> Dev - Harden the release and test pipelines: pin the deploy action and test dependencies, gate production deploys behind a protected environment.

