### PR TITLE
Let the E2E suite target a different host with WP_BASE_URL

### DIFF
--- a/tests/e2e/config/playwright.config.js
+++ b/tests/e2e/config/playwright.config.js
@@ -39,7 +39,7 @@ module.exports = defineConfig( {
 		actionTimeout: 0,
 
 		/* Base URL to use in actions like `await page.goto('/')`. */
-		baseURL: url,
+		baseURL: process.env.WP_BASE_URL || url,
 
 		/* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
 		trace: 'retain-on-failure',

--- a/tests/e2e/utils/api.js
+++ b/tests/e2e/utils/api.js
@@ -19,7 +19,9 @@ export function api( version ) {
 	).toString( 'base64' );
 
 	return axios.create( {
-		baseURL: `${ config.url }wp-json/${ version ?? 'wc/v3' }/`,
+		baseURL: `${ process.env.WP_BASE_URL || config.url }wp-json/${
+			version ?? 'wc/v3'
+		}/`,
 		headers: {
 			'Content-Type': 'application/json',
 			Authorization: `Basic ${ token }`,


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The E2E site URL is hardcoded in `tests/e2e/config/default.json`, so the suite can only run against port 8889 and one checkout at a time. Playwright's `baseURL` and the REST helper now prefer `WP_BASE_URL` when it is set, and fall back to that file otherwise. The REST helper needs its own change because it builds an axios base URL from the config file rather than from Playwright's `baseURL`.

### Checks:

* [x] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Screenshots:

_N/A_

### Detailed test instructions:

1. `npm run wp-env:up && npm run test:php:setup`, then `npm run test:e2e` — passes as before.
2. `npm run wp-env:down`.
3. `WP_ENV_PORT=9031 npm run wp-env:up && WP_ENV_PORT=9031 npm run test:php:setup`.
4. `WP_BASE_URL=http://localhost:9031/ npm run test:e2e` — the log prints `Base URL: http://localhost:9031/` and the tests pass.
5. `WP_ENV_PORT=9031 npm run wp-env:down`.

### Changelog entry

> Dev - Allow the E2E suite to run against a site other than localhost:8889 via the WP_BASE_URL environment variable.
