### PR TITLE
Deploy the approved commit instead of the release branch head

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,8 +6,8 @@ name: Deploy Product
 # **How to use it**: Run it from the `release/x.y.z` or `hotfix/x.y.z` branch that matches
 # the `version` input. Dry runs need no approval and never see the WP.org publishing
 # password. Production runs wait for approval on the `production` environment and refuse
-# to start if the branch moved since the approved commit. The action itself resolves the
-# branch by name, so the branch must also be protected against force pushes.
+# to start if the branch moved since the approved commit. The action is then given that
+# commit, so what it builds cannot drift from what was approved.
 #
 # The `woocommerce/woo-product-deploy` action is pinned to a commit SHA. Dependabot does
 # not track `repository:` refs in `actions/checkout`, so bump `WOO_PRODUCT_DEPLOY_SHA`
@@ -46,8 +46,8 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  # woocommerce/woo-product-deploy trunk @ 2026-08-31
-  WOO_PRODUCT_DEPLOY_SHA: 5f5b49d49b8a3681a7a99efec089187666885759
+  # woocommerce/woo-product-deploy trunk @ 2026-09-10
+  WOO_PRODUCT_DEPLOY_SHA: c36d132b80747d6a96569712d69937177d7a0274
 
 jobs:
   validate:
@@ -105,13 +105,14 @@ jobs:
 
       # Dry runs do not publish, so they never receive the WP.org SVN password.
       # Partner credentials are kept so QIT tests still run against the built zip.
-      # wporg_release is forced on because the action needs at least one release
-      # target enabled to set up woorelease, and simulate mode never commits.
+      # wporg_release is forced on so the action installs Subversion, which the
+      # simulated WordPress.org release still needs. Simulate mode never commits.
       - name: Simulate deploy
         uses: ./.github/actions/woo-product-deploy
         with:
           repo_url: https://github.com/woocommerce/woocommerce-google-analytics-integration
           branch: ${{ needs.validate.outputs.ref_name }}
+          commit: ${{ needs.validate.outputs.sha }}
           version: ${{ inputs.version }}
           node_version: '24'
           npm_version: '11'
@@ -167,6 +168,7 @@ jobs:
         with:
           repo_url: https://github.com/woocommerce/woocommerce-google-analytics-integration
           branch: ${{ needs.validate.outputs.ref_name }}
+          commit: ${{ needs.validate.outputs.sha }}
           version: ${{ inputs.version }}
           node_version: '24'
           npm_version: '11'


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Follow-up to #664, now that woocommerce/woo-product-deploy#7 is merged. Both jobs pass the SHA that `validate` recorded and the reviewer approved; the action checks the target repository out at it and fails if the checkout lands elsewhere. That closes the window where a push to the release branch between approval and checkout would ship a different commit.

The pin moves to the merge commit of that PR, which also brings two upstream fixes: the woorelease phar now resolves for the standalone workflows, and Setup Woorelease runs on simulate.

### Checks:
* [x] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Screenshots:

_N/A_

### Detailed test instructions:

1. Run the Deploy workflow from a real `release/x.y.z` branch with dry run on.
2. Confirm `Validate release ref` records a commit in its step summary.
3. Confirm the action's `Verify the checked-out commit` step passes with that SHA.
4. Confirm the deployment summary shows a **Commit** line matching it.
5. Confirm QIT still runs and the zip artifact is produced.

### Additional details:

The dry-run comment about `wporg_release` is corrected: after the upstream fix, Subversion is what still needs it, not the woorelease setup.

### Changelog entry

> Dev - Deploy the reviewed commit instead of the release branch head.
